### PR TITLE
docs: record which release files the AUR -bin package depends on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # The AUR package rubick-kubernetes-bin
+          # (https://aur.archlinux.org/packages/rubick-kubernetes-bin)
+          # downloads releases/download/v${pkgver}/Rubick_${pkgver}_amd64.deb
+          # from every release. The .deb asset name is a public contract —
+          # renaming the product, the target, or the bundle format breaks
+          # the package.
           - name: linux-x64
             os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu

--- a/src-tauri/icons/README.md
+++ b/src-tauri/icons/README.md
@@ -1,0 +1,8 @@
+# Icons
+
+These files are consumed outside this repo: the AUR package
+[rubick-kubernetes-bin](https://aur.archlinux.org/packages/rubick-kubernetes-bin)
+fetches `256x256.png`, `128x128.png`, `64x64.png`, `32x32.png`, and
+`icon.svg` by raw GitHub URL (pinned to a commit, bumped by the package
+maintainer on each release). Renaming or moving them breaks the next
+package update — keep the paths stable.


### PR DESCRIPTION
## What's wrong now

Since #70, the AUR package [rubick-kubernetes-bin](https://aur.archlinux.org/packages/rubick-kubernetes-bin) (maintained by @Prototik, outside this repo) hardcodes two things from us: the asset URL `releases/download/v${pkgver}/Rubick_${pkgver}_amd64.deb`, and raw pinned-commit URLs to five files under `src-tauri/icons/`. Nothing in the repo says so — a product rename, a bundle-target change, or an icon shuffle would pass review here and break the package on its next update.

## What changes

Docs only: a comment on the `linux-x64` matrix entry in `release.yml` naming the asset contract, and a new `src-tauri/icons/README.md` listing the externally fetched icons.

## How to verify

Compare both notes against the [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=rubick-kubernetes-bin): `source_x86_64` is the deb URL, `source` lists the icons.

## Risk / rollback

None — a YAML comment and a README. The bundler references icons by explicit paths, so the new file in that directory is inert.