### PR TITLE
test(release): make the AUR asset contract fail in CI, not in pacman

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Every name you can go to is a link, with the gestures you expect: click to peek,
 
 ## Install
 
-Grab the build for your platform from [Releases](https://github.com/Dudude-bit/rubick/releases/latest). There is no Homebrew or winget package yet.
+Grab the build for your platform from [Releases](https://github.com/Dudude-bit/rubick/releases/latest). There is no Homebrew or winget package yet. On Arch there is [`rubick-kubernetes-bin`](https://aur.archlinux.org/packages/rubick-kubernetes-bin) in the AUR — packaged and updated by someone outside this project, from the same `.deb` published here.
 
 - **macOS** — signed with a Developer ID certificate and notarised by Apple, so it opens on a double-click.
 - **Windows** — not signed, so SmartScreen will warn on the first launch. **More info → Run anyway**.

--- a/src/release-assets.test.ts
+++ b/src/release-assets.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The names other people's packaging depends on.
+ *
+ * The AUR package rubick-kubernetes-bin fetches
+ * `Rubick_${pkgver}_amd64.deb` from every release, and five icons by raw
+ * GitHub URL. Both are recorded in prose — a comment in `release.yml` and
+ * `src-tauri/icons/README.md` — and prose sits where nobody renaming the
+ * product will pass: `productName` is in `tauri.conf.json`, which cannot
+ * hold a comment at all. So the contract is a test instead, and it fails
+ * in the pull request rather than in somebody's next `pacman -Syu`.
+ *
+ * Breaking it on purpose is fine. Tell the package's maintainer, then
+ * change this test in the same commit that changes the name.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(__dirname, "..");
+const config = JSON.parse(
+  readFileSync(resolve(root, "src-tauri/tauri.conf.json"), "utf8")
+) as { productName: string; bundle: { targets: string[] } };
+
+describe("what the AUR package downloads", () => {
+  /**
+   * Would break if the product were renamed: the asset becomes
+   * `Something_4.3.0_amd64.deb` and the package's fetch 404s on the next
+   * release, with nothing in this repo having looked wrong.
+   */
+  it("still builds a .deb called Rubick", () => {
+    expect(config.productName).toBe("Rubick");
+    expect(config.bundle.targets).toContain("deb");
+  });
+
+  /**
+   * Would break if an icon were renamed or moved: the package pins a
+   * commit and bumps it per release, so the failure lands on the
+   * maintainer, one release later, far from whoever tidied the folder.
+   */
+  it("still keeps the five icons it fetches by raw URL", () => {
+    for (const icon of [
+      "256x256.png",
+      "128x128.png",
+      "64x64.png",
+      "32x32.png",
+      "icon.svg",
+    ]) {
+      expect(
+        existsSync(resolve(root, "src-tauri/icons", icon)),
+        `src-tauri/icons/${icon} is fetched by rubick-kubernetes-bin`
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to #73, which wrote down that `rubick-kubernetes-bin` fetches `Rubick_${pkgver}_amd64.deb` and five icons from every release.

## What is still wrong after #73

The contract is recorded in `release.yml` and `src-tauri/icons/README.md`. Neither is on the path of the person who would break it: `productName` lives in `src-tauri/tauri.conf.json`, which is JSON and cannot hold a comment at all. Rename the product there and everything in this repo stays green — the AUR package's fetch 404s one release later, on its maintainer.

## What changes

- `src/release-assets.test.ts` reads the config and the icon folder and fails with the reason. Checked by breaking it both ways:
  - `productName: "Rubik"` → `expected 'Rubik' to be 'Rubick'`
  - `icon.svg` moved away → `src-tauri/icons/icon.svg is fetched by rubick-kubernetes-bin: expected false to be true`
- README said there was no package anywhere. On Arch there is; it now says so, and says it is packaged outside this project.

Renaming on purpose stays cheap: tell the maintainer, change the test in the same commit.

## Verified

`bun run test` 1839 passed · `bunx tsc --noEmit` clean · `bun run lint` zero warnings.

## Not verified

I could not open the AUR listing to confirm what the package actually fetches — `aur.archlinux.org` and its RPC both answer with an Anubis challenge. The file names here come from #73.