### PR TITLE
feat(integrations): point at a Service the search cannot recognise

### DIFF
--- a/src/components/settings/ConnectIntegration.tsx
+++ b/src/components/settings/ConnectIntegration.tsx
@@ -40,6 +40,8 @@ import type {
   ProbeResult,
 } from "@/integrations";
 import { useT } from "@/i18n/useT";
+import { commands } from "@/lib/commands";
+import type { ServiceInfo } from "@/generated/types";
 
 export function ConnectIntegration({
   vendorId,
@@ -184,6 +186,10 @@ function ConnectForm({
                   service: picked.service,
                   remotePort: picked.remotePort,
                   localPort: picked.localPort,
+                  // Carried, so waking this forward tomorrow rebuilds the
+                  // same address — an API under /prometheus is not reachable
+                  // at the port alone.
+                  subpath: picked.subpath,
                   // Off until asked for: a forward is a socket on this
                   // machine and a connection into the cluster, and neither is
                   // started on somebody's behalf because they pressed a
@@ -331,7 +337,8 @@ function ConnectForm({
  * for the reader would be this app guessing which of their monitoring stacks
  * they meant.
  */
-function InCluster({
+/** Exported for its own test: the dialog around it needs a live cluster. */
+export function InCluster({
   hint,
   vendorName,
   onPicked,
@@ -414,7 +421,159 @@ function InCluster({
         );
       })}
 
+      <ByHand hint={hint} onPicked={onPicked} onFailed={setFailed} />
+
       {failed && <p className="text-[11px] text-err">{failed}</p>}
+    </div>
+  );
+}
+
+/**
+ * Point at a Service this app did not recognise.
+ *
+ * The search above matches a Service by the vendor's own name and label,
+ * which is right for the thing it names and useless for everything that
+ * merely speaks its API — a VictoriaMetrics is called `vmsingle`, wears no
+ * Prometheus label, listens on 8428 and answers the same queries (#71).
+ *
+ * So: any Service in the cluster, any of its ports, and the subpath the API
+ * sits under. Namespace, Service and port are chosen from what the cluster
+ * actually has rather than typed, because three of the four fields are facts
+ * this app already holds and a typo in them is a connection that fails with
+ * nothing to point at. Only the subpath is typed, because only the subpath is
+ * something the cluster cannot tell us.
+ */
+function ByHand({
+  hint,
+  onPicked,
+  onFailed,
+}: {
+  hint: InClusterHint;
+  onPicked: (forwarded: Forwarded) => void;
+  onFailed: (message: string | null) => void;
+}) {
+  const t = useT();
+  const [open, setOpen] = React.useState(false);
+  const [services, setServices] = React.useState<ServiceInfo[] | null>(null);
+  const [chosen, setChosen] = React.useState("");
+  const [port, setPort] = React.useState("");
+  const [subpath, setSubpath] = React.useState("");
+  const [busy, setBusy] = React.useState(false);
+
+  const service = services?.find(
+    (candidate) => `${candidate.namespace}/${candidate.name}` === chosen
+  );
+
+  const reveal = async () => {
+    setOpen(true);
+    onFailed(null);
+    if (services !== null) return;
+    try {
+      setServices(await commands.listServices(null));
+    } catch (error) {
+      onFailed(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const go = async () => {
+    if (!service) return;
+    setBusy(true);
+    onFailed(null);
+    try {
+      onPicked(await forward(service, [Number(port)], undefined, subpath));
+    } catch (error) {
+      onFailed(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => void reveal()}
+        className="self-start text-[11px] text-fg-fnt underline underline-offset-2 hover:text-fg"
+      >
+        {t("settings", "pointAtServiceYourself")}
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 rounded border border-hair p-2">
+      <p className="text-[11px] text-fg-fnt">
+        {t("settings", "pointAtServiceHint")}
+      </p>
+
+      <label className="flex flex-col gap-1 text-xs text-fg-mut">
+        {t("settings", "serviceLabel")}
+        <select
+          value={chosen}
+          onChange={(event) => {
+            setChosen(event.target.value);
+            setPort("");
+          }}
+          className="rounded-md border border-hair bg-canvas px-2 py-1 text-xs text-fg"
+        >
+          <option value="">{t("settings", "chooseService")}</option>
+          {(services ?? []).map((candidate) => (
+            <option
+              key={`${candidate.namespace}/${candidate.name}`}
+              value={`${candidate.namespace}/${candidate.name}`}
+            >
+              {candidate.namespace}/{candidate.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-fg-mut">
+        {t("settings", "portLabel")}
+        <select
+          value={port}
+          onChange={(event) => setPort(event.target.value)}
+          disabled={!service}
+          className="rounded-md border border-hair bg-canvas px-2 py-1 text-xs text-fg disabled:opacity-60"
+        >
+          <option value="">{t("settings", "choosePort")}</option>
+          {(service?.ports ?? []).map((exposed) => (
+            <option key={exposed.port} value={String(exposed.port)}>
+              {exposed.port}
+              {exposed.name ? ` · ${exposed.name}` : ""}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="flex flex-col gap-1">
+        {/* The hint sits outside the label: inside it, the accessible name of
+            the field becomes the whole paragraph. */}
+        <label htmlFor="integration-subpath" className="text-xs text-fg-mut">
+          {t("settings", "subpathLabel")}
+        </label>
+        <Input
+          id="integration-subpath"
+          value={subpath}
+          onChange={(event) => setSubpath(event.target.value)}
+          placeholder={hint.subpathExample ?? "/prometheus"}
+          className="h-7 font-mono text-xs"
+        />
+        <span className="text-[11px] text-fg-fnt">
+          {t("settings", "subpathHint")}
+        </span>
+      </div>
+
+      <Button
+        size="sm"
+        onClick={() => void go()}
+        disabled={!service || !port || busy}
+        className="self-start text-xs"
+      >
+        {busy
+          ? t("settings", "forwardingEllipsis")
+          : t("settings", "forwardIt")}
+      </Button>
     </div>
   );
 }

--- a/src/components/settings/InCluster.test.tsx
+++ b/src/components/settings/InCluster.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Pointing at a Service the search cannot recognise (#71).
+ *
+ * The search matches a Service by the vendor's own name and label, which is
+ * right for the thing it names and useless for anything that merely speaks
+ * its API: a VictoriaMetrics is called `vmsingle`, wears no Prometheus label,
+ * listens on 8428 and answers the same queries. Worse, its query API is not
+ * at the root — so an address that stops at the port tests green and then
+ * 404s on every query.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ServiceInfo } from "@/generated/types";
+
+const listServices = vi.fn();
+const listPods = vi.fn();
+const portForwardPod = vi.fn(async (..._args: unknown[]) => ({}));
+
+vi.mock("@/lib/commands", () => ({
+  commands: {
+    listServices: (filters: unknown) => listServices(filters),
+    listPods: (filters: unknown) => listPods(filters),
+    portForwardPod: (pod: unknown, namespace: unknown, config: unknown) =>
+      portForwardPod(pod, namespace, config),
+    listPortForwards: vi.fn(async () => []),
+    listPortForwardConfigs: vi.fn(async () => []),
+    stopPortForward: vi.fn(async () => undefined),
+  },
+}));
+
+const { InCluster } = await import("./ConnectIntegration");
+
+const vmsingle = {
+  name: "vmsingle-victoria-metrics-k8s-stack",
+  namespace: "monitoring",
+  uid: "u1",
+  type: "ClusterIP",
+  sessionAffinity: "None",
+  clusterIp: "10.0.0.9",
+  externalIps: [],
+  loadBalancerIps: [],
+  ports: [{ name: "http", port: 8428, targetPort: 8428, protocol: "TCP" }],
+  selector: { "app.kubernetes.io/name": "vmsingle" },
+  labels: { "app.kubernetes.io/name": "vmsingle" },
+  annotations: {},
+  createdAt: null,
+} as unknown as ServiceInfo;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listServices.mockResolvedValue([vmsingle]);
+  listPods.mockResolvedValue([
+    { name: "vmsingle-0", status: { phase: "Running", ready: true } },
+  ]);
+});
+
+const hint = { names: ["prometheus"], ports: [9090] };
+
+describe("pointing at a Service the search cannot find", () => {
+  it("is offered even before the search has been run", async () => {
+    render(
+      <InCluster hint={hint} vendorName="Prometheus" onPicked={vi.fn()} />
+    );
+    expect(
+      screen.getByRole("button", { name: "Point at a Service yourself" })
+    ).toBeInTheDocument();
+  });
+
+  /**
+   * The assertion the issue is about: the port is the one chosen rather than
+   * the vendor's 9090, and the address carries the subpath the API sits under.
+   */
+  it("forwards the chosen port and gives back an address with the subpath", async () => {
+    const user = userEvent.setup();
+    const picked = vi.fn();
+    render(<InCluster hint={hint} vendorName="Prometheus" onPicked={picked} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Point at a Service yourself" })
+    );
+    await waitFor(() => expect(listServices).toHaveBeenCalled());
+
+    await user.selectOptions(
+      screen.getByLabelText("Service"),
+      "monitoring/vmsingle-victoria-metrics-k8s-stack"
+    );
+    await user.selectOptions(screen.getByLabelText("Port"), "8428");
+    await user.type(screen.getByLabelText("Subpath"), "/prometheus");
+    await user.click(screen.getByRole("button", { name: "Forward it" }));
+
+    await waitFor(() => expect(picked).toHaveBeenCalled());
+    const forwarded = picked.mock.calls[0][0];
+    expect(forwarded.remotePort).toBe(8428);
+    expect(forwarded.subpath).toBe("/prometheus");
+    expect(forwarded.url).toBe(
+      `http://localhost:${forwarded.localPort}/prometheus`
+    );
+  });
+});

--- a/src/hooks/useClusterForwards.ts
+++ b/src/hooks/useClusterForwards.ts
@@ -16,7 +16,12 @@ import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { commands } from "@/lib/commands";
-import { connectOf, forward, type Forwarded } from "@/integrations";
+import {
+  connectOf,
+  forward,
+  normalisedSubpath,
+  type Forwarded,
+} from "@/integrations";
 import type { ServiceInfo } from "@/generated/types";
 import {
   forwardsFor,
@@ -92,10 +97,12 @@ export async function wake(
     for (const id of await orphansOf(preference, preference.localPort)) {
       await commands.stopPortForward(id).catch(() => undefined);
     }
+    const subpath = normalisedSubpath(preference.subpath);
     return {
       ...preference,
       pod: "",
-      url: `http://localhost:${preference.localPort}`,
+      subpath,
+      url: `http://localhost:${preference.localPort}${subpath}`,
     };
   }
 
@@ -114,7 +121,8 @@ export async function wake(
   const found = await forward(
     service,
     [preference.remotePort],
-    preference.localPort
+    preference.localPort,
+    preference.subpath
   );
   if (found.localPort !== preference.localPort) {
     await moveAddress(vendorId, preference, found.localPort);
@@ -145,7 +153,7 @@ async function moveAddress(
   const saved = await connect.read().catch(() => null);
   await connect
     .save({
-      url: `http://localhost:${localPort}`,
+      url: `http://localhost:${localPort}${normalisedSubpath(preference.subpath)}`,
       authType: saved?.authType ?? "none",
       // Empty, never null: the backend keeps the stored one when nothing is
       // sent, and the token has never been in this window to send back.

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -1169,6 +1169,17 @@ export const en = {
     problemCount: { one: "{n} problem", other: "{n} problems" },
   },
   settings: {
+    pointAtServiceYourself: "Point at a Service yourself",
+    pointAtServiceHint:
+      "For anything that speaks this API without carrying the vendor's name — a VictoriaMetrics is called vmsingle and answers the same queries.",
+    serviceLabel: "Service",
+    chooseService: "Choose a Service",
+    portLabel: "Port",
+    choosePort: "Choose a port",
+    subpathLabel: "Subpath",
+    subpathHint:
+      "What comes after the port, when the API is not at the root. VMSingle serves it under /prometheus; a VMCluster's vmselect under /select/0/prometheus. Leave empty for a plain Prometheus.",
+    forwardIt: "Forward it",
     authRunsPlugin: "Runs {plugin} for a token.",
     aCredentialPlugin: "a credential plugin",
     authClientCertFrom:

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -1183,6 +1183,17 @@ export const ru: Catalogue = {
     },
   },
   settings: {
+    pointAtServiceYourself: "Указать Service вручную",
+    pointAtServiceHint:
+      "Для всего, что говорит на этом API, но не носит имя вендора: VictoriaMetrics называется vmsingle и отвечает на те же запросы.",
+    serviceLabel: "Service",
+    chooseService: "Выберите Service",
+    portLabel: "Порт",
+    choosePort: "Выберите порт",
+    subpathLabel: "Подпуть",
+    subpathHint:
+      "То, что идёт после порта, когда API не в корне. VMSingle отдаёт его под /prometheus, vmselect у VMCluster — под /select/0/prometheus. Для обычного Prometheus оставьте пустым.",
+    forwardIt: "Пробросить",
     authRunsPlugin: "Запускает {plugin} за токеном.",
     aCredentialPlugin: "плагин учётных данных",
     authClientCertFrom:

--- a/src/integrations/forwarded.test.ts
+++ b/src/integrations/forwarded.test.ts
@@ -29,6 +29,7 @@ import {
   podFor,
   portOf,
   reestablish,
+  normalisedSubpath,
 } from "./forwarded";
 import type { ServiceInfo } from "@/generated/types";
 
@@ -182,6 +183,7 @@ describe("keeping the forward alive across a rollout", () => {
           remotePort: 9090,
           localPort: 20000,
           pod: "prom-old",
+          subpath: "",
           url: "http://localhost:20000",
         },
         service("prom", "mon", [9090])
@@ -348,5 +350,91 @@ describe("keeping the address a connection was saved under", () => {
     );
     const found = await forward(svc(), [9090], 20000);
     expect(found.localPort).not.toBe(20000);
+  });
+});
+
+describe("an API that does not sit at the root", () => {
+  /**
+   * Why this exists at all (#71). Prometheus answers `/api/v1/query` straight
+   * off the host, so a forward's address could stop at the port. A
+   * VictoriaMetrics does not: VMSingle serves the same API under
+   * `/prometheus`, and a VMCluster's vmselect under `/select/<tenant>/…`.
+   * The app cannot read which from the Service, so it is carried.
+   */
+  it("puts the subpath after the port, where the query path is appended", () => {
+    expect(normalisedSubpath("/prometheus")).toBe("/prometheus");
+  });
+
+  it("takes one without the leading slash, because people type it that way", () => {
+    expect(normalisedSubpath("prometheus")).toBe("/prometheus");
+    expect(normalisedSubpath("  select/0/prometheus  ")).toBe(
+      "/select/0/prometheus"
+    );
+  });
+
+  /**
+   * A trailing slash would make the address `…/prometheus//api/v1/query`.
+   * Some servers forgive that and some answer 404; none of them should have to.
+   */
+  it("drops a trailing slash rather than doubling it against the query path", () => {
+    expect(normalisedSubpath("/prometheus/")).toBe("/prometheus");
+    expect(normalisedSubpath("/prometheus///")).toBe("/prometheus");
+  });
+
+  it("is empty for an API at the root, and for nothing at all", () => {
+    expect(normalisedSubpath("")).toBe("");
+    expect(normalisedSubpath("   ")).toBe("");
+    expect(normalisedSubpath(undefined)).toBe("");
+    expect(normalisedSubpath("/")).toBe("");
+  });
+});
+
+describe("forwarding to something that only speaks the API", () => {
+  beforeEach(() => {
+    vi.mocked(commands.listPods).mockResolvedValue([pod("vmsingle-0", true)]);
+    vi.mocked(commands.listPortForwards).mockResolvedValue([]);
+  });
+
+  /**
+   * The whole of #71 in one assertion. A VictoriaMetrics is not called
+   * prometheus, wears no prometheus label and does not listen on 9090 — the
+   * search cannot find it — and its query API is not at the root, so the
+   * address the forward hands back has to carry the subpath or every query
+   * 404s against a connection that tested green.
+   */
+  it("builds the address with the subpath, not just the port", async () => {
+    const found = await forward(
+      service("vmsingle-victoria-metrics-k8s-stack", "monitoring", [8428]),
+      [8428],
+      undefined,
+      "/prometheus"
+    );
+    expect(found.url).toBe(`http://localhost:${found.localPort}/prometheus`);
+    expect(found.subpath).toBe("/prometheus");
+  });
+
+  /** A plain Prometheus is unchanged: no subpath, no trailing anything. */
+  it("leaves an API at the root exactly where it was", async () => {
+    const found = await forward(service("prom", "mon", [9090]), [9090]);
+    expect(found.url).toBe(`http://localhost:${found.localPort}`);
+    expect(found.subpath).toBe("");
+  });
+
+  /**
+   * The port comes from the form, not from the vendor's guess: 8428 is not in
+   * Prometheus's list, and picking a Service by hand is exactly the case
+   * where the app has no opinion about which port is the right one.
+   */
+  it("forwards the port it was given rather than one it recognises", async () => {
+    const found = await forward(
+      service("vmselect", "monitoring", [8481, 8482]),
+      [8481],
+      undefined,
+      "select/0/prometheus"
+    );
+    expect(found.remotePort).toBe(8481);
+    expect(found.url).toBe(
+      `http://localhost:${found.localPort}/select/0/prometheus`
+    );
   });
 });

--- a/src/integrations/forwarded.ts
+++ b/src/integrations/forwarded.ts
@@ -38,6 +38,8 @@ export interface Forwarded {
   localPort: number;
   /** The pod it resolved to this time. Never durable — see the module note. */
   pod: string;
+  /** Empty for an API at the root — see {@link normalisedSubpath}. */
+  subpath: string;
   url: string;
 }
 
@@ -134,6 +136,21 @@ export async function podFor(service: ServiceInfo): Promise<string | null> {
  * explicitly *not* the answer to a pod that has gone for good, which is what
  * {@link reestablish} is for.
  */
+/**
+ * The part of the address after the port, when the API does not sit at the root.
+ *
+ * Prometheus answers `/api/v1/query` straight off the host; VictoriaMetrics
+ * does not — VMSingle serves the same API under `/prometheus`, and a
+ * VMCluster's vmselect under `/select/<tenant>/prometheus`. The app cannot
+ * work out which from the Service, so it is asked for and carried with the
+ * forward, and everything downstream concatenates as it always did.
+ */
+export function normalisedSubpath(subpath: string | undefined): string {
+  const trimmed = (subpath ?? "").trim().replace(/\/+$/, "");
+  if (!trimmed) return "";
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
 export async function forward(
   service: ServiceInfo,
   preferredPorts: number[],
@@ -142,7 +159,8 @@ export async function forward(
    * address is already made of. Taken, a free one is chosen instead and the
    * caller is expected to move the address with it.
    */
-  keepLocal?: number
+  keepLocal?: number,
+  subpath?: string
 ): Promise<Forwarded> {
   const remotePort = portOf(service, preferredPorts);
   if (remotePort === null) {
@@ -185,7 +203,8 @@ export async function forward(
     remotePort,
     localPort,
     pod,
-    url: `http://localhost:${localPort}`,
+    subpath: normalisedSubpath(subpath),
+    url: `http://localhost:${localPort}${normalisedSubpath(subpath)}`,
   };
 }
 
@@ -249,6 +268,12 @@ export interface InClusterHint {
    * feature exists to stop somebody hitting.
    */
   avoid?: string[];
+  /**
+   * What a subpath looks like for this vendor, shown as the field's
+   * placeholder. Prometheus itself needs none; the things that speak its API
+   * do, and the example is the fastest way to say which shape is wanted.
+   */
+  subpathExample?: string;
 }
 
 export interface Candidate {

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -1090,6 +1090,7 @@ export {
   type Candidate,
   type Forwarded,
   type InClusterHint,
+  normalisedSubpath,
 } from "./forwarded";
 import { useT } from "@/i18n/useT";
 

--- a/src/integrations/prometheus/index.ts
+++ b/src/integrations/prometheus/index.ts
@@ -60,6 +60,7 @@ export default defineVendor({
     inCluster: {
       names: ["prometheus", "thanos-query", "thanos-querier"],
       ports: [9090, 10902],
+      subpathExample: "/prometheus",
       prefer: ["thanos-query", "operated", "server"],
       avoid: [
         "alertmanager",

--- a/src/stores/clusterForwardStore.ts
+++ b/src/stores/clusterForwardStore.ts
@@ -34,6 +34,12 @@ export interface ForwardPreference {
   /** What the connection's `http://localhost:<port>` address is made of. */
   localPort: number;
   /**
+   * What follows the port, for an API that does not sit at the root — a
+   * VictoriaMetrics under `/prometheus`. Absent on everything saved before
+   * this existed, which is the same as empty.
+   */
+  subpath?: string;
+  /**
    * Bring it up when this cluster is opened.
    *
    * Off by default and asked for explicitly, because a forward is a listening


### PR DESCRIPTION
Closes #71.

## What it does

"Find Prometheus in this cluster" matches a Service by the vendor's own name and label. That is right for the thing it names and useless for anything that merely speaks its API: a VictoriaMetrics is called `vmsingle`, wears no Prometheus label, listens on 8428, and answers the same queries.

The dialog now offers a second way in — **Point at a Service yourself**:

- **Service** — any Service in the cluster, chosen from a list
- **Port** — any port that Service exposes
- **Subpath** — what comes after the port, typed

Namespace, Service and port are chosen rather than typed: three of the four are facts the app already holds, and a typo in them is a connection that fails with nothing to point at. Only the subpath is typed, because only the subpath is something the cluster cannot tell us.

## Why not just teach the search about VictoriaMetrics

@syorito-hatsuki said why in the issue, and it is the right reason: the query API is not at the root, and where it sits depends on which VictoriaMetrics it is — VMSingle serves it under `/prometheus`, a VMCluster's vmselect under `/select/<tenant>/prometheus`. Nothing on the Service says which. A discovery that finds the Service and then builds the wrong address is worse than no discovery, because it tests green and 404s on every query.

## Details worth knowing

- The subpath is carried on the forward **and saved with it**, so waking the connection tomorrow rebuilds the same address.
- `normalisedSubpath` accepts it with or without the leading slash and drops a trailing one — `…/prometheus/` against `/api/v1/query` is a double slash some servers forgive and some answer 404 to.
- **A direct address already worked and is unchanged.** The backend concatenates the query path onto whatever was configured, so `http://host:8428/prometheus` has always reached a VMSingle. This PR is about the in-cluster path.

## Verification

`bun run test` 1889 passed · `tsc` clean · `lint` zero warnings · `build` clean.

New tests cover the subpath normalisation, forwarding the chosen port rather than a recognised one, and the form end to end. Each was checked to discriminate — reverting the change turns it red.

Not seen in the running app: the connect dialog needs a live cluster, so the form is covered by a component test instead.
