### PR TITLE
Ship an AppImage

### DIFF
--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -54,7 +54,11 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
+        # librsvg2-dev and libgtk-3-bin are the AppImage's: linuxdeploy's gtk
+        # plugin reads librsvg-2.0.pc through pkg-config and exits 1 without
+        # it, and calls gtk-query-immodules-3.0 for the input modules.
         sudo apt-get install -y \
           build-essential curl git pkg-config \
           libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
-          libsoup-3.0-dev libssl-dev ca-certificates
+          libsoup-3.0-dev libssl-dev ca-certificates \
+          librsvg2-dev libgtk-3-bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,12 @@ jobs:
       - name: Build (cargo tauri)
         # Skip updater-artifact signing in PR validation — release.yml has the secrets.
         # Frontend is built automatically by `cargo tauri build` via beforeBuildCommand.
+        env:
+          # linuxdeploy, which bundles the AppImage, is an AppImage itself and
+          # mounts itself to run — needing FUSE 2 and /dev/fuse, neither of
+          # which ubuntu-24.04 has. Extracting instead needs neither. Harmless
+          # on macOS and Windows, which never read it.
+          APPIMAGE_EXTRACT_AND_RUN: 1
         run: cargo tauri build --target ${{ matrix.target }} --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       - name: Collect artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,10 @@ jobs:
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f  # action-v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # linuxdeploy, which bundles the AppImage, is an AppImage itself and
+          # mounts itself to run — needing FUSE 2 and /dev/fuse, neither of
+          # which ubuntu-24.04 has. Extracting instead needs neither.
+          APPIMAGE_EXTRACT_AND_RUN: 1
           # Updater signing (minisign). Unrelated to Apple code signing —
           # this is what proves an update payload came from us; Gatekeeper
           # never sees it.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
     "publisher": "Rubick Team",
     "homepage": "https://github.com/Dudude-bit/rubick",
     "createUpdaterArtifacts": true,
-    "targets": ["deb", "rpm", "app", "dmg", "nsis", "msi"],
+    "targets": ["deb", "rpm", "appimage", "app", "dmg", "nsis", "msi"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
deb and rpm leave everyone else with nothing to install.

Two blockers, neither visible in the build log — tauri swallows linuxdeploy's output and prints `failed to run linuxdeploy` on its own. Building with `--verbose` on a scratch branch is what surfaced them:

- linuxdeploy is itself an AppImage and mounts itself to run, which needs FUSE 2 and `/dev/fuse`; ubuntu-24.04 has neither. `APPIMAGE_EXTRACT_AND_RUN` makes it extract instead.
- Its gtk plugin reads `librsvg-2.0.pc` through pkg-config and exits 1 without it.

Already verified on the runner at `42e7622`: linux-x64 green, and the artifact contains `Rubick_4.6.0_amd64.AppImage` — ELF with the type-2 AppImage magic — beside the deb and rpm. This PR is the same change with the diagnostic `--verbose` removed.