### PR TITLE
feat: Network module redesign - TLS, ports, resource linking

### DIFF
--- a/docs/plans/2026-01-14-network-redesign-design.md
+++ b/docs/plans/2026-01-14-network-redesign-design.md
@@ -1,0 +1,388 @@
+# Network Module Redesign
+
+## Overview
+
+Полный редизайн Network модуля (Services, Ingresses, Endpoints) для улучшения:
+- Корректного отображения TLS информации
+- Читаемости портов и данных
+- Связанности между ресурсами
+- Обработки ошибок и edge cases
+
+## Проблемы текущей реализации
+
+### TLS отображение
+1. **Несоответствие между списком и деталями** - в списке проверяется только `tlsHosts`, а в деталях ещё и `hasCatchAllTls`
+2. **"All hosts" при пустом массиве** - если `hosts: []`, показывается "All hosts" без объяснения
+3. **Backend проблема** - если TLS секция без hosts, `tls_hosts` пустой, но `tls_configs` содержит запись
+
+### Читаемость данных
+4. **Формат портов непонятный** - `8080:30000>8000/TCP` неочевидно что есть что
+5. **Resource Backend как сырая строка** - плохо читается
+
+### Связанность
+6. **Нет связи Service → Pods** - selector показывается, но какие поды выбраны не видно
+7. **Нет ссылок на backend services** - в Ingress нельзя перейти к сервису
+
+### Обработка ошибок
+8. **"Open in Browser" скрывается без объяснения**
+9. **Нестандартные порты не учитываются в URL**
+10. **Events не показывают ошибки загрузки**
+
+---
+
+## Дизайн решения
+
+### 1. Исправления TLS отображения
+
+#### Backend изменения (src-tauri/src/resources/network.rs)
+
+```rust
+pub struct IngressTlsConfig {
+    pub hosts: Vec<String>,
+    pub secret_name: Option<String>,
+    pub is_catch_all: bool,  // НОВОЕ: true если hosts пустой
+}
+
+pub struct IngressInfo {
+    // существующие поля...
+    pub tls_hosts: Vec<String>,
+    pub tls_configs: Vec<IngressTlsConfig>,
+    pub has_catch_all_tls: bool,  // НОВОЕ: для быстрой проверки
+}
+```
+
+Логика парсинга:
+```rust
+let is_catch_all = tls.hosts.as_ref().map(|h| h.is_empty()).unwrap_or(true);
+
+let has_catch_all_tls = tls_configs.iter().any(|c| c.is_catch_all);
+```
+
+#### IngressList - новое отображение TLS колонки
+
+| Состояние | Отображение |
+|-----------|-------------|
+| Явные TLS хосты | `TLS (2)` зелёный бейдж с tooltip списка |
+| Catch-all TLS | `TLS (all)` зелёный бейдж |
+| Оба варианта | `TLS (2 + all)` |
+| Нет TLS | `No TLS` серый бейдж |
+
+#### IngressDetail - улучшенный TLS таб
+
+```
+┌─────────────────────────────────────────────────┐
+│ TLS Configuration                               │
+├─────────────────────────────────────────────────┤
+│ Explicit TLS Hosts:                             │
+│ ┌─────────────────────────────────────────────┐ │
+│ │ 🔒 example.com                              │ │
+│ │    Secret: my-tls-secret                    │ │
+│ ├─────────────────────────────────────────────┤ │
+│ │ 🔒 api.example.com                          │ │
+│ │    Secret: api-tls-secret                   │ │
+│ └─────────────────────────────────────────────┘ │
+│                                                 │
+│ ⚠️ Catch-all TLS:                               │
+│ ┌─────────────────────────────────────────────┐ │
+│ │ Secret: wildcard-cert                       │ │
+│ │ Applies to: All hosts not explicitly listed │ │
+│ └─────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────┘
+```
+
+#### Access URLs - точное определение HTTPS
+
+- Проверять `tlsHosts.includes(host)` ИЛИ `hasCatchAllTls`
+- Показывать tooltip объясняющий почему HTTPS:
+  - "TLS: explicit host configuration"
+  - "TLS: catch-all certificate"
+
+---
+
+### 2. Улучшение читаемости портов в Services
+
+#### ServiceList - новый формат портов
+
+Вместо `8080:30000>8000/TCP` показывать компактно:
+- `80→8080` (port → targetPort)
+- Если есть NodePort: `80→8080 (30080)`
+
+Tooltip с полной информацией:
+```
+Port: 80
+Target Port: 8080
+Node Port: 30080
+Protocol: TCP
+```
+
+#### ServiceDetail - секция "How to Access This Service"
+
+```
+┌─────────────────────────────────────────────────┐
+│ 🔗 How to Access This Service                   │
+├─────────────────────────────────────────────────┤
+│ Type: LoadBalancer                              │
+│                                                 │
+│ External Access:                                │
+│ • http://203.0.113.50:80                       │ [Copy] [Open]
+│                                                 │
+│ Internal Access (within cluster):               │
+│ • my-service.default.svc.cluster.local:80      │ [Copy]
+│                                                 │
+│ From same namespace:                            │
+│ • my-service:80                                │ [Copy]
+└─────────────────────────────────────────────────┘
+```
+
+Для разных типов сервисов:
+- **ClusterIP**: только internal access
+- **NodePort**: `<any-node-ip>:30080` + internal
+- **LoadBalancer**: External IP + internal
+- **ExternalName**: DNS alias информация
+
+#### Цветовая индикация типов сервисов
+
+| Тип | Цвет | Значение |
+|-----|------|----------|
+| ClusterIP | Серый | Internal only |
+| NodePort | Синий | External via nodes |
+| LoadBalancer | Зелёный | External via LB |
+| ExternalName | Жёлтый | DNS alias |
+
+#### Улучшенная таблица портов
+
+```
+┌────────┬────────────┬──────────┬──────────┐
+│ Port   │ Target     │ NodePort │ Protocol │
+├────────┼────────────┼──────────┼──────────┤
+│ 80     │ 8080       │ 30080    │ TCP      │
+│ 443    │ 8443       │ 30443    │ TCP      │
+└────────┴────────────┴──────────┴──────────┘
+```
+
+---
+
+### 3. Связанность ресурсов
+
+#### ServiceDetail - секция "Matching Pods"
+
+```
+┌─────────────────────────────────────────────────┐
+│ 🔗 Matching Pods (3 running, 1 pending)         │
+├─────────────────────────────────────────────────┤
+│ ● my-app-7d4b8c9-abc12   Running    10.0.1.15  │ → click
+│ ● my-app-7d4b8c9-def34   Running    10.0.1.16  │ → click
+│ ● my-app-7d4b8c9-ghi56   Running    10.0.1.17  │ → click
+│ ○ my-app-7d4b8c9-jkl78   Pending    -          │ → click
+└─────────────────────────────────────────────────┘
+```
+
+Функционал:
+- Показывать поды, соответствующие selector
+- Кликабельные ссылки на PodDetail
+- Статус и IP каждого пода
+- Счётчик по статусам в заголовке
+- Если нет подов: "No pods match this selector"
+
+#### Backend: новая команда
+
+```rust
+#[tauri::command]
+pub async fn get_pods_by_selector(
+    namespace: String,
+    selector: std::collections::BTreeMap<String, String>,
+    state: State<'_, AppState>,
+) -> Result<Vec<PodInfo>, String> {
+    // Конвертировать selector в label selector string
+    // Запросить поды с этим selector
+}
+```
+
+#### IngressDetail - кликабельные backend services
+
+В Access URLs и Rules табах:
+- `→ my-service:8080` становится ссылкой `<Link to="/services/default/my-service">`
+- Tooltip показывает: тип сервиса, количество endpoints, статус
+- Иконка ⚠️ если сервис не найден в кластере
+
+#### Endpoints - связь с Service и Pods
+
+- Заголовок страницы: ссылка на родительский Service
+- Каждый address с targetRef: ссылка на Pod
+- Not ready addresses: показать причину (если pod в CrashLoopBackOff и т.д.)
+
+---
+
+### 4. Обработка ошибок и edge cases
+
+#### Ingress "Open in Browser" - информативные состояния
+
+| Состояние | UI |
+|-----------|-----|
+| URL готов | ✅ Активная кнопка |
+| Ждём LoadBalancer | ⏳ "Waiting for LoadBalancer IP" с анимацией |
+| Wildcard host | ⚠️ "Wildcard host - enter URL manually" |
+| Нет хостов | ❌ "No valid host configured" (disabled) |
+
+#### Ingress Access URLs - нестандартные порты
+
+Проверять LoadBalancer ports и показывать предупреждение:
+```
+⚠️ LoadBalancer uses non-standard port 8443
+   Access via: https://203.0.113.50:8443
+```
+
+Также проверять известные annotations:
+- `nginx.ingress.kubernetes.io/backend-protocol`
+- `nginx.ingress.kubernetes.io/ssl-passthrough`
+
+#### Events - обработка ошибок
+
+```tsx
+{eventsError ? (
+    <Alert variant="warning">
+        <AlertTriangle className="h-4 w-4" />
+        <span>Failed to load events: {eventsError.message}</span>
+        <Button size="sm" onClick={refetchEvents}>Retry</Button>
+    </Alert>
+) : eventsLoading ? (
+    <Skeleton className="h-20" />
+) : events.length === 0 ? (
+    <p className="text-muted-foreground">No events found</p>
+) : (
+    <EventsList events={events} />
+)}
+```
+
+#### Пустые/невалидные состояния
+
+| Ресурс | Состояние | Отображение |
+|--------|-----------|-------------|
+| Service | Нет портов, есть selector | "Headless service" (информация) |
+| Service | Нет портов, нет selector | "Configuration issue: no ports defined" (предупреждение) |
+| Endpoints | Нет ready addresses | "No ready endpoints - check pod status" + ссылка на поды |
+| Ingress | Нет rules | "No routing rules configured" |
+
+---
+
+## Структура файлов
+
+### Изменения в существующих файлах
+
+```
+src-tauri/src/resources/network.rs
+├── IngressInfo: добавить has_catch_all_tls
+├── IngressTlsConfig: добавить is_catch_all
+└── Новая функция: get_pods_by_selector()
+
+src/generated/types.ts
+└── Обновить типы после изменений backend
+
+src/components/resources/
+├── IngressList.tsx: новая TLS колонка с catch-all
+├── ServiceList.tsx: новый формат портов, цветные типы
+└── EndpointsList.tsx: добавить nodeName в not-ready tooltip
+
+src/pages/
+├── IngressDetail.tsx:
+│   ├── Улучшенный TLS таб (explicit + catch-all секции)
+│   ├── Кликабельные backend services
+│   └── Информативные состояния "Open in Browser"
+├── ServiceDetail.tsx:
+│   ├── Новая секция "How to Access"
+│   ├── Новая секция "Matching Pods"
+│   └── Улучшенная таблица портов
+└── EndpointsDetail.tsx:
+    ├── Ссылка на родительский Service
+    └── Кликабельные pod references
+```
+
+### Новые компоненты
+
+```
+src/components/network/
+├── TlsBadge.tsx          # Универсальный бейдж TLS с tooltip
+├── PortsDisplay.tsx      # Компактное отображение портов
+├── ServiceAccessInfo.tsx # "How to Access" карточка
+├── MatchingPods.tsx      # Список подов по selector
+└── LinkedResource.tsx    # Кликабельная ссылка на ресурс с превью
+```
+
+---
+
+## План реализации
+
+### Этап 1: Backend изменения
+- [ ] Добавить `is_catch_all` в `IngressTlsConfig`
+- [ ] Добавить `has_catch_all_tls` в `IngressInfo`
+- [ ] Реализовать `get_pods_by_selector` команду
+- [ ] Обновить парсинг TLS в `From<Ingress> for IngressInfo`
+
+### Этап 2: Regenerate types
+- [ ] Запустить генерацию типов
+- [ ] Обновить фронтенд типы
+
+### Этап 3: TLS исправления
+- [ ] Создать `TlsBadge.tsx` компонент
+- [ ] Обновить TLS колонку в `IngressList.tsx`
+- [ ] Переделать TLS таб в `IngressDetail.tsx`
+- [ ] Исправить логику HTTPS в `generateAccessUrls`
+
+### Этап 4: Services улучшения
+- [ ] Создать `PortsDisplay.tsx` компонент
+- [ ] Создать `ServiceAccessInfo.tsx` компонент
+- [ ] Создать `MatchingPods.tsx` компонент
+- [ ] Обновить `ServiceList.tsx` (порты, цвета типов)
+- [ ] Обновить `ServiceDetail.tsx` (access info, matching pods, таблица портов)
+
+### Этап 5: Связанность ресурсов
+- [ ] Создать `LinkedResource.tsx` компонент
+- [ ] Добавить кликабельные backend services в `IngressDetail.tsx`
+- [ ] Добавить ссылку на Service в `EndpointsDetail.tsx`
+- [ ] Добавить кликабельные pod references в Endpoints
+
+### Этап 6: Error handling
+- [ ] Добавить информативные состояния "Open in Browser"
+- [ ] Добавить обработку ошибок Events
+- [ ] Добавить предупреждения о нестандартных портах
+- [ ] Обработать все edge cases (пустые состояния)
+
+---
+
+## Примеры UI
+
+### TLS Badge варианты
+
+```
+[TLS (2)]           - зелёный, tooltip: "example.com, api.example.com"
+[TLS (all)]         - зелёный, tooltip: "Catch-all TLS certificate"
+[TLS (2 + all)]     - зелёный, tooltip: "2 explicit + catch-all"
+[No TLS]            - серый outline
+```
+
+### Service Type Badge варианты
+
+```
+[ClusterIP]         - серый, internal
+[NodePort]          - синий, external via node ports
+[LoadBalancer]      - зелёный, external via load balancer
+[ExternalName]      - жёлтый, DNS alias
+```
+
+### Port Display варианты
+
+Компактно (в списке):
+```
+80→8080, 443→8443
+80→8080 (30080)     - с NodePort
+```
+
+Полная таблица (в деталях):
+```
+┌────────┬────────────┬──────────┬──────────┐
+│ Port   │ Target     │ NodePort │ Protocol │
+├────────┼────────────┼──────────┼──────────┤
+│ 80     │ http       │ 30080    │ TCP      │
+│ 443    │ https      │ 30443    │ TCP      │
+└────────┴────────────┴──────────┴──────────┘
+```

--- a/docs/plans/2026-01-14-network-redesign.md
+++ b/docs/plans/2026-01-14-network-redesign.md
@@ -1,0 +1,1602 @@
+# Network Module Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix TLS display inconsistencies, improve port readability, add resource linking (Service→Pods, Ingress→Service), and better error handling in the Network module.
+
+**Architecture:** Backend changes add `is_catch_all` flag to TLS configs and `has_catch_all_tls` to IngressInfo. New `get_pods_by_selector` command enables Service→Pods linking. Frontend creates reusable components in `src/components/network/` and updates existing list/detail pages.
+
+**Tech Stack:** Rust (Tauri backend), TypeScript/React (frontend), TanStack Query, shadcn/ui components.
+
+---
+
+## Task 1: Backend - Add TLS Catch-All Flags
+
+**Files:**
+- Modify: `src-tauri/src/resources/network.rs:29-51`
+
+**Step 1: Add is_catch_all to IngressTlsConfig**
+
+In `src-tauri/src/resources/network.rs`, update the `IngressTlsConfig` struct:
+
+```rust
+/// Information about an Ingress TLS configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IngressTlsConfig {
+    pub hosts: Vec<String>,
+    pub secret_name: Option<String>,
+    pub is_catch_all: bool,
+}
+```
+
+**Step 2: Add has_catch_all_tls to IngressInfo**
+
+Update the `IngressInfo` struct:
+
+```rust
+/// Information about an Ingress
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IngressInfo {
+    pub name: String,
+    pub namespace: String,
+    pub class_name: Option<String>,
+    pub rules: Vec<IngressRule>,
+    pub load_balancer_ips: Vec<String>,
+    pub tls_hosts: Vec<String>,
+    pub tls_configs: Vec<IngressTlsConfig>,
+    pub has_catch_all_tls: bool,
+    pub labels: std::collections::BTreeMap<String, String>,
+    pub annotations: std::collections::BTreeMap<String, String>,
+    pub created_at: Option<String>,
+}
+```
+
+**Step 3: Update the From implementation**
+
+In the `From<&Ingress> for IngressInfo` implementation, update the TLS config parsing (around line 141-152):
+
+```rust
+        // Parse TLS configs with secret names
+        let tls_configs: Vec<IngressTlsConfig> = spec
+            .and_then(|s| s.tls.as_ref())
+            .map(|tls_list| {
+                tls_list
+                    .iter()
+                    .map(|tls| {
+                        let hosts = tls.hosts.clone().unwrap_or_default();
+                        let is_catch_all = hosts.is_empty();
+                        IngressTlsConfig {
+                            hosts,
+                            secret_name: tls.secret_name.clone(),
+                            is_catch_all,
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let has_catch_all_tls = tls_configs.iter().any(|c| c.is_catch_all);
+```
+
+**Step 4: Update the Self return**
+
+Add `has_catch_all_tls` to the returned struct:
+
+```rust
+        Self {
+            name: ingress.name_any(),
+            namespace: ingress.namespace().unwrap_or_default(),
+            class_name: spec.and_then(|s| s.ingress_class_name.clone()),
+            rules,
+            load_balancer_ips,
+            tls_hosts,
+            tls_configs,
+            has_catch_all_tls,
+            labels,
+            annotations,
+            created_at: ingress
+                .metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|t| t.0.to_rfc3339()),
+        }
+```
+
+**Step 5: Verify compilation**
+
+Run: `cd src-tauri && cargo check`
+Expected: Compilation succeeds with no errors
+
+**Step 6: Commit**
+
+```bash
+git add src-tauri/src/resources/network.rs
+git commit -m "feat(network): add TLS catch-all flags to IngressInfo"
+```
+
+---
+
+## Task 2: Backend - Add get_pods_by_selector Command
+
+**Files:**
+- Modify: `src-tauri/src/commands/workloads.rs` (add new command)
+- Modify: `src-tauri/src/lib.rs` (register command)
+
+**Step 1: Find workloads.rs location**
+
+Run: `ls src-tauri/src/commands/`
+Note the file structure for workload commands.
+
+**Step 2: Add the get_pods_by_selector function**
+
+Add to the workloads commands file:
+
+```rust
+#[tauri::command]
+pub async fn get_pods_by_selector(
+    namespace: String,
+    selector: std::collections::BTreeMap<String, String>,
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Vec<crate::resources::workloads::PodInfo>, String> {
+    let client = state.get_client().await.map_err(|e| e.to_string())?;
+
+    // Convert selector map to label selector string
+    let label_selector = selector
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let pods: kube::Api<k8s_openapi::api::core::v1::Pod> =
+        kube::Api::namespaced(client, &namespace);
+
+    let lp = kube::api::ListParams::default().labels(&label_selector);
+    let pod_list = pods.list(&lp).await.map_err(|e| e.to_string())?;
+
+    let pod_infos: Vec<crate::resources::workloads::PodInfo> = pod_list
+        .items
+        .iter()
+        .map(|p| p.into())
+        .collect();
+
+    Ok(pod_infos)
+}
+```
+
+**Step 3: Register the command in lib.rs**
+
+Find the `invoke_handler` section and add `get_pods_by_selector` to the list.
+
+**Step 4: Verify compilation**
+
+Run: `cd src-tauri && cargo check`
+Expected: Compilation succeeds
+
+**Step 5: Commit**
+
+```bash
+git add src-tauri/src/commands/ src-tauri/src/lib.rs
+git commit -m "feat(network): add get_pods_by_selector command for Service->Pods linking"
+```
+
+---
+
+## Task 3: Regenerate TypeScript Types
+
+**Files:**
+- Modify: `src/generated/types.ts` (auto-generated)
+- Modify: `src/generated/commands.ts` (auto-generated)
+
+**Step 1: Run type generation**
+
+Run: `npm run generate-types` (or the appropriate command for this project)
+
+If no generate script exists, check `package.json` for the correct command or run:
+```bash
+cd src-tauri && cargo build
+```
+
+**Step 2: Verify types updated**
+
+Check that `src/generated/types.ts` now contains:
+- `IngressTlsConfig` with `isCatchAll: boolean`
+- `IngressInfo` with `hasCatchAllTls: boolean`
+
+**Step 3: Verify commands updated**
+
+Check that `src/generated/commands.ts` contains the new `getPodsBySelector` function.
+
+**Step 4: Commit**
+
+```bash
+git add src/generated/
+git commit -m "chore: regenerate TypeScript types with TLS flags"
+```
+
+---
+
+## Task 4: Create TlsBadge Component
+
+**Files:**
+- Create: `src/components/network/TlsBadge.tsx`
+- Create: `src/components/network/index.ts`
+
+**Step 1: Create the network components directory**
+
+```bash
+mkdir -p src/components/network
+```
+
+**Step 2: Create TlsBadge.tsx**
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Shield } from "lucide-react";
+
+interface TlsBadgeProps {
+  tlsHosts: string[];
+  hasCatchAllTls: boolean;
+  showIcon?: boolean;
+}
+
+export function TlsBadge({ tlsHosts, hasCatchAllTls, showIcon = false }: TlsBadgeProps) {
+  const explicitCount = tlsHosts.length;
+  const hasTls = explicitCount > 0 || hasCatchAllTls;
+
+  if (!hasTls) {
+    return (
+      <Badge variant="outline" className="text-muted-foreground">
+        No TLS
+      </Badge>
+    );
+  }
+
+  // Build display text
+  let displayText: string;
+  if (explicitCount > 0 && hasCatchAllTls) {
+    displayText = `TLS (${explicitCount} + all)`;
+  } else if (hasCatchAllTls) {
+    displayText = "TLS (all)";
+  } else {
+    displayText = `TLS (${explicitCount})`;
+  }
+
+  // Build tooltip content
+  const tooltipLines: string[] = [];
+  if (explicitCount > 0) {
+    tooltipLines.push(...tlsHosts);
+  }
+  if (hasCatchAllTls) {
+    tooltipLines.push("+ Catch-all TLS certificate");
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <Badge
+          variant="default"
+          className="bg-green-500/10 text-green-500 border-green-500/20"
+        >
+          {showIcon && <Shield className="h-3 w-3 mr-1" />}
+          {displayText}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="space-y-1">
+          {tooltipLines.map((line, i) => (
+            <div key={i} className="text-xs">
+              {line}
+            </div>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+```
+
+**Step 3: Create index.ts**
+
+```tsx
+export { TlsBadge } from "./TlsBadge";
+```
+
+**Step 4: Verify no TypeScript errors**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 5: Commit**
+
+```bash
+git add src/components/network/
+git commit -m "feat(network): add TlsBadge component with catch-all support"
+```
+
+---
+
+## Task 5: Update IngressList TLS Column
+
+**Files:**
+- Modify: `src/components/resources/IngressList.tsx:131-161`
+
+**Step 1: Add TlsBadge import**
+
+At the top of `IngressList.tsx`, add:
+
+```tsx
+import { TlsBadge } from "@/components/network";
+```
+
+**Step 2: Replace TLS column cell**
+
+Replace the TLS column (around lines 131-161) with:
+
+```tsx
+  {
+    accessorKey: "tlsHosts",
+    header: "TLS",
+    cell: ({ row }) => (
+      <TlsBadge
+        tlsHosts={row.original.tlsHosts}
+        hasCatchAllTls={row.original.hasCatchAllTls}
+      />
+    ),
+  },
+```
+
+**Step 3: Update getIngressOpenUrl for catch-all TLS**
+
+Update the `getIngressOpenUrl` function (around lines 26-38):
+
+```tsx
+const getIngressOpenUrl = (ingress: IngressInfo): string | null => {
+  const host =
+    ingress.rules.find((rule) => rule.host && rule.host !== "*")?.host ||
+    ingress.loadBalancerIps[0];
+
+  if (!host) {
+    return null;
+  }
+
+  // Check both explicit TLS hosts and catch-all TLS
+  const usesTls = ingress.tlsHosts.includes(host) || ingress.hasCatchAllTls;
+  const scheme = usesTls ? "https" : "http";
+  return `${scheme}://${host}`;
+};
+```
+
+**Step 4: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 5: Commit**
+
+```bash
+git add src/components/resources/IngressList.tsx
+git commit -m "feat(network): use TlsBadge in IngressList with catch-all support"
+```
+
+---
+
+## Task 6: Update IngressDetail TLS Tab
+
+**Files:**
+- Modify: `src/pages/IngressDetail.tsx:282-328`
+
+**Step 1: Add TlsBadge import**
+
+Add at the top:
+
+```tsx
+import { TlsBadge } from "@/components/network";
+```
+
+**Step 2: Replace generateAccessUrls TLS logic**
+
+Update the `generateAccessUrls` function (around lines 34-67) to use `hasCatchAllTls`:
+
+```tsx
+function generateAccessUrls(rules: IngressRule[], tlsHosts: string[], hasCatchAllTls: boolean): AccessUrl[] {
+    const urls: AccessUrl[] = [];
+
+    for (const rule of rules) {
+        const isWildcard = rule.host === "*" || !rule.host;
+        const displayHost = isWildcard ? "All hosts" : rule.host;
+        const actualHost = isWildcard ? "" : rule.host;
+
+        // TLS detection: host is in tlsHosts, or there's a catch-all TLS config
+        const isHttps = tlsHosts.includes(rule.host) || hasCatchAllTls;
+        const scheme = isHttps ? "https" : "http";
+        const tlsReason = tlsHosts.includes(rule.host)
+            ? "explicit"
+            : hasCatchAllTls
+                ? "catch-all"
+                : null;
+
+        for (const path of rule.paths) {
+            const fullUrl = actualHost ? `${scheme}://${actualHost}${path.path}` : `${scheme}://<host>${path.path}`;
+            urls.push({
+                fullUrl,
+                host: rule.host,
+                displayHost,
+                path: path.path,
+                pathType: path.pathType,
+                backendService: path.backendService,
+                backendPort: path.backendPort,
+                resourceBackend: path.resourceBackend,
+                isHttps,
+                tlsReason,
+            });
+        }
+    }
+
+    return urls;
+}
+```
+
+**Step 3: Update AccessUrl interface**
+
+Add `tlsReason` to the interface:
+
+```tsx
+interface AccessUrl {
+    fullUrl: string;
+    host: string;
+    displayHost: string;
+    path: string;
+    pathType: string;
+    backendService: string;
+    backendPort: string;
+    resourceBackend: string | null;
+    isHttps: boolean;
+    tlsReason: "explicit" | "catch-all" | null;
+}
+```
+
+**Step 4: Update accessUrls call**
+
+Update the call to pass `hasCatchAllTls`:
+
+```tsx
+const hasCatchAllTls = ingress?.hasCatchAllTls ?? false;
+const accessUrls = generateAccessUrls(rules, tlsHosts, hasCatchAllTls);
+```
+
+**Step 5: Update TLS tab content**
+
+Replace the TLS tab content (around lines 282-328) with improved version:
+
+```tsx
+        {
+            id: "tls",
+            label: "TLS",
+            content: (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2">
+                            <Shield className="h-5 w-5" />
+                            TLS Configuration
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        {tlsConfigs.length > 0 ? (
+                            <div className="space-y-4">
+                                {/* Explicit TLS Hosts */}
+                                {tlsConfigs.filter(c => !c.isCatchAll).length > 0 && (
+                                    <div>
+                                        <h4 className="text-sm font-medium mb-2">Explicit TLS Hosts</h4>
+                                        <div className="space-y-3">
+                                            {tlsConfigs.filter(c => !c.isCatchAll).map((config, idx) => (
+                                                <div key={idx} className="rounded-lg border p-4">
+                                                    <div className="flex items-center gap-2 mb-3">
+                                                        <Shield className="h-4 w-4 text-green-500" />
+                                                        <span className="font-medium">
+                                                            Secret: {config.secretName || "(auto-generated)"}
+                                                        </span>
+                                                    </div>
+                                                    <div className="flex flex-wrap gap-2">
+                                                        {config.hosts.map((host, hostIdx) => (
+                                                            <Badge key={hostIdx} variant="outline" className="font-mono">
+                                                                {host}
+                                                            </Badge>
+                                                        ))}
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+
+                                {/* Catch-all TLS */}
+                                {tlsConfigs.filter(c => c.isCatchAll).length > 0 && (
+                                    <div>
+                                        <h4 className="text-sm font-medium mb-2 flex items-center gap-2">
+                                            <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                                            Catch-all TLS
+                                        </h4>
+                                        <div className="space-y-3">
+                                            {tlsConfigs.filter(c => c.isCatchAll).map((config, idx) => (
+                                                <div key={idx} className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4">
+                                                    <div className="flex items-center gap-2 mb-2">
+                                                        <Shield className="h-4 w-4 text-yellow-500" />
+                                                        <span className="font-medium">
+                                                            Secret: {config.secretName || "(auto-generated)"}
+                                                        </span>
+                                                    </div>
+                                                    <p className="text-sm text-muted-foreground">
+                                                        Applies to all hosts not explicitly listed above
+                                                    </p>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        ) : (
+                            <p className="text-muted-foreground">No TLS configured</p>
+                        )}
+                    </CardContent>
+                </Card>
+            ),
+        },
+```
+
+**Step 6: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 7: Commit**
+
+```bash
+git add src/pages/IngressDetail.tsx
+git commit -m "feat(network): improve IngressDetail TLS tab with explicit/catch-all sections"
+```
+
+---
+
+## Task 7: Create ServiceTypeBadge Component
+
+**Files:**
+- Create: `src/components/network/ServiceTypeBadge.tsx`
+- Modify: `src/components/network/index.ts`
+
+**Step 1: Create ServiceTypeBadge.tsx**
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface ServiceTypeBadgeProps {
+  type: string;
+}
+
+const typeConfig: Record<string, { color: string; description: string }> = {
+  ClusterIP: {
+    color: "bg-gray-500/10 text-gray-500 border-gray-500/20",
+    description: "Internal only - accessible within cluster",
+  },
+  NodePort: {
+    color: "bg-blue-500/10 text-blue-500 border-blue-500/20",
+    description: "External via node ports",
+  },
+  LoadBalancer: {
+    color: "bg-green-500/10 text-green-500 border-green-500/20",
+    description: "External via load balancer",
+  },
+  ExternalName: {
+    color: "bg-yellow-500/10 text-yellow-500 border-yellow-500/20",
+    description: "DNS alias to external service",
+  },
+};
+
+export function ServiceTypeBadge({ type }: ServiceTypeBadgeProps) {
+  const config = typeConfig[type] || {
+    color: "bg-gray-500/10 text-gray-500 border-gray-500/20",
+    description: "Unknown service type",
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <Badge variant="default" className={config.color}>
+          {type}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="text-xs">{config.description}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+```
+
+**Step 2: Update index.ts**
+
+```tsx
+export { TlsBadge } from "./TlsBadge";
+export { ServiceTypeBadge } from "./ServiceTypeBadge";
+```
+
+**Step 3: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add src/components/network/
+git commit -m "feat(network): add ServiceTypeBadge component with color coding"
+```
+
+---
+
+## Task 8: Create PortsDisplay Component
+
+**Files:**
+- Create: `src/components/network/PortsDisplay.tsx`
+- Modify: `src/components/network/index.ts`
+
+**Step 1: Create PortsDisplay.tsx**
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ServicePortInfo } from "@/generated/types";
+
+interface PortsDisplayProps {
+  ports: ServicePortInfo[];
+  maxDisplay?: number;
+}
+
+function formatPortCompact(port: ServicePortInfo): string {
+  let result = `${port.port}→${port.targetPort}`;
+  if (port.nodePort) {
+    result += ` (${port.nodePort})`;
+  }
+  return result;
+}
+
+function formatPortFull(port: ServicePortInfo): string {
+  const parts = [`Port: ${port.port}`, `Target: ${port.targetPort}`];
+  if (port.nodePort) {
+    parts.push(`NodePort: ${port.nodePort}`);
+  }
+  parts.push(`Protocol: ${port.protocol}`);
+  if (port.name) {
+    parts.push(`Name: ${port.name}`);
+  }
+  return parts.join("\n");
+}
+
+export function PortsDisplay({ ports, maxDisplay = 2 }: PortsDisplayProps) {
+  if (ports.length === 0) {
+    return <span className="text-muted-foreground">No ports</span>;
+  }
+
+  const displayPorts = ports.slice(0, maxDisplay);
+  const remainingCount = ports.length - maxDisplay;
+
+  return (
+    <div className="flex flex-wrap gap-1 items-center">
+      {displayPorts.map((port, idx) => (
+        <Tooltip key={idx}>
+          <TooltipTrigger>
+            <Badge variant="secondary" className="text-xs font-mono">
+              {formatPortCompact(port)}
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            <pre className="text-xs whitespace-pre">{formatPortFull(port)}</pre>
+          </TooltipContent>
+        </Tooltip>
+      ))}
+      {remainingCount > 0 && (
+        <Tooltip>
+          <TooltipTrigger>
+            <Badge variant="outline" className="text-xs">
+              +{remainingCount}
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            <div className="space-y-2">
+              {ports.slice(maxDisplay).map((port, idx) => (
+                <pre key={idx} className="text-xs whitespace-pre">
+                  {formatPortFull(port)}
+                </pre>
+              ))}
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}
+```
+
+**Step 2: Update index.ts**
+
+```tsx
+export { TlsBadge } from "./TlsBadge";
+export { ServiceTypeBadge } from "./ServiceTypeBadge";
+export { PortsDisplay } from "./PortsDisplay";
+```
+
+**Step 3: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add src/components/network/
+git commit -m "feat(network): add PortsDisplay component with compact format"
+```
+
+---
+
+## Task 9: Update ServiceList with New Components
+
+**Files:**
+- Modify: `src/components/resources/ServiceList.tsx`
+
+**Step 1: Add imports**
+
+```tsx
+import { ServiceTypeBadge, PortsDisplay } from "@/components/network";
+```
+
+**Step 2: Remove old formatPort function**
+
+Delete the `formatPort` function (around lines 24-34).
+
+**Step 3: Update type column**
+
+Replace the type column cell with:
+
+```tsx
+  {
+    accessorKey: "type",
+    header: "Type",
+    cell: ({ row }) => <ServiceTypeBadge type={row.original.type} />,
+  },
+```
+
+**Step 4: Update ports column**
+
+Replace the ports column cell with:
+
+```tsx
+  {
+    accessorKey: "ports",
+    header: "Ports",
+    cell: ({ row }) => <PortsDisplay ports={row.original.ports} maxDisplay={2} />,
+  },
+```
+
+**Step 5: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 6: Commit**
+
+```bash
+git add src/components/resources/ServiceList.tsx
+git commit -m "feat(network): use ServiceTypeBadge and PortsDisplay in ServiceList"
+```
+
+---
+
+## Task 10: Create ServiceAccessInfo Component
+
+**Files:**
+- Create: `src/components/network/ServiceAccessInfo.tsx`
+- Modify: `src/components/network/index.ts`
+
+**Step 1: Create ServiceAccessInfo.tsx**
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Link2, Copy, ExternalLink } from "lucide-react";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import type { ServiceInfo } from "@/generated/types";
+
+interface ServiceAccessInfoProps {
+  service: ServiceInfo;
+}
+
+export function ServiceAccessInfo({ service }: ServiceAccessInfoProps) {
+  const copyToClipboard = useCopyToClipboard();
+
+  const internalDns = `${service.name}.${service.namespace}.svc.cluster.local`;
+  const shortDns = `${service.name}`;
+
+  // Build access URLs based on service type
+  const accessItems: Array<{
+    label: string;
+    url: string;
+    canOpen: boolean;
+    description: string;
+  }> = [];
+
+  if (service.type === "LoadBalancer" && service.externalIps.length > 0) {
+    const port = service.ports[0]?.port;
+    const url = `http://${service.externalIps[0]}${port && port !== 80 ? `:${port}` : ""}`;
+    accessItems.push({
+      label: "External (LoadBalancer)",
+      url,
+      canOpen: true,
+      description: "Access via load balancer IP",
+    });
+  }
+
+  if (service.type === "NodePort" && service.ports.some(p => p.nodePort)) {
+    const nodePort = service.ports.find(p => p.nodePort)?.nodePort;
+    accessItems.push({
+      label: "External (NodePort)",
+      url: `<any-node-ip>:${nodePort}`,
+      canOpen: false,
+      description: "Access via any cluster node IP",
+    });
+  }
+
+  if (service.type === "ExternalName") {
+    accessItems.push({
+      label: "External Name",
+      url: service.clusterIp || "N/A",
+      canOpen: false,
+      description: "DNS alias to external service",
+    });
+  }
+
+  // Internal access for all types except ExternalName
+  if (service.type !== "ExternalName") {
+    const port = service.ports[0]?.port;
+    accessItems.push({
+      label: "Internal (full DNS)",
+      url: `${internalDns}${port ? `:${port}` : ""}`,
+      canOpen: false,
+      description: "From any namespace in cluster",
+    });
+    accessItems.push({
+      label: "Internal (short)",
+      url: `${shortDns}${port ? `:${port}` : ""}`,
+      canOpen: false,
+      description: "From same namespace only",
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Link2 className="h-5 w-5" />
+          How to Access This Service
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {accessItems.map((item, idx) => (
+            <div
+              key={idx}
+              className="flex items-center justify-between rounded-lg border p-3 bg-muted/30"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-sm font-medium">{item.label}</span>
+                </div>
+                <code className="text-sm font-mono text-muted-foreground break-all">
+                  {item.url}
+                </code>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {item.description}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 ml-3">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => copyToClipboard(item.url)}
+                  title="Copy"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+                {item.canOpen && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => window.open(item.url, "_blank", "noreferrer")}
+                    title="Open in Browser"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {service.type === "ClusterIP" && (
+          <div className="mt-4 p-3 rounded-lg bg-muted/50 border">
+            <p className="text-sm text-muted-foreground">
+              <strong>ClusterIP</strong> services are only accessible from within the cluster.
+              Use port-forward for local development:
+              <code className="ml-1 text-xs bg-muted px-1 rounded">
+                kubectl port-forward svc/{service.name} {service.ports[0]?.port || 8080}:{service.ports[0]?.port || 8080}
+              </code>
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+**Step 2: Update index.ts**
+
+```tsx
+export { TlsBadge } from "./TlsBadge";
+export { ServiceTypeBadge } from "./ServiceTypeBadge";
+export { PortsDisplay } from "./PortsDisplay";
+export { ServiceAccessInfo } from "./ServiceAccessInfo";
+```
+
+**Step 3: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add src/components/network/
+git commit -m "feat(network): add ServiceAccessInfo component with access URLs"
+```
+
+---
+
+## Task 11: Create MatchingPods Component
+
+**Files:**
+- Create: `src/components/network/MatchingPods.tsx`
+- Modify: `src/components/network/index.ts`
+
+**Step 1: Create MatchingPods.tsx**
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Link } from "react-router-dom";
+import { Users, Circle } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { commands } from "@/lib/commands";
+import { getResourceDetailUrl } from "@/lib/navigation-utils";
+import { ResourceType } from "@/lib/resource-registry";
+import type { PodInfo } from "@/generated/types";
+
+interface MatchingPodsProps {
+  namespace: string;
+  selector: Record<string, string>;
+}
+
+function getPodStatusColor(phase: string): string {
+  switch (phase) {
+    case "Running":
+      return "text-green-500";
+    case "Pending":
+      return "text-yellow-500";
+    case "Succeeded":
+      return "text-blue-500";
+    case "Failed":
+      return "text-red-500";
+    default:
+      return "text-gray-500";
+  }
+}
+
+export function MatchingPods({ namespace, selector }: MatchingPodsProps) {
+  const { data: pods, isLoading, error } = useQuery({
+    queryKey: ["pods-by-selector", namespace, selector],
+    queryFn: () => commands.getPodsBySelector(namespace, selector),
+    enabled: Object.keys(selector).length > 0,
+  });
+
+  if (Object.keys(selector).length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            Matching Pods
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground">No selector defined</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Count pods by status
+  const statusCounts = pods?.reduce((acc, pod) => {
+    const phase = pod.phase || "Unknown";
+    acc[phase] = (acc[phase] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>) || {};
+
+  const statusSummary = Object.entries(statusCounts)
+    .map(([phase, count]) => `${count} ${phase.toLowerCase()}`)
+    .join(", ");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Users className="h-5 w-5" />
+          Matching Pods
+          {pods && pods.length > 0 && (
+            <Badge variant="secondary" className="ml-2">
+              {statusSummary}
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : error ? (
+          <p className="text-destructive">Failed to load pods: {String(error)}</p>
+        ) : pods && pods.length > 0 ? (
+          <div className="space-y-2">
+            {pods.map((pod) => (
+              <Link
+                key={pod.uid}
+                to={getResourceDetailUrl(ResourceType.Pod, pod.name, pod.namespace)}
+                className="flex items-center justify-between rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+              >
+                <div className="flex items-center gap-3">
+                  <Circle
+                    className={`h-3 w-3 fill-current ${getPodStatusColor(pod.phase || "Unknown")}`}
+                  />
+                  <span className="font-medium">{pod.name}</span>
+                </div>
+                <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                  <span>{pod.phase}</span>
+                  {pod.podIp && <code className="font-mono text-xs">{pod.podIp}</code>}
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground">No pods match this selector</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+**Step 2: Update index.ts**
+
+```tsx
+export { TlsBadge } from "./TlsBadge";
+export { ServiceTypeBadge } from "./ServiceTypeBadge";
+export { PortsDisplay } from "./PortsDisplay";
+export { ServiceAccessInfo } from "./ServiceAccessInfo";
+export { MatchingPods } from "./MatchingPods";
+```
+
+**Step 3: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds (or type errors if getPodsBySelector not yet generated)
+
+**Step 4: Commit**
+
+```bash
+git add src/components/network/
+git commit -m "feat(network): add MatchingPods component for Service->Pods linking"
+```
+
+---
+
+## Task 12: Update ServiceDetail with New Components
+
+**Files:**
+- Modify: `src/pages/ServiceDetail.tsx`
+
+**Step 1: Add imports**
+
+```tsx
+import { ServiceAccessInfo, MatchingPods, ServiceTypeBadge } from "@/components/network";
+```
+
+**Step 2: Add ServiceAccessInfo to the detail view**
+
+In the tabs array, add a new "Access" tab at the beginning:
+
+```tsx
+    {
+      id: "access",
+      label: "Access",
+      content: service ? <ServiceAccessInfo service={service} /> : null,
+    },
+```
+
+**Step 3: Add MatchingPods tab**
+
+Add a new "Pods" tab:
+
+```tsx
+    {
+      id: "pods",
+      label: "Pods",
+      content: service ? (
+        <MatchingPods
+          namespace={service.namespace}
+          selector={service.selector}
+        />
+      ) : null,
+    },
+```
+
+**Step 4: Update default tab**
+
+Change `defaultTab` from existing value to `"access"`.
+
+**Step 5: Use ServiceTypeBadge in badges section**
+
+In the badges prop, replace the type badge with:
+
+```tsx
+{service?.type && <ServiceTypeBadge type={service.type} />}
+```
+
+**Step 6: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 7: Commit**
+
+```bash
+git add src/pages/ServiceDetail.tsx
+git commit -m "feat(network): add Access and Pods tabs to ServiceDetail"
+```
+
+---
+
+## Task 13: Create LinkedResource Component
+
+**Files:**
+- Create: `src/components/network/LinkedResource.tsx`
+- Modify: `src/components/network/index.ts`
+
+**Step 1: Create LinkedResource.tsx**
+
+```tsx
+import { Link } from "react-router-dom";
+import { ExternalLink, AlertTriangle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { getResourceDetailUrl } from "@/lib/navigation-utils";
+import { ResourceType } from "@/lib/resource-registry";
+
+interface LinkedResourceProps {
+  resourceType: ResourceType;
+  name: string;
+  namespace: string;
+  port?: string;
+  exists?: boolean;
+  className?: string;
+}
+
+export function LinkedResource({
+  resourceType,
+  name,
+  namespace,
+  port,
+  exists = true,
+  className = "",
+}: LinkedResourceProps) {
+  const displayText = port ? `${name}:${port}` : name;
+  const url = getResourceDetailUrl(resourceType, name, namespace);
+
+  if (!exists) {
+    return (
+      <Tooltip>
+        <TooltipTrigger>
+          <span className={`text-destructive flex items-center gap-1 ${className}`}>
+            <AlertTriangle className="h-3 w-3" />
+            {displayText}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p className="text-xs">Resource not found in cluster</p>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link
+          to={url}
+          className={`text-primary hover:underline flex items-center gap-1 ${className}`}
+        >
+          {displayText}
+          <ExternalLink className="h-3 w-3" />
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="text-xs">View {resourceType} details</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+```
+
+**Step 2: Update index.ts**
+
+```tsx
+export { TlsBadge } from "./TlsBadge";
+export { ServiceTypeBadge } from "./ServiceTypeBadge";
+export { PortsDisplay } from "./PortsDisplay";
+export { ServiceAccessInfo } from "./ServiceAccessInfo";
+export { MatchingPods } from "./MatchingPods";
+export { LinkedResource } from "./LinkedResource";
+```
+
+**Step 3: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add src/components/network/
+git commit -m "feat(network): add LinkedResource component for cross-resource navigation"
+```
+
+---
+
+## Task 14: Update IngressDetail with LinkedResource
+
+**Files:**
+- Modify: `src/pages/IngressDetail.tsx`
+
+**Step 1: Add LinkedResource import**
+
+```tsx
+import { TlsBadge, LinkedResource } from "@/components/network";
+```
+
+**Step 2: Update Access URLs to use LinkedResource**
+
+In the Access tab content, update the backend display (around line 166-173):
+
+```tsx
+<span className="text-sm text-muted-foreground shrink-0">
+    {url.resourceBackend ? (
+        `Resource: ${url.resourceBackend}`
+    ) : url.backendService ? (
+        <LinkedResource
+            resourceType={ResourceType.Service}
+            name={url.backendService}
+            namespace={ingress?.namespace || ""}
+            port={url.backendPort}
+        />
+    ) : (
+        "No backend"
+    )}
+</span>
+```
+
+**Step 3: Update Rules tab backend display**
+
+In the Rules tab (around line 260-267):
+
+```tsx
+<div className="text-sm text-muted-foreground">
+    → {path.resourceBackend ? (
+        `Resource: ${path.resourceBackend}`
+    ) : path.backendService ? (
+        <LinkedResource
+            resourceType={ResourceType.Service}
+            name={path.backendService}
+            namespace={ingress?.namespace || ""}
+            port={path.backendPort}
+        />
+    ) : (
+        "No backend"
+    )}
+</div>
+```
+
+**Step 4: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/IngressDetail.tsx
+git commit -m "feat(network): add clickable service links in IngressDetail"
+```
+
+---
+
+## Task 15: Update EndpointsDetail with Service Link
+
+**Files:**
+- Modify: `src/pages/EndpointsDetail.tsx`
+
+**Step 1: Add LinkedResource import**
+
+```tsx
+import { LinkedResource } from "@/components/network";
+```
+
+**Step 2: Add Service link in header**
+
+In the badges section, add a link to the parent Service:
+
+```tsx
+badges={
+    <>
+        {endpoints?.namespace && (
+            <Badge variant="outline">{endpoints.namespace}</Badge>
+        )}
+        <LinkedResource
+            resourceType={ResourceType.Service}
+            name={endpoints?.name || name || ""}
+            namespace={endpoints?.namespace || namespace || ""}
+        />
+    </>
+}
+```
+
+**Step 3: Update pod references to be clickable**
+
+In the addresses display, make targetRef clickable:
+
+```tsx
+{addr.targetRef && addr.targetRef.kind === "Pod" && (
+    <LinkedResource
+        resourceType={ResourceType.Pod}
+        name={addr.targetRef.name}
+        namespace={addr.targetRef.namespace || endpoints?.namespace || ""}
+        className="text-xs"
+    />
+)}
+```
+
+**Step 4: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/EndpointsDetail.tsx
+git commit -m "feat(network): add Service and Pod links in EndpointsDetail"
+```
+
+---
+
+## Task 16: Add Error Handling to Events
+
+**Files:**
+- Modify: `src/pages/IngressDetail.tsx:404-448`
+
+**Step 1: Update events query to expose error**
+
+```tsx
+const { data: events = [], isLoading: eventsLoading, error: eventsError, refetch: refetchEvents } = useQuery({
+    // ... existing config
+});
+```
+
+**Step 2: Update Events tab content**
+
+Replace the Events tab content with:
+
+```tsx
+{
+    id: "events",
+    label: "Events",
+    content: (
+        <Card>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    <Clock className="h-5 w-5" />
+                    Events
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                {eventsError ? (
+                    <div className="flex items-center justify-between p-3 rounded-lg border border-yellow-500/30 bg-yellow-500/5">
+                        <div className="flex items-center gap-2">
+                            <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                            <span className="text-sm">Failed to load events</span>
+                        </div>
+                        <Button size="sm" variant="outline" onClick={() => refetchEvents()}>
+                            Retry
+                        </Button>
+                    </div>
+                ) : eventsLoading ? (
+                    <div className="space-y-2">
+                        <Skeleton className="h-16 w-full" />
+                        <Skeleton className="h-16 w-full" />
+                    </div>
+                ) : events.length > 0 ? (
+                    <div className="space-y-3">
+                        {events.map((event: EventInfo) => {
+                            const isWarning = event.type === "Warning";
+                            return (
+                                <div
+                                    key={event.uid}
+                                    className={cn(
+                                        "rounded-lg border p-3",
+                                        isWarning ? "border-yellow-500/50 bg-yellow-500/5" : "border-border"
+                                    )}
+                                >
+                                    <div className="flex items-start justify-between">
+                                        <div className="flex items-center gap-2">
+                                            {isWarning ? (
+                                                <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                                            ) : (
+                                                <Info className="h-4 w-4 text-blue-500" />
+                                            )}
+                                            <span className="font-medium">{event.reason}</span>
+                                        </div>
+                                        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                                            <Clock className="h-3 w-3" />
+                                            {event.lastTimestamp
+                                                ? new Date(event.lastTimestamp).toLocaleString()
+                                                : "Unknown"}
+                                            {(event.count || 0) > 1 && (
+                                                <Badge variant="secondary" className="ml-2">
+                                                    x{event.count}
+                                                </Badge>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <p className="mt-1 text-sm text-muted-foreground">{event.message}</p>
+                                </div>
+                            );
+                        })}
+                    </div>
+                ) : (
+                    <p className="text-muted-foreground">No events found</p>
+                )}
+            </CardContent>
+        </Card>
+    ),
+},
+```
+
+**Step 3: Add Skeleton import if missing**
+
+```tsx
+import { Skeleton } from "@/components/ui/skeleton";
+```
+
+**Step 4: Verify build**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/IngressDetail.tsx
+git commit -m "feat(network): add error handling and retry to Events tab"
+```
+
+---
+
+## Task 17: Final Verification and Cleanup
+
+**Step 1: Run full build**
+
+```bash
+npm run build
+```
+
+Expected: Build succeeds with no errors
+
+**Step 2: Run Rust check**
+
+```bash
+cd src-tauri && cargo check
+```
+
+Expected: Compiles with no errors (warnings OK)
+
+**Step 3: Verify all new components export**
+
+Check `src/components/network/index.ts` exports all:
+- TlsBadge
+- ServiceTypeBadge
+- PortsDisplay
+- ServiceAccessInfo
+- MatchingPods
+- LinkedResource
+
+**Step 4: Create final commit**
+
+```bash
+git add -A
+git status
+```
+
+If any uncommitted changes:
+
+```bash
+git commit -m "chore(network): cleanup and final verification"
+```
+
+**Step 5: Push branch**
+
+```bash
+git push -u origin feature/network-redesign
+```
+
+---
+
+## Summary
+
+| Task | Component | Description |
+|------|-----------|-------------|
+| 1 | Backend | Add TLS catch-all flags |
+| 2 | Backend | Add get_pods_by_selector command |
+| 3 | Types | Regenerate TypeScript types |
+| 4 | TlsBadge | Reusable TLS badge with catch-all |
+| 5 | IngressList | Use TlsBadge, fix TLS detection |
+| 6 | IngressDetail | Improve TLS tab sections |
+| 7 | ServiceTypeBadge | Color-coded service types |
+| 8 | PortsDisplay | Compact port format |
+| 9 | ServiceList | Use new components |
+| 10 | ServiceAccessInfo | "How to Access" card |
+| 11 | MatchingPods | Service→Pods linking |
+| 12 | ServiceDetail | Add Access/Pods tabs |
+| 13 | LinkedResource | Cross-resource navigation |
+| 14 | IngressDetail | Clickable backend services |
+| 15 | EndpointsDetail | Service/Pod links |
+| 16 | Events | Error handling with retry |
+| 17 | Verification | Final build and push |

--- a/src-tauri/src/commands/workloads.rs
+++ b/src-tauri/src/commands/workloads.rs
@@ -172,3 +172,45 @@ pub async fn delete_cronjob(
     crate::validation::validate_dns_label(&name)?;
     crate::commands::helpers::delete_resource::<CronJob>(name, namespace, state, None).await
 }
+
+// ============= Pod Selector Query =============
+
+#[tauri::command]
+pub async fn get_pods_by_selector(
+    namespace: String,
+    selector: std::collections::BTreeMap<String, String>,
+    state: State<'_, AppState>,
+) -> Result<Vec<crate::resources::PodInfo>> {
+    use crate::error::Error;
+
+    let context = state
+        .get_current_context()
+        .ok_or_else(|| Error::Internal("No cluster connected".to_string()))?;
+
+    let client = state
+        .client_manager
+        .get_client(&context)
+        .ok_or_else(|| Error::Internal("Client not found".to_string()))
+        .map(|c| (*c).clone())?;
+
+    // Convert selector map to label selector string
+    let label_selector = selector
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let pods: kube::Api<k8s_openapi::api::core::v1::Pod> =
+        kube::Api::namespaced(client, &namespace);
+
+    let lp = kube::api::ListParams::default().labels(&label_selector);
+    let pod_list = pods.list(&lp).await?;
+
+    let pod_infos: Vec<crate::resources::PodInfo> = pod_list
+        .items
+        .iter()
+        .map(|p| p.into())
+        .collect();
+
+    Ok(pod_infos)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -383,6 +383,7 @@ fn main() {
             commands::workloads::get_cronjob,
             commands::workloads::get_cronjob_yaml,
             commands::workloads::delete_cronjob,
+            commands::workloads::get_pods_by_selector,
 
             // Validation commands
             commands::validation::validate_email_command,

--- a/src-tauri/src/resources/network.rs
+++ b/src-tauri/src/resources/network.rs
@@ -1,6 +1,5 @@
 //! Network resource types
 
-use crate::utils::format_k8s_age;
 use k8s_openapi::api::core::v1::Endpoints;
 use k8s_openapi::api::networking::v1::Ingress;
 use kube::ResourceExt;

--- a/src-tauri/src/resources/network.rs
+++ b/src-tauri/src/resources/network.rs
@@ -32,6 +32,7 @@ pub struct IngressRule {
 pub struct IngressTlsConfig {
     pub hosts: Vec<String>,
     pub secret_name: Option<String>,
+    pub is_catch_all: bool,
 }
 
 /// Information about an Ingress
@@ -45,6 +46,7 @@ pub struct IngressInfo {
     pub load_balancer_ips: Vec<String>,
     pub tls_hosts: Vec<String>,
     pub tls_configs: Vec<IngressTlsConfig>,
+    pub has_catch_all_tls: bool,
     pub labels: std::collections::BTreeMap<String, String>,
     pub annotations: std::collections::BTreeMap<String, String>,
     pub created_at: Option<String>,
@@ -138,18 +140,25 @@ impl From<&Ingress> for IngressInfo {
             .unwrap_or_default();
 
         // Parse TLS configs with secret names
-        let tls_configs = spec
+        let tls_configs: Vec<IngressTlsConfig> = spec
             .and_then(|s| s.tls.as_ref())
             .map(|tls_list| {
                 tls_list
                     .iter()
-                    .map(|tls| IngressTlsConfig {
-                        hosts: tls.hosts.clone().unwrap_or_default(),
-                        secret_name: tls.secret_name.clone(),
+                    .map(|tls| {
+                        let hosts = tls.hosts.clone().unwrap_or_default();
+                        let is_catch_all = hosts.is_empty();
+                        IngressTlsConfig {
+                            hosts,
+                            secret_name: tls.secret_name.clone(),
+                            is_catch_all,
+                        }
                     })
                     .collect()
             })
             .unwrap_or_default();
+
+        let has_catch_all_tls = tls_configs.iter().any(|c| c.is_catch_all);
 
         // Extract labels and annotations
         let labels = ingress
@@ -171,6 +180,7 @@ impl From<&Ingress> for IngressInfo {
             load_balancer_ips,
             tls_hosts,
             tls_configs,
+            has_catch_all_tls,
             labels,
             annotations,
             created_at: ingress

--- a/src-tauri/src/resources/types.rs
+++ b/src-tauri/src/resources/types.rs
@@ -624,6 +624,7 @@ pub struct ServiceInfo {
     pub session_affinity: String,
     pub cluster_ip: Option<String>,
     pub external_ips: Vec<String>,
+    pub load_balancer_ips: Vec<String>,
     pub ports: Vec<ServicePortInfo>,
     pub selector: BTreeMap<String, String>,
     pub labels: BTreeMap<String, String>,
@@ -645,6 +646,19 @@ pub struct ServicePortInfo {
 impl From<&Service> for ServiceInfo {
     fn from(service: &Service) -> Self {
         let spec = service.spec.as_ref();
+        let status = service.status.as_ref();
+
+        // Get LoadBalancer IPs from status.loadBalancer.ingress
+        let load_balancer_ips = status
+            .and_then(|s| s.load_balancer.as_ref())
+            .and_then(|lb| lb.ingress.as_ref())
+            .map(|ingresses| {
+                ingresses
+                    .iter()
+                    .filter_map(|i| i.ip.clone().or_else(|| i.hostname.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
 
         let ports = spec
             .and_then(|s| s.ports.as_ref())
@@ -686,6 +700,7 @@ impl From<&Service> for ServiceInfo {
             external_ips: spec
                 .and_then(|s| s.external_ips.clone())
                 .unwrap_or_default(),
+            load_balancer_ips,
             ports,
             selector: spec.and_then(|s| s.selector.clone()).unwrap_or_default(),
             labels: service.labels().clone(),

--- a/src/components/network/LinkedResource.tsx
+++ b/src/components/network/LinkedResource.tsx
@@ -1,0 +1,63 @@
+import { Link } from "react-router-dom";
+import { ExternalLink, AlertTriangle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { getResourceDetailUrl } from "@/lib/navigation-utils";
+import { ResourceKind } from "@/lib/resource-registry";
+
+interface LinkedResourceProps {
+  resourceType: ResourceKind;
+  name: string;
+  namespace: string;
+  port?: string;
+  exists?: boolean;
+  className?: string;
+}
+
+export function LinkedResource({
+  resourceType,
+  name,
+  namespace,
+  port,
+  exists = true,
+  className = "",
+}: LinkedResourceProps) {
+  const displayText = port ? `${name}:${port}` : name;
+  const url = getResourceDetailUrl(resourceType, name, namespace);
+
+  if (!exists) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={`text-destructive flex items-center gap-1 ${className}`}>
+            <AlertTriangle className="h-3 w-3" />
+            {displayText}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p className="text-xs">Resource not found in cluster</p>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link
+          to={url}
+          className={`text-primary hover:underline flex items-center gap-1 ${className}`}
+        >
+          {displayText}
+          <ExternalLink className="h-3 w-3" />
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="text-xs">View {resourceType} details</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/network/MatchingPods.tsx
+++ b/src/components/network/MatchingPods.tsx
@@ -1,0 +1,113 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Link } from "react-router-dom";
+import { Users, Circle } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { commands } from "@/lib/commands";
+import { getResourceDetailUrl } from "@/lib/navigation-utils";
+import { ResourceType } from "@/lib/resource-registry";
+
+interface MatchingPodsProps {
+  namespace: string;
+  selector: Record<string, string>;
+}
+
+function getPodStatusColor(phase: string): string {
+  switch (phase) {
+    case "Running":
+      return "text-green-500";
+    case "Pending":
+      return "text-yellow-500";
+    case "Succeeded":
+      return "text-blue-500";
+    case "Failed":
+      return "text-red-500";
+    default:
+      return "text-gray-500";
+  }
+}
+
+export function MatchingPods({ namespace, selector }: MatchingPodsProps) {
+  const { data: pods, isLoading, error } = useQuery({
+    queryKey: ["pods-by-selector", namespace, selector],
+    queryFn: () => commands.getPodsBySelector(namespace, selector),
+    enabled: Object.keys(selector).length > 0,
+  });
+
+  if (Object.keys(selector).length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            Matching Pods
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground">No selector defined</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Count pods by status
+  const statusCounts = pods?.reduce((acc, pod) => {
+    const phase = pod.status.phase || "Unknown";
+    acc[phase] = (acc[phase] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>) || {};
+
+  const statusSummary = Object.entries(statusCounts)
+    .map(([phase, count]) => `${count} ${phase.toLowerCase()}`)
+    .join(", ");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Users className="h-5 w-5" />
+          Matching Pods
+          {pods && pods.length > 0 && (
+            <Badge variant="secondary" className="ml-2">
+              {statusSummary}
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : error ? (
+          <p className="text-destructive">Failed to load pods: {String(error)}</p>
+        ) : pods && pods.length > 0 ? (
+          <div className="space-y-2">
+            {pods.map((pod) => (
+              <Link
+                key={pod.uid}
+                to={getResourceDetailUrl(ResourceType.Pod, pod.name, pod.namespace)}
+                className="flex items-center justify-between rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+              >
+                <div className="flex items-center gap-3">
+                  <Circle
+                    className={`h-3 w-3 fill-current ${getPodStatusColor(pod.status.phase || "Unknown")}`}
+                  />
+                  <span className="font-medium">{pod.name}</span>
+                </div>
+                <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                  <span>{pod.status.phase}</span>
+                  {pod.podIp && <code className="font-mono text-xs">{pod.podIp}</code>}
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground">No pods match this selector</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/network/PortsDisplay.tsx
+++ b/src/components/network/PortsDisplay.tsx
@@ -1,0 +1,76 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ServicePortInfo } from "@/generated/types";
+
+interface PortsDisplayProps {
+  ports: ServicePortInfo[];
+  maxDisplay?: number;
+}
+
+function formatPortCompact(port: ServicePortInfo): string {
+  let result = `${port.port}→${port.targetPort}`;
+  if (port.nodePort) {
+    result += ` (${port.nodePort})`;
+  }
+  return result;
+}
+
+function formatPortFull(port: ServicePortInfo): string {
+  const parts = [`Port: ${port.port}`, `Target: ${port.targetPort}`];
+  if (port.nodePort) {
+    parts.push(`NodePort: ${port.nodePort}`);
+  }
+  parts.push(`Protocol: ${port.protocol}`);
+  if (port.name) {
+    parts.push(`Name: ${port.name}`);
+  }
+  return parts.join("\n");
+}
+
+export function PortsDisplay({ ports, maxDisplay = 2 }: PortsDisplayProps) {
+  if (ports.length === 0) {
+    return <span className="text-muted-foreground">No ports</span>;
+  }
+
+  const displayPorts = ports.slice(0, maxDisplay);
+  const remainingCount = ports.length - maxDisplay;
+
+  return (
+    <div className="flex flex-wrap gap-1 items-center">
+      {displayPorts.map((port, idx) => (
+        <Tooltip key={idx}>
+          <TooltipTrigger>
+            <Badge variant="secondary" className="text-xs font-mono">
+              {formatPortCompact(port)}
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            <pre className="text-xs whitespace-pre">{formatPortFull(port)}</pre>
+          </TooltipContent>
+        </Tooltip>
+      ))}
+      {remainingCount > 0 && (
+        <Tooltip>
+          <TooltipTrigger>
+            <Badge variant="outline" className="text-xs">
+              +{remainingCount}
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            <div className="space-y-2">
+              {ports.slice(maxDisplay).map((port, idx) => (
+                <pre key={idx} className="text-xs whitespace-pre">
+                  {formatPortFull(port)}
+                </pre>
+              ))}
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/src/components/network/ServiceAccessInfo.tsx
+++ b/src/components/network/ServiceAccessInfo.tsx
@@ -1,0 +1,136 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Link2, Copy, ExternalLink } from "lucide-react";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import type { ServiceInfo } from "@/generated/types";
+
+interface ServiceAccessInfoProps {
+  service: ServiceInfo;
+}
+
+export function ServiceAccessInfo({ service }: ServiceAccessInfoProps) {
+  const copyToClipboard = useCopyToClipboard();
+
+  const internalDns = `${service.name}.${service.namespace}.svc.cluster.local`;
+  const shortDns = `${service.name}`;
+
+  // Build access URLs based on service type
+  const accessItems: Array<{
+    label: string;
+    url: string;
+    canOpen: boolean;
+    description: string;
+  }> = [];
+
+  if (service.type === "LoadBalancer" && service.externalIps.length > 0) {
+    const port = service.ports[0]?.port;
+    const url = `http://${service.externalIps[0]}${port && port !== 80 ? `:${port}` : ""}`;
+    accessItems.push({
+      label: "External (LoadBalancer)",
+      url,
+      canOpen: true,
+      description: "Access via load balancer IP",
+    });
+  }
+
+  if (service.type === "NodePort" && service.ports.some(p => p.nodePort)) {
+    const nodePort = service.ports.find(p => p.nodePort)?.nodePort;
+    accessItems.push({
+      label: "External (NodePort)",
+      url: `<any-node-ip>:${nodePort}`,
+      canOpen: false,
+      description: "Access via any cluster node IP",
+    });
+  }
+
+  if (service.type === "ExternalName") {
+    accessItems.push({
+      label: "External Name",
+      url: service.clusterIp || "N/A",
+      canOpen: false,
+      description: "DNS alias to external service",
+    });
+  }
+
+  // Internal access for all types except ExternalName
+  if (service.type !== "ExternalName") {
+    const port = service.ports[0]?.port;
+    accessItems.push({
+      label: "Internal (full DNS)",
+      url: `${internalDns}${port ? `:${port}` : ""}`,
+      canOpen: false,
+      description: "From any namespace in cluster",
+    });
+    accessItems.push({
+      label: "Internal (short)",
+      url: `${shortDns}${port ? `:${port}` : ""}`,
+      canOpen: false,
+      description: "From same namespace only",
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Link2 className="h-5 w-5" />
+          How to Access This Service
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {accessItems.map((item, idx) => (
+            <div
+              key={idx}
+              className="flex items-center justify-between rounded-lg border p-3 bg-muted/30"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-sm font-medium">{item.label}</span>
+                </div>
+                <code className="text-sm font-mono text-muted-foreground break-all">
+                  {item.url}
+                </code>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {item.description}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 ml-3">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => copyToClipboard(item.url)}
+                  title="Copy"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+                {item.canOpen && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => window.open(item.url, "_blank", "noreferrer")}
+                    title="Open in Browser"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {service.type === "ClusterIP" && (
+          <div className="mt-4 p-3 rounded-lg bg-muted/50 border">
+            <p className="text-sm text-muted-foreground">
+              <strong>ClusterIP</strong> services are only accessible from within the cluster.
+              Use port-forward for local development:
+              <code className="ml-1 text-xs bg-muted px-1 rounded">
+                kubectl port-forward svc/{service.name} {service.ports[0]?.port || 8080}:{service.ports[0]?.port || 8080}
+              </code>
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/network/ServiceAccessInfo.tsx
+++ b/src/components/network/ServiceAccessInfo.tsx
@@ -22,9 +22,9 @@ export function ServiceAccessInfo({ service }: ServiceAccessInfoProps) {
     description: string;
   }> = [];
 
-  if (service.type === "LoadBalancer" && service.externalIps.length > 0) {
+  if (service.type === "LoadBalancer" && service.loadBalancerIps.length > 0) {
     const port = service.ports[0]?.port;
-    const url = `http://${service.externalIps[0]}${port && port !== 80 ? `:${port}` : ""}`;
+    const url = `http://${service.loadBalancerIps[0]}${port && port !== 80 ? `:${port}` : ""}`;
     accessItems.push({
       label: "External (LoadBalancer)",
       url,

--- a/src/components/network/ServiceTypeBadge.tsx
+++ b/src/components/network/ServiceTypeBadge.tsx
@@ -1,0 +1,49 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface ServiceTypeBadgeProps {
+  type: string;
+}
+
+const typeConfig: Record<string, { color: string; description: string }> = {
+  ClusterIP: {
+    color: "bg-gray-500/10 text-gray-500 border-gray-500/20",
+    description: "Internal only - accessible within cluster",
+  },
+  NodePort: {
+    color: "bg-blue-500/10 text-blue-500 border-blue-500/20",
+    description: "External via node ports",
+  },
+  LoadBalancer: {
+    color: "bg-green-500/10 text-green-500 border-green-500/20",
+    description: "External via load balancer",
+  },
+  ExternalName: {
+    color: "bg-yellow-500/10 text-yellow-500 border-yellow-500/20",
+    description: "DNS alias to external service",
+  },
+};
+
+export function ServiceTypeBadge({ type }: ServiceTypeBadgeProps) {
+  const config = typeConfig[type] || {
+    color: "bg-gray-500/10 text-gray-500 border-gray-500/20",
+    description: "Unknown service type",
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <Badge variant="default" className={config.color}>
+          {type}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="text-xs">{config.description}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/network/TlsBadge.tsx
+++ b/src/components/network/TlsBadge.tsx
@@ -1,0 +1,68 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Shield } from "lucide-react";
+
+interface TlsBadgeProps {
+  tlsHosts: string[];
+  hasCatchAllTls: boolean;
+  showIcon?: boolean;
+}
+
+export function TlsBadge({ tlsHosts, hasCatchAllTls, showIcon = false }: TlsBadgeProps) {
+  const explicitCount = tlsHosts.length;
+  const hasTls = explicitCount > 0 || hasCatchAllTls;
+
+  if (!hasTls) {
+    return (
+      <Badge variant="outline" className="text-muted-foreground">
+        No TLS
+      </Badge>
+    );
+  }
+
+  // Build display text
+  let displayText: string;
+  if (explicitCount > 0 && hasCatchAllTls) {
+    displayText = `TLS (${explicitCount} + all)`;
+  } else if (hasCatchAllTls) {
+    displayText = "TLS (all)";
+  } else {
+    displayText = `TLS (${explicitCount})`;
+  }
+
+  // Build tooltip content
+  const tooltipLines: string[] = [];
+  if (explicitCount > 0) {
+    tooltipLines.push(...tlsHosts);
+  }
+  if (hasCatchAllTls) {
+    tooltipLines.push("+ Catch-all TLS certificate");
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <Badge
+          variant="default"
+          className="bg-green-500/10 text-green-500 border-green-500/20"
+        >
+          {showIcon && <Shield className="h-3 w-3 mr-1" />}
+          {displayText}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="space-y-1">
+          {tooltipLines.map((line, i) => (
+            <div key={i} className="text-xs">
+              {line}
+            </div>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/network/index.ts
+++ b/src/components/network/index.ts
@@ -1,1 +1,3 @@
 export { TlsBadge } from "./TlsBadge";
+export { ServiceTypeBadge } from "./ServiceTypeBadge";
+export { PortsDisplay } from "./PortsDisplay";

--- a/src/components/network/index.ts
+++ b/src/components/network/index.ts
@@ -1,3 +1,5 @@
 export { TlsBadge } from "./TlsBadge";
 export { ServiceTypeBadge } from "./ServiceTypeBadge";
 export { PortsDisplay } from "./PortsDisplay";
+export { ServiceAccessInfo } from "./ServiceAccessInfo";
+export { MatchingPods } from "./MatchingPods";

--- a/src/components/network/index.ts
+++ b/src/components/network/index.ts
@@ -1,0 +1,1 @@
+export { TlsBadge } from "./TlsBadge";

--- a/src/components/network/index.ts
+++ b/src/components/network/index.ts
@@ -3,3 +3,4 @@ export { ServiceTypeBadge } from "./ServiceTypeBadge";
 export { PortsDisplay } from "./PortsDisplay";
 export { ServiceAccessInfo } from "./ServiceAccessInfo";
 export { MatchingPods } from "./MatchingPods";
+export { LinkedResource } from "./LinkedResource";

--- a/src/components/resources/IngressList.tsx
+++ b/src/components/resources/IngressList.tsx
@@ -16,6 +16,7 @@ import {
 import { ResourceList } from "@/components/resources/ResourceList";
 import { createNamespaceColumn, createAgeColumn } from "@/components/resources/columns";
 import type { QuickAction } from "@/components/ui/quick-actions";
+import { TlsBadge } from "@/components/network";
 
 import type { IngressInfo } from "@/generated/types";
 import { STALE_TIMES } from "@/lib/refresh";
@@ -32,7 +33,8 @@ const getIngressOpenUrl = (ingress: IngressInfo): string | null => {
     return null;
   }
 
-  const usesTls = ingress.tlsHosts.includes(host);
+  // Check both explicit TLS hosts and catch-all TLS
+  const usesTls = ingress.tlsHosts.includes(host) || ingress.hasCatchAllTls;
   const scheme = usesTls ? "https" : "http";
   return `${scheme}://${host}`;
 };
@@ -131,33 +133,12 @@ const baseColumns: ColumnDef<IngressInfo>[] = [
   {
     accessorKey: "tlsHosts",
     header: "TLS",
-    cell: ({ row }) => {
-      const tlsHosts = row.original.tlsHosts;
-      if (tlsHosts.length === 0) {
-        return <Badge variant="outline">No TLS</Badge>;
-      }
-      return (
-        <Tooltip>
-          <TooltipTrigger>
-            <Badge
-              variant="default"
-              className="bg-green-500/10 text-green-500 border-green-500/20"
-            >
-              TLS ({tlsHosts.length})
-            </Badge>
-          </TooltipTrigger>
-          <TooltipContent>
-            <div className="space-y-1">
-              {tlsHosts.map((host, i) => (
-                <div key={i} className="text-xs">
-                  {host}
-                </div>
-              ))}
-            </div>
-          </TooltipContent>
-        </Tooltip>
-      );
-    },
+    cell: ({ row }) => (
+      <TlsBadge
+        tlsHosts={row.original.tlsHosts}
+        hasCatchAllTls={row.original.hasCatchAllTls}
+      />
+    ),
   },
   createAgeColumn<IngressInfo>(),
 ];

--- a/src/components/resources/ServiceList.tsx
+++ b/src/components/resources/ServiceList.tsx
@@ -1,6 +1,5 @@
 import { commands } from "@/lib/commands";
 import { useClusterStore } from "@/stores/clusterStore";
-import { Badge } from "@/components/ui/badge";
 import { ColumnDef } from "@tanstack/react-table";
 import { Eye, Trash2, ExternalLink } from "lucide-react";
 import { useMemo } from "react";
@@ -8,30 +7,17 @@ import { ResourceList } from "./ResourceList";
 import { ResourceType, toPlural } from "@/lib/resource-registry";
 import { queryKeys } from "@/lib/query-keys";
 import { getResourceDetailUrl, getResourceListUrl } from "@/lib/navigation-utils";
-import type { ServiceInfo, ServicePortInfo } from "@/generated/types";
+import type { ServiceInfo } from "@/generated/types";
 import { STALE_TIMES } from "@/lib/refresh";
 import {
   createNameColumn,
   createNamespaceColumn,
   createAgeColumn,
-  createTypeBadgeColumn,
 } from "./columns";
 import { getResourceRowId } from "@/lib/table-utils";
 import type { QuickAction } from "@/components/ui/quick-actions";
 import { useNavigate } from "react-router-dom";
-
-// Format port for display
-function formatPort(port: ServicePortInfo): string {
-  const parts = [String(port.port)];
-  if (port.nodePort) {
-    parts.push(`:${port.nodePort}`);
-  }
-  if (port.targetPort) {
-    parts.push(`>${port.targetPort}`);
-  }
-  parts.push(`/${port.protocol}`);
-  return parts.join("");
-}
+import { ServiceTypeBadge, PortsDisplay } from "@/components/network";
 
 export function ServiceList() {
   const { currentNamespace } = useClusterStore();
@@ -41,7 +27,11 @@ export function ServiceList() {
     () => [
       createNameColumn<ServiceInfo>(getResourceListUrl(ResourceType.Service)),
       createNamespaceColumn<ServiceInfo>(),
-      createTypeBadgeColumn<ServiceInfo>(),
+      {
+        accessorKey: "type",
+        header: "Type",
+        cell: ({ row }) => <ServiceTypeBadge type={row.original.type} />,
+      },
       {
         accessorKey: "clusterIp",
         header: "Cluster IP",
@@ -72,17 +62,9 @@ export function ServiceList() {
         },
       },
       {
-        id: "ports",
+        accessorKey: "ports",
         header: "Ports",
-        cell: ({ row }) => (
-          <div className="flex flex-wrap gap-1">
-            {row.original.ports.map((port, i) => (
-              <Badge key={i} variant="outline" className="font-mono text-xs">
-                {formatPort(port)}
-              </Badge>
-            ))}
-          </div>
-        ),
+        cell: ({ row }) => <PortsDisplay ports={row.original.ports} maxDisplay={2} />,
       },
       createAgeColumn<ServiceInfo>(),
     ],

--- a/src/generated/commands.ts
+++ b/src/generated/commands.ts
@@ -240,6 +240,13 @@ export async function listPods(filters: PodFilters | null): Promise<PodInfo[]> {
   return invoke<PodInfo[]>("list_pods", { filters });
 }
 
+export async function getPodsBySelector(
+  namespace: string,
+  selector: Record<string, string>
+): Promise<PodInfo[]> {
+  return invoke<PodInfo[]>("get_pods_by_selector", { namespace, selector });
+}
+
 export async function getPod(name: string, namespace: string | null): Promise<PodInfo> {
   return invoke<PodInfo>("get_pod", { name, namespace });
 }

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -782,6 +782,7 @@ export interface ServiceInfo {
   sessionAffinity: string;
   clusterIp: string | null;
   externalIps: string[];
+  loadBalancerIps: string[];
   ports: ServicePortInfo[];
   selector: Record<string, string>;
   labels: Record<string, string>;

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -79,6 +79,7 @@ export interface IngressInfo {
   loadBalancerIps: string[];
   tlsHosts: string[];
   tlsConfigs: IngressTlsConfig[];
+  hasCatchAllTls: boolean;
   labels: Record<string, string>;
   annotations: Record<string, string>;
   createdAt: string | null;
@@ -87,6 +88,7 @@ export interface IngressInfo {
 export interface IngressTlsConfig {
   hosts: string[];
   secretName: string | null;
+  isCatchAll: boolean;
 }
 
 export interface IngressRule {

--- a/src/pages/EndpointsDetail.tsx
+++ b/src/pages/EndpointsDetail.tsx
@@ -8,6 +8,7 @@ import {
 import { useResourceDetail } from "@/hooks";
 import { ResourceType } from "@/lib/resource-registry";
 import { Network, CircleDot, Server } from "lucide-react";
+import { LinkedResource } from "@/components/network";
 import { commands } from "@/lib/commands";
 import type { EndpointsInfo } from "@/generated/types";
 
@@ -66,9 +67,17 @@ export function EndpointsDetail() {
                                                         <CircleDot className="h-4 w-4 text-green-500" />
                                                         <span className="font-mono">{addr.ip}</span>
                                                     </div>
-                                                    <div className="text-sm text-muted-foreground">
-                                                        {addr.targetRef && `${addr.targetRef.kind}/${addr.targetRef.name}`}
-                                                        {addr.nodeName && ` @ ${addr.nodeName}`}
+                                                    <div className="text-sm text-muted-foreground flex items-center gap-1">
+                                                        {addr.targetRef && addr.targetRef.kind === "Pod" ? (
+                                                            <LinkedResource
+                                                                resourceType={ResourceType.Pod}
+                                                                name={addr.targetRef.name}
+                                                                namespace={addr.targetRef.namespace || endpoints?.namespace || ""}
+                                                            />
+                                                        ) : addr.targetRef ? (
+                                                            `${addr.targetRef.kind}/${addr.targetRef.name}`
+                                                        ) : null}
+                                                        {addr.nodeName && <span>@ {addr.nodeName}</span>}
                                                     </div>
                                                 </div>
                                             ))}
@@ -86,8 +95,16 @@ export function EndpointsDetail() {
                                                         <CircleDot className="h-4 w-4 text-yellow-500" />
                                                         <span className="font-mono">{addr.ip}</span>
                                                     </div>
-                                                    <div className="text-sm text-muted-foreground">
-                                                        {addr.targetRef && `${addr.targetRef.kind}/${addr.targetRef.name}`}
+                                                    <div className="text-sm text-muted-foreground flex items-center gap-1">
+                                                        {addr.targetRef && addr.targetRef.kind === "Pod" ? (
+                                                            <LinkedResource
+                                                                resourceType={ResourceType.Pod}
+                                                                name={addr.targetRef.name}
+                                                                namespace={addr.targetRef.namespace || endpoints?.namespace || ""}
+                                                            />
+                                                        ) : addr.targetRef ? (
+                                                            `${addr.targetRef.kind}/${addr.targetRef.name}`
+                                                        ) : null}
                                                     </div>
                                                 </div>
                                             ))}
@@ -161,6 +178,11 @@ export function EndpointsDetail() {
             namespace={endpoints?.namespace || namespace}
             badges={
                 <>
+                    <LinkedResource
+                        resourceType={ResourceType.Service}
+                        name={endpoints?.name || name || ""}
+                        namespace={endpoints?.namespace || namespace || ""}
+                    />
                     {totalReady > 0 && (
                         <Badge className="bg-green-500/10 text-green-500 border-green-500/20">
                             {totalReady} ready

--- a/src/pages/IngressDetail.tsx
+++ b/src/pages/IngressDetail.tsx
@@ -12,7 +12,7 @@ import { REFRESH_INTERVALS } from "@/lib/refresh";
 import { Globe, ExternalLink, Shield, Network, Copy, Link2, Tag, FileText, ArrowRight, AlertTriangle, Info, Clock, Calendar } from "lucide-react";
 import { RealtimeAge } from "@/components/ui/realtime";
 import { commands } from "@/lib/commands";
-import type { IngressInfo, IngressRule, IngressTlsConfig, EventInfo, EventFilters } from "@/generated/types";
+import type { IngressInfo, IngressRule, EventInfo, EventFilters } from "@/generated/types";
 import { normalizeTauriError } from "@/lib/error-utils";
 import { useQuery } from "@tanstack/react-query";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
@@ -29,25 +29,27 @@ interface AccessUrl {
     backendPort: string;
     resourceBackend: string | null;
     isHttps: boolean;
+    tlsReason: "explicit" | "catch-all" | null;
 }
 
-function generateAccessUrls(rules: IngressRule[], tlsHosts: string[], tlsConfigs: IngressTlsConfig[]): AccessUrl[] {
+function generateAccessUrls(rules: IngressRule[], tlsHosts: string[], hasCatchAllTls: boolean): AccessUrl[] {
     const urls: AccessUrl[] = [];
-
-    // Check if there's a catch-all TLS config (empty hosts array means all hosts)
-    const hasCatchAllTls = tlsConfigs.some(config => config.hosts.length === 0);
 
     for (const rule of rules) {
         const isWildcard = rule.host === "*" || !rule.host;
         const displayHost = isWildcard ? "All hosts" : rule.host;
         const actualHost = isWildcard ? "" : rule.host;
-        
+
         // TLS detection: host is in tlsHosts, or there's a catch-all TLS config
         const isHttps = tlsHosts.includes(rule.host) || hasCatchAllTls;
         const scheme = isHttps ? "https" : "http";
+        const tlsReason = tlsHosts.includes(rule.host)
+            ? "explicit"
+            : hasCatchAllTls
+                ? "catch-all"
+                : null;
 
         for (const path of rule.paths) {
-            // For wildcard hosts, show path only; otherwise show full URL
             const fullUrl = actualHost ? `${scheme}://${actualHost}${path.path}` : `${scheme}://<host>${path.path}`;
             urls.push({
                 fullUrl,
@@ -59,6 +61,7 @@ function generateAccessUrls(rules: IngressRule[], tlsHosts: string[], tlsConfigs
                 backendPort: path.backendPort,
                 resourceBackend: path.resourceBackend,
                 isHttps,
+                tlsReason,
             });
         }
     }
@@ -104,7 +107,8 @@ export function IngressDetail() {
     const loadBalancerIps = ingress?.loadBalancerIps ?? [];
     const labels = ingress?.labels ?? {};
     const annotations = ingress?.annotations ?? {};
-    const accessUrls = generateAccessUrls(rules, tlsHosts, tlsConfigs);
+    const hasCatchAllTls = ingress?.hasCatchAllTls ?? false;
+    const accessUrls = generateAccessUrls(rules, tlsHosts, hasCatchAllTls);
 
     // Fetch events for this ingress
     const { data: events = [], isLoading: eventsLoading } = useQuery({
@@ -231,9 +235,8 @@ export function IngressDetail() {
                             {rules.map((rule, idx) => {
                                 const isWildcard = rule.host === "*" || !rule.host;
                                 const displayHost = isWildcard ? "All hosts" : rule.host;
-                                const hasCatchAllTls = tlsConfigs.some(config => config.hosts.length === 0);
                                 const hasTls = tlsHosts.includes(rule.host) || hasCatchAllTls;
-                                
+
                                 return (
                                     <div key={idx} className="rounded-lg border p-4">
                                         <div className="flex items-center gap-2 mb-3">
@@ -285,40 +288,64 @@ export function IngressDetail() {
             content: (
                 <Card>
                     <CardHeader>
-                        <CardTitle>TLS Configuration</CardTitle>
+                        <CardTitle className="flex items-center gap-2">
+                            <Shield className="h-5 w-5" />
+                            TLS Configuration
+                        </CardTitle>
                     </CardHeader>
                     <CardContent>
                         {tlsConfigs.length > 0 ? (
                             <div className="space-y-4">
-                                {tlsConfigs.map((config: IngressTlsConfig, idx: number) => (
-                                    <div
-                                        key={idx}
-                                        className="rounded-lg border p-4"
-                                    >
-                                        <div className="flex items-center gap-2 mb-3">
-                                            <Shield className="h-4 w-4 text-green-500" />
-                                            <span className="font-medium">
-                                                Secret: {config.secretName || "(auto-generated)"}
-                                            </span>
-                                        </div>
-                                        <div className="space-y-2">
-                                            <h4 className="text-sm text-muted-foreground">Protected Hosts:</h4>
-                                            <div className="flex flex-wrap gap-2">
-                                                {config.hosts.length > 0 ? (
-                                                    config.hosts.map((host, hostIdx) => (
-                                                        <Badge key={hostIdx} variant="outline" className="font-mono">
-                                                            {host || "All hosts"}
-                                                        </Badge>
-                                                    ))
-                                                ) : (
-                                                    <Badge variant="outline" className="font-mono">
-                                                        All hosts
-                                                    </Badge>
-                                                )}
-                                            </div>
+                                {/* Explicit TLS Hosts */}
+                                {tlsConfigs.filter(c => !c.isCatchAll).length > 0 && (
+                                    <div>
+                                        <h4 className="text-sm font-medium mb-2">Explicit TLS Hosts</h4>
+                                        <div className="space-y-3">
+                                            {tlsConfigs.filter(c => !c.isCatchAll).map((config, idx) => (
+                                                <div key={idx} className="rounded-lg border p-4">
+                                                    <div className="flex items-center gap-2 mb-3">
+                                                        <Shield className="h-4 w-4 text-green-500" />
+                                                        <span className="font-medium">
+                                                            Secret: {config.secretName || "(auto-generated)"}
+                                                        </span>
+                                                    </div>
+                                                    <div className="flex flex-wrap gap-2">
+                                                        {config.hosts.map((host, hostIdx) => (
+                                                            <Badge key={hostIdx} variant="outline" className="font-mono">
+                                                                {host}
+                                                            </Badge>
+                                                        ))}
+                                                    </div>
+                                                </div>
+                                            ))}
                                         </div>
                                     </div>
-                                ))}
+                                )}
+
+                                {/* Catch-all TLS */}
+                                {tlsConfigs.filter(c => c.isCatchAll).length > 0 && (
+                                    <div>
+                                        <h4 className="text-sm font-medium mb-2 flex items-center gap-2">
+                                            <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                                            Catch-all TLS
+                                        </h4>
+                                        <div className="space-y-3">
+                                            {tlsConfigs.filter(c => c.isCatchAll).map((config, idx) => (
+                                                <div key={idx} className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4">
+                                                    <div className="flex items-center gap-2 mb-2">
+                                                        <Shield className="h-4 w-4 text-yellow-500" />
+                                                        <span className="font-medium">
+                                                            Secret: {config.secretName || "(auto-generated)"}
+                                                        </span>
+                                                    </div>
+                                                    <p className="text-sm text-muted-foreground">
+                                                        Applies to all hosts not explicitly listed above
+                                                    </p>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                         ) : (
                             <p className="text-muted-foreground">No TLS configured</p>

--- a/src/pages/IngressDetail.tsx
+++ b/src/pages/IngressDetail.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { YamlTabContent } from "@/components/resources/YamlTabContent";
 import {
     ResourceDetailLayout,
@@ -112,7 +113,7 @@ export function IngressDetail() {
     const accessUrls = generateAccessUrls(rules, tlsHosts, hasCatchAllTls);
 
     // Fetch events for this ingress
-    const { data: events = [], isLoading: eventsLoading } = useQuery({
+    const { data: events = [], isLoading: eventsLoading, error: eventsError, refetch: refetchEvents } = useQuery({
         queryKey: ["ingress-events", namespace, name],
         queryFn: async () => {
             const filters: EventFilters = {
@@ -442,8 +443,21 @@ export function IngressDetail() {
                         </CardTitle>
                     </CardHeader>
                     <CardContent>
-                        {eventsLoading ? (
-                            <p className="text-muted-foreground">Loading events...</p>
+                        {eventsError ? (
+                            <div className="flex items-center justify-between p-3 rounded-lg border border-yellow-500/30 bg-yellow-500/5">
+                                <div className="flex items-center gap-2">
+                                    <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                                    <span className="text-sm">Failed to load events</span>
+                                </div>
+                                <Button size="sm" variant="outline" onClick={() => refetchEvents()}>
+                                    Retry
+                                </Button>
+                            </div>
+                        ) : eventsLoading ? (
+                            <div className="space-y-2">
+                                <Skeleton className="h-16 w-full" />
+                                <Skeleton className="h-16 w-full" />
+                            </div>
                         ) : events.length > 0 ? (
                             <div className="space-y-3">
                                 {events.map((event: EventInfo) => {

--- a/src/pages/IngressDetail.tsx
+++ b/src/pages/IngressDetail.tsx
@@ -6,6 +6,7 @@ import {
     ResourceDetailLayout,
     InfoCard,
 } from "@/components/resources/ResourceDetailLayout";
+import { LinkedResource } from "@/components/network";
 import { useResourceDetail } from "@/hooks";
 import { ResourceType } from "@/lib/resource-registry";
 import { REFRESH_INTERVALS } from "@/lib/refresh";
@@ -168,12 +169,18 @@ export function IngressDetail() {
                                                 </div>
                                                 <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
                                                 <span className="text-sm text-muted-foreground shrink-0">
-                                                    {url.resourceBackend 
-                                                        ? `Resource: ${url.resourceBackend}`
-                                                        : url.backendService 
-                                                            ? `${url.backendService}:${url.backendPort}`
-                                                            : "No backend"
-                                                    }
+                                                    {url.resourceBackend ? (
+                                                        `Resource: ${url.resourceBackend}`
+                                                    ) : url.backendService ? (
+                                                        <LinkedResource
+                                                            resourceType={ResourceType.Service}
+                                                            name={url.backendService}
+                                                            namespace={ingress?.namespace || ""}
+                                                            port={url.backendPort}
+                                                        />
+                                                    ) : (
+                                                        "No backend"
+                                                    )}
                                                 </span>
                                             </div>
                                             <div className="flex items-center gap-2 ml-3">
@@ -260,13 +267,19 @@ export function IngressDetail() {
                                                             {path.pathType}
                                                         </Badge>
                                                     </div>
-                                                    <div className="text-sm text-muted-foreground">
-                                                        → {path.resourceBackend 
-                                                            ? `Resource: ${path.resourceBackend}`
-                                                            : path.backendService 
-                                                                ? `${path.backendService}:${path.backendPort}`
-                                                                : "No backend"
-                                                        }
+                                                    <div className="text-sm text-muted-foreground flex items-center gap-1">
+                                                        → {path.resourceBackend ? (
+                                                            `Resource: ${path.resourceBackend}`
+                                                        ) : path.backendService ? (
+                                                            <LinkedResource
+                                                                resourceType={ResourceType.Service}
+                                                                name={path.backendService}
+                                                                namespace={ingress?.namespace || ""}
+                                                                port={path.backendPort}
+                                                            />
+                                                        ) : (
+                                                            "No backend"
+                                                        )}
                                                     </div>
                                                 </div>
                                             ))}

--- a/src/pages/ServiceDetail.tsx
+++ b/src/pages/ServiceDetail.tsx
@@ -1,5 +1,4 @@
 import { Badge } from "@/components/ui/badge";
-import { StatusBadge } from "@/components/ui/status-badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { YamlTabContent } from "@/components/resources/YamlTabContent";
 import { LabelsDisplay } from "@/components/resources/LabelsDisplay";
@@ -8,6 +7,7 @@ import {
   InfoCard,
   ResourceDetailLayout,
 } from "@/components/resources/ResourceDetailLayout";
+import { ServiceAccessInfo, MatchingPods, ServiceTypeBadge } from "@/components/network";
 import { useResourceDetail } from "@/hooks";
 import { ResourceType } from "@/lib/resource-registry";
 import { Network, Globe, Server } from "lucide-react";
@@ -31,7 +31,7 @@ export function ServiceDetail() {
     resourceKind: ResourceType.Service,
     fetchResource: (name, ns) => commands.getService(name, ns),
     deleteResource: (name, ns) => commands.deleteService(name, ns),
-    defaultTab: "ports",
+    defaultTab: "access",
   });
 
   if (!service && !isLoading && !error) {
@@ -45,6 +45,11 @@ export function ServiceDetail() {
   const annotations = service?.annotations ?? {};
 
   const tabs = [
+    {
+      id: "access",
+      label: "Access",
+      content: service ? <ServiceAccessInfo service={service} /> : null,
+    },
     {
       id: "ports",
       label: "Ports",
@@ -94,6 +99,16 @@ export function ServiceDetail() {
       ),
     },
     {
+      id: "pods",
+      label: "Pods",
+      content: service ? (
+        <MatchingPods
+          namespace={service.namespace}
+          selector={service.selector}
+        />
+      ) : null,
+    },
+    {
       id: "labels",
       label: "Labels",
       content: (
@@ -127,7 +142,7 @@ export function ServiceDetail() {
       resourceKind={ResourceType.Service}
       title={service?.name || ""}
       namespace={service?.namespace}
-      statusBadge={service && <StatusBadge status={service.type} />}
+      statusBadge={service?.type && <ServiceTypeBadge type={service.type} />}
       icon={<Network className="h-8 w-8 text-muted-foreground" />}
       onBack={goBack}
       tabs={tabs}


### PR DESCRIPTION
## Summary

- **Fixed TLS display**: Added `hasCatchAllTls` flag to correctly show catch-all TLS configurations (e.g., "TLS (all)" or "TLS (2 + all)")
- **Improved port readability**: Changed confusing `8080:30000>8000/TCP` format to clear `port→targetPort (nodePort)` with tooltips
- **Added resource linking**: Service→Pods via new `MatchingPods` component, Ingress→Service clickable links, Endpoints→Service/Pod navigation
- **Better error handling**: Events tab now shows loading skeletons and error state with retry button
- **New reusable components**: `TlsBadge`, `ServiceTypeBadge`, `PortsDisplay`, `ServiceAccessInfo`, `MatchingPods`, `LinkedResource`

## Test Plan

- [x] Verify TLS badge shows correctly for ingresses with explicit hosts only
- [x] Verify TLS badge shows "TLS (all)" for catch-all TLS configurations
- [x] Verify port display in ServiceList shows `port→targetPort` format
- [x] Verify ServiceDetail "Access" tab shows correct URLs for different service types
- [x] Verify ServiceDetail "Pods" tab shows matching pods
- [x] Verify clicking service links in IngressDetail navigates to ServiceDetail
- [x] Verify Events tab shows retry button on error

🤖 Generated with [Claude Code](https://claude.com/claude-code)