### PR TITLE
Never delete a pod an eviction refused

### DIFF
--- a/src-tauri/src/commands/nodes.rs
+++ b/src-tauri/src/commands/nodes.rs
@@ -94,16 +94,188 @@ pub async fn uncordon_node(name: String, state: State<'_, AppState>) -> Result<(
     Ok(())
 }
 
-/// Drain a node (evict all pods)
+/// Why a pod is still on the node when the drain stops.
+///
+/// A code rather than a sentence: the reader's language is chosen in the
+/// webview, and a refusal phrased here would arrive in whatever language
+/// this file happens to be written in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DrainRefusal {
+    /// HTTP 429 — the API declined this eviction *for now*, and the same
+    /// call may well succeed a moment later.
+    ///
+    /// Deliberately not called "budget". Kubernetes answers 429 both for a
+    /// spent `PodDisruptionBudget` and for its own request throttling, and
+    /// `kube::core::ErrorResponse` in 0.97 is flattened to
+    /// status/message/reason/code — it carries neither `details.causes`,
+    /// which is where `DisruptionBudget` would be named, nor `Retry-After`.
+    /// Which of the two this is cannot be known from here, so it is not
+    /// claimed. The drain dialog reads the budgets from the cluster itself
+    /// and names them from that instead.
+    NotNow,
+    /// No controller owns this pod, so evicting it ends it for good.
+    /// Left where it is unless `evict_unmanaged_pods` says otherwise —
+    /// which is what `kubectl drain` spends `--force` on.
+    NothingWouldReplaceIt,
+    /// The pod has an `emptyDir`, whose contents do not outlive it.
+    /// Needs `evict_pods_with_emptydir`, as `kubectl drain` needs
+    /// `--delete-emptydir-data`.
+    HoldsLocalData,
+    /// Anything else. `message` carries the API's own words, which is all
+    /// there is when this app has no name for the failure.
+    Other,
+}
+
+/// One pod the drain left where it was, and why.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefusedPod {
+    pub namespace: String,
+    pub name: String,
+    pub refusal: DrainRefusal,
+    /// Set only for `Other`, and quoted rather than composed.
+    pub message: Option<String>,
+}
+
+impl RefusedPod {
+    /// The three refusals this app has a name for. `Other` is built by hand,
+    /// because it is the only one that carries words.
+    fn new(namespace: String, name: String, refusal: DrainRefusal) -> Self {
+        Self {
+            namespace,
+            name,
+            refusal,
+            message: None,
+        }
+    }
+}
+
+/// What a drain did, as opposed to whether it threw.
+///
+/// A report rather than `Result<()>`, because a drain that moved forty pods
+/// and was refused one is neither a success nor a failure, and the old
+/// signature had to pick. It picked failure and joined the refusals into a
+/// single error string — which put English somewhere the catalogue cannot
+/// reach, and left the dialog a blob to print instead of a list to walk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DrainReport {
+    /// Pods this drain evicted.
+    pub evicted: u32,
+    /// Pods that had already left between the listing and their turn.
+    /// Neither evicted by this drain nor refused by anything — kept apart
+    /// from both so that neither count claims them.
+    pub already_gone: u32,
+    /// `DaemonSet` pods left in place, which is the whole of what
+    /// `ignore_daemonsets` does.
+    pub daemonset_pods_left: u32,
+    /// Everything still on the node, in the order it was met.
+    pub refused: Vec<RefusedPod>,
+}
+
+/// What the drain has decided about one pod, before it calls anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PodPlan {
+    /// A `DaemonSet` pod under `ignore_daemonsets`. It stays, and that is not a
+    /// refusal — nothing was ever asked of it.
+    LeaveDaemonSet,
+    /// In the set.
+    Evict,
+    /// Out of the set, for a reason the report can name.
+    Leave(DrainRefusal),
+}
+
+/// Decide about one pod from its spec alone.
+///
+/// Split out of the loop so the membership rules can be tested without a
+/// cluster: which pods a drain touches is the half of this command that
+/// decides whether anything is lost by running it.
+fn plan_for(
+    pod: &Pod,
+    ignore_daemonsets: bool,
+    evict_unmanaged: bool,
+    evict_emptydir: bool,
+) -> PodPlan {
+    let owners = pod.metadata.owner_references.as_deref().unwrap_or_default();
+
+    if ignore_daemonsets && owners.iter().any(|r| r.kind == "DaemonSet") {
+        return PodPlan::LeaveDaemonSet;
+    }
+
+    if owners.is_empty() && !evict_unmanaged {
+        return PodPlan::Leave(DrainRefusal::NothingWouldReplaceIt);
+    }
+
+    let holds_local_data = pod
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.volumes.as_ref())
+        .is_some_and(|volumes| volumes.iter().any(|v| v.empty_dir.is_some()));
+
+    if holds_local_data && !evict_emptydir {
+        return PodPlan::Leave(DrainRefusal::HoldsLocalData);
+    }
+
+    PodPlan::Evict
+}
+
+/// How one eviction call turned out.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Evicted {
+    Yes,
+    /// It had already left. Not this drain's doing, and not a refusal either.
+    AlreadyGone,
+    /// It is still on the node. There is deliberately no fourth arm that
+    /// reaches for `DELETE` instead.
+    No(DrainRefusal, Option<String>),
+}
+
+/// Read one failed eviction.
+///
+/// This is the half the security report was about. Every arm leaves the pod
+/// where it is; the version this replaced turned *any* of them into a direct
+/// `DELETE`, which is the one call that does not consult a
+/// `PodDisruptionBudget`.
+fn outcome_of(err: kube::Error) -> Evicted {
+    if let kube::Error::Api(response) = &err {
+        match response.code {
+            404 | 410 => return Evicted::AlreadyGone,
+            429 => return Evicted::No(DrainRefusal::NotNow, None),
+            _ => {}
+        }
+    }
+
+    let message = crate::state::readable_cause(&crate::error::Error::KubeApi(err));
+    Evicted::No(DrainRefusal::Other, Some(message))
+}
+
+/// Drain a node: cordon it, then evict the pods it is allowed to.
+///
+/// **Eviction only, always.** The eviction API is the thing that consults a
+/// `PodDisruptionBudget`; a `DELETE` simply goes around it. An earlier version
+/// fell back to `DELETE` whenever an eviction returned *any* error, and the
+/// UI passed the flag that enabled it on every single drain — so a budget
+/// that refused an eviction had the pod deleted out from under it a moment
+/// later, while the dialog was still on screen promising the drain would
+/// wait. There is deliberately no flag here to bring that back: a tool that
+/// quietly voids the guarantee a workload was configured with is worse than
+/// one that stops and names what is holding it.
+///
+/// The two opt-ins decide which pods are *in* the set, not how they leave it
+/// — the same distinction `kubectl drain` draws with `--force` and
+/// `--delete-emptydir-data`, both of which still evict.
 #[tauri::command]
 pub async fn drain_node(
     name: String,
     ignore_daemonsets: Option<bool>,
-    force: Option<bool>,
+    evict_unmanaged_pods: Option<bool>,
+    evict_pods_with_emptydir: Option<bool>,
     state: State<'_, AppState>,
-) -> Result<()> {
+) -> Result<DrainReport> {
     crate::validation::validate_dns_subdomain(&name)?;
-    // First cordon the node
+    // Cordon first, so nothing new lands on the node while what is already
+    // there is being moved.
     cordon_node(name.clone(), state.clone()).await?;
 
     let ctx = ResourceContext::for_list(&state, None)?;
@@ -113,9 +285,15 @@ pub async fn drain_node(
     let pods = api.list(&params).await?;
 
     let ignore_daemonsets = ignore_daemonsets.unwrap_or(true);
-    let force = force.unwrap_or(false);
+    let evict_unmanaged = evict_unmanaged_pods.unwrap_or(false);
+    let evict_emptydir = evict_pods_with_emptydir.unwrap_or(false);
 
-    let mut eviction_errors: Vec<String> = Vec::new();
+    let mut report = DrainReport {
+        evicted: 0,
+        already_gone: 0,
+        daemonset_pods_left: 0,
+        refused: Vec::new(),
+    };
 
     for pod in pods.items {
         let pod_name = pod.metadata.name.clone().unwrap_or_default();
@@ -125,80 +303,248 @@ pub async fn drain_node(
             .clone()
             .unwrap_or_else(|| "default".to_string());
 
-        // Skip DaemonSet pods if configured
-        if ignore_daemonsets {
-            if let Some(refs) = &pod.metadata.owner_references {
-                if refs.iter().any(|r| r.kind == "DaemonSet") {
-                    continue;
-                }
+        match plan_for(&pod, ignore_daemonsets, evict_unmanaged, evict_emptydir) {
+            PodPlan::LeaveDaemonSet => {
+                report.daemonset_pods_left += 1;
+                continue;
             }
+            PodPlan::Leave(refusal) => {
+                report
+                    .refused
+                    .push(RefusedPod::new(namespace, pod_name, refusal));
+                continue;
+            }
+            PodPlan::Evict => {}
         }
 
-        // Check if pod is unmanaged (no owner references) - requires force
-        let is_unmanaged = pod
-            .metadata
-            .owner_references
-            .as_ref()
-            .is_none_or(std::vec::Vec::is_empty);
-
-        if is_unmanaged && !force {
-            eviction_errors.push(format!(
-                "Pod {namespace}/{pod_name} is not managed by a controller. Use --force to delete."
-            ));
-            continue;
-        }
-
-        // Check for local storage (emptyDir) - requires force
-        let has_local_storage = pod
-            .spec
-            .as_ref()
-            .and_then(|s| s.volumes.as_ref())
-            .is_some_and(|volumes| volumes.iter().any(|v| v.empty_dir.is_some()));
-
-        if has_local_storage && !force {
-            eviction_errors.push(format!(
-                "Pod {namespace}/{pod_name} has local storage (emptyDir). Use --force to delete."
-            ));
-            continue;
-        }
-
-        // Evict the pod
         let pod_ctx = ResourceContext::for_command(&state, Some(namespace.clone()))?;
         let pod_api: kube::Api<Pod> = pod_ctx.namespaced_api();
-        let evict_params = kube::api::EvictParams::default();
 
-        match pod_api.evict(&pod_name, &evict_params).await {
-            Ok(_) => {
-                tracing::info!("Successfully evicted pod {}/{}", namespace, pod_name);
+        let outcome = match pod_api
+            .evict(&pod_name, &kube::api::EvictParams::default())
+            .await
+        {
+            Ok(_) => Evicted::Yes,
+            Err(err) => outcome_of(err),
+        };
+
+        match outcome {
+            Evicted::Yes => {
+                tracing::info!("Evicted pod {}/{}", namespace, pod_name);
+                report.evicted += 1;
             }
-            Err(e) => {
-                let error_msg = format!("Failed to evict pod {namespace}/{pod_name}: {e}");
-                tracing::warn!("{}", error_msg);
-
-                // If force is enabled, try to delete the pod directly
-                if force {
-                    tracing::info!("Force deleting pod {}/{}", namespace, pod_name);
-                    if let Err(delete_err) = pod_api
-                        .delete(&pod_name, &kube::api::DeleteParams::default())
-                        .await
-                    {
-                        eviction_errors.push(format!(
-                            "Failed to force delete pod {namespace}/{pod_name}: {delete_err}"
-                        ));
-                    }
-                } else {
-                    eviction_errors.push(error_msg);
-                }
+            Evicted::AlreadyGone => report.already_gone += 1,
+            Evicted::No(refusal, message) => {
+                tracing::info!(
+                    "Pod {}/{} stays: {:?}{}",
+                    namespace,
+                    pod_name,
+                    refusal,
+                    message
+                        .as_deref()
+                        .map_or_else(String::new, |m| format!(" — {m}"))
+                );
+                report.refused.push(RefusedPod {
+                    namespace,
+                    name: pod_name,
+                    refusal,
+                    message,
+                });
             }
         }
     }
 
-    if !eviction_errors.is_empty() {
-        return Err(crate::error::Error::Internal(format!(
-            "Drain completed with errors:\n{}",
-            eviction_errors.join("\n")
-        )));
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{outcome_of, plan_for, DrainRefusal, Evicted, PodPlan};
+    use k8s_openapi::api::core::v1::{
+        EmptyDirVolumeSource, PersistentVolumeClaimVolumeSource, Pod, PodSpec, Volume,
+    };
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, OwnerReference};
+
+    fn owner(kind: &str) -> OwnerReference {
+        OwnerReference {
+            kind: kind.to_string(),
+            name: "owner".to_string(),
+            uid: "u".to_string(),
+            api_version: "apps/v1".to_string(),
+            ..Default::default()
+        }
     }
 
-    Ok(())
+    fn pod(owners: Vec<OwnerReference>, volumes: Vec<Volume>) -> Pod {
+        Pod {
+            metadata: ObjectMeta {
+                name: Some("p".to_string()),
+                namespace: Some("n".to_string()),
+                owner_references: if owners.is_empty() {
+                    None
+                } else {
+                    Some(owners)
+                },
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                volumes: if volumes.is_empty() {
+                    None
+                } else {
+                    Some(volumes)
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn scratch() -> Volume {
+        Volume {
+            name: "scratch".to_string(),
+            empty_dir: Some(EmptyDirVolumeSource::default()),
+            ..Default::default()
+        }
+    }
+
+    fn api_error(code: u16) -> kube::Error {
+        kube::Error::Api(kube::error::ErrorResponse {
+            status: "Failure".into(),
+            message: format!("the server responded with {code}"),
+            reason: "Whatever".into(),
+            code,
+        })
+    }
+
+    // --- which pods are in the set ------------------------------------------
+
+    #[test]
+    fn an_ordinary_replaceable_pod_is_evicted() {
+        let plan = plan_for(&pod(vec![owner("ReplicaSet")], vec![]), true, false, false);
+        assert_eq!(plan, PodPlan::Evict);
+    }
+
+    /// Left alone, and counted apart from the refusals: a `DaemonSet` pod that
+    /// stays is the option working, not something declining to move.
+    #[test]
+    fn a_daemonset_pod_is_left_without_being_called_refused() {
+        let ds = pod(vec![owner("DaemonSet")], vec![]);
+        assert_eq!(plan_for(&ds, true, false, false), PodPlan::LeaveDaemonSet);
+        assert_eq!(plan_for(&ds, false, false, false), PodPlan::Evict);
+    }
+
+    /// `kubectl drain` refuses these without `--force` because nothing will
+    /// bring them back. The old code shipped that opt-in switched permanently
+    /// on, so a drain silently ended every standalone pod it met.
+    #[test]
+    fn a_pod_no_controller_owns_stays_until_it_is_asked_for() {
+        let bare = pod(vec![], vec![]);
+        assert_eq!(
+            plan_for(&bare, true, false, false),
+            PodPlan::Leave(DrainRefusal::NothingWouldReplaceIt)
+        );
+        assert_eq!(plan_for(&bare, true, true, false), PodPlan::Evict);
+    }
+
+    #[test]
+    fn a_pod_holding_local_data_stays_until_it_is_asked_for() {
+        let with_data = pod(vec![owner("ReplicaSet")], vec![scratch()]);
+        assert_eq!(
+            plan_for(&with_data, true, false, false),
+            PodPlan::Leave(DrainRefusal::HoldsLocalData)
+        );
+        assert_eq!(plan_for(&with_data, true, false, true), PodPlan::Evict);
+    }
+
+    /// A volume that is not an `emptyDir` survives the pod, so it is not a
+    /// reason to hold one back.
+    #[test]
+    fn a_mounted_volume_that_outlives_the_pod_is_not_local_data() {
+        let mounted = Volume {
+            name: "data".to_string(),
+            persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource::default()),
+            ..Default::default()
+        };
+        let plan = plan_for(
+            &pod(vec![owner("StatefulSet")], vec![mounted]),
+            true,
+            false,
+            false,
+        );
+        assert_eq!(plan, PodPlan::Evict);
+    }
+
+    /// Both opt-ins are off and both apply: the first one met is the one
+    /// reported, and either way the pod does not move.
+    #[test]
+    fn a_pod_that_trips_both_rules_still_stays() {
+        let both = pod(vec![], vec![scratch()]);
+        assert!(matches!(
+            plan_for(&both, true, false, false),
+            PodPlan::Leave(_)
+        ));
+        // Answering only the first still leaves the second holding it.
+        assert_eq!(
+            plan_for(&both, true, true, false),
+            PodPlan::Leave(DrainRefusal::HoldsLocalData)
+        );
+    }
+
+    // --- what a failed eviction means ---------------------------------------
+
+    /// The reported bug, as a test. A 429 is the eviction API saying "not
+    /// now" — most often a spent `PodDisruptionBudget`. The old code answered
+    /// it with a direct `DELETE`, which is the one call that does not consult
+    /// the budget at all.
+    #[test]
+    fn a_refused_eviction_leaves_the_pod_where_it_is() {
+        assert_eq!(
+            outcome_of(api_error(429)),
+            Evicted::No(DrainRefusal::NotNow, None)
+        );
+    }
+
+    /// Deliberately not named after the budget. Kubernetes answers 429 for
+    /// throttling too, and nothing in `ErrorResponse` tells the two apart.
+    #[test]
+    fn the_refusal_does_not_claim_to_know_which_429_it_was() {
+        let Evicted::No(refusal, message) = outcome_of(api_error(429)) else {
+            panic!("a 429 leaves the pod");
+        };
+        assert_eq!(refusal, DrainRefusal::NotNow);
+        assert!(
+            message.is_none(),
+            "no words here: the dialog reads the budgets itself"
+        );
+    }
+
+    /// It left on its own between the listing and its turn. Neither an
+    /// eviction this drain performed nor a refusal — the third state.
+    #[test]
+    fn a_pod_that_already_left_is_neither_evicted_nor_refused() {
+        assert_eq!(outcome_of(api_error(404)), Evicted::AlreadyGone);
+        assert_eq!(outcome_of(api_error(410)), Evicted::AlreadyGone);
+    }
+
+    /// Anything this app has no name for still leaves the pod, and carries
+    /// the API's own sentence so the reader has something to act on.
+    #[test]
+    fn an_unrecognised_failure_leaves_the_pod_and_quotes_the_server() {
+        let Evicted::No(refusal, Some(message)) = outcome_of(api_error(403)) else {
+            panic!("an unrecognised failure leaves the pod and says why");
+        };
+        assert_eq!(refusal, DrainRefusal::Other);
+        assert!(message.contains("403"), "got {message:?}");
+    }
+
+    /// Not every failure is an API rejection — a dropped connection has no
+    /// HTTP code at all, and must not fall through to anything destructive.
+    #[test]
+    fn a_transport_failure_also_leaves_the_pod() {
+        let err = kube::Error::LinesCodecMaxLineLengthExceeded;
+        assert!(matches!(
+            outcome_of(err),
+            Evicted::No(DrainRefusal::Other, Some(_))
+        ));
+    }
 }

--- a/src-tauri/src/commands/settings/helpers.rs
+++ b/src-tauri/src/commands/settings/helpers.rs
@@ -14,7 +14,9 @@ pub fn save_config(config: &AppConfig) -> Result<()> {
     let toml_str = toml::to_string_pretty(config)
         .map_err(|e| Error::Config(format!("Failed to serialize config: {e}")))?;
 
-    std::fs::write(&config_path, toml_str)
+    // Not `std::fs::write`: this file holds bearer tokens and the registry
+    // password, and that call would leave them at the umask's mercy.
+    crate::config::private_file::write(&config_path, toml_str.as_bytes())
         .map_err(|e| Error::Config(format!("Failed to write config file: {e}")))?;
 
     Ok(())

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -20,6 +20,7 @@ mod cloud;
 mod connection;
 mod editor;
 mod integrations;
+pub mod private_file;
 
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
@@ -103,6 +104,10 @@ impl AppConfig {
         let config_path = Self::config_path()?;
 
         if config_path.exists() {
+            // A config written by an older version is world-readable and holds
+            // credentials. Reading it is the moment we know it exists.
+            private_file::harden(&config_path);
+
             let content = std::fs::read_to_string(&config_path)
                 .map_err(|e| Error::Config(format!("Failed to read config: {e}")))?;
 

--- a/src-tauri/src/config/private_file.rs
+++ b/src-tauri/src/config/private_file.rs
@@ -1,0 +1,243 @@
+//! Writing `config.toml` so that only its owner can read it.
+//!
+//! This file holds the bearer tokens for Prometheus and Loki and the registry
+//! password in plain text. Storing them there rather than in a second, better
+//! store is a deliberate choice — see [`crate::config::integrations`] for why
+//! — but it is not a licence to leave them where the rest of the machine can
+//! read them, and `std::fs::write` does exactly that: it creates with `0666`
+//! masked by the umask, which on a stock macOS or Linux account leaves `0644`.
+//!
+//! Both things this module does come from the same trick — write a fresh
+//! neighbouring file and rename it over the target:
+//!
+//! * **Owner-only from the first byte.** Creating the file `0600` and then
+//!   filling it means the token is never briefly readable, which chmod-ing
+//!   after the write would not give.
+//! * **All of the new file or none of it.** A rename is atomic, so an
+//!   interrupted save can no longer leave half a config behind.
+//!
+//! Renaming also replaces the inode, so a config already sitting at `0644`
+//! from an older version heals the next time anything is saved. [`harden`]
+//! covers the reader who never changes a setting again.
+//!
+//! On Windows there are no mode bits and this falls back to a plain replace:
+//! the file inherits the ACL of `%APPDATA%`, which is already scoped to the
+//! account.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Distinguishes the scratch files of two saves racing each other. The
+/// process id alone is not enough — both would be this process.
+static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(unix)]
+const OWNER_ONLY: u32 = 0o600;
+
+/// Write `bytes` to `path`, atomically, readable only by this user.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error. The scratch file is removed first, so a
+/// failure leaves neither a half-written config nor litter beside it.
+pub fn write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let scratch = scratch_beside(path)?;
+
+    match fill(&scratch, bytes).and_then(|()| std::fs::rename(&scratch, path)) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let _ = std::fs::remove_file(&scratch);
+            Err(err)
+        }
+    }
+}
+
+/// Take an existing file's permissions down to owner-only.
+///
+/// Best-effort and silent on failure: this runs on every config read, and a
+/// file whose mode cannot be changed — a read-only mount, a config owned by
+/// someone else — is not a reason to refuse to start. It is already the
+/// wrong mode; refusing would only take the app away too.
+pub fn harden(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let Ok(metadata) = std::fs::metadata(path) else {
+            return;
+        };
+        // Every save already writes 0600, so the common path is a stat and
+        // nothing else.
+        if metadata.permissions().mode() & 0o777 == OWNER_ONLY {
+            return;
+        }
+        let outcome = std::fs::set_permissions(path, std::fs::Permissions::from_mode(OWNER_ONLY));
+        match outcome {
+            Ok(()) => tracing::info!(
+                "Tightened {} to owner-only; it held credentials at mode {:o}",
+                path.display(),
+                metadata.permissions().mode() & 0o777
+            ),
+            Err(err) => tracing::warn!("Could not tighten {}: {err}", path.display()),
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+/// A scratch name in the same directory, because a rename is only atomic
+/// within one filesystem and `/tmp` is regularly a different one.
+fn scratch_beside(path: &Path) -> std::io::Result<std::path::PathBuf> {
+    let dir = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "config path has no directory to write beside",
+        )
+    })?;
+    let stem = path
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("config.toml");
+    Ok(dir.join(format!(
+        ".{stem}.{}.{}.partial",
+        std::process::id(),
+        SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    )))
+}
+
+/// Create the scratch file owner-only and fill it.
+///
+/// `create_new` rather than `create`: the name is unique, so an existing one
+/// means something unexpected is there and overwriting it blindly is how a
+/// scratch file becomes a place to plant something.
+fn fill(scratch: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(OWNER_ONLY);
+    }
+
+    let mut file = options.open(scratch)?;
+    file.write_all(bytes)?;
+    // The rename is atomic, but only orders against data that has reached the
+    // disk; without this a crash can leave the new name pointing at nothing.
+    file.sync_all()
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::{harden, write, OWNER_ONLY};
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static DIRS: AtomicU32 = AtomicU32::new(0);
+
+    /// A directory of our own per test: these run in parallel and all want a
+    /// file called `config.toml`.
+    fn scratch_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "rubick-private-file-{}-{}-{label}",
+            std::process::id(),
+            DIRS.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).expect("scratch directory");
+        dir
+    }
+
+    fn mode_of(path: &Path) -> u32 {
+        std::fs::metadata(path)
+            .expect("the file exists")
+            .permissions()
+            .mode()
+            & 0o777
+    }
+
+    /// What the security report asked for, as a test that runs the real code
+    /// against a real filesystem rather than reasoning about the umask.
+    #[test]
+    fn a_written_config_is_readable_only_by_its_owner() {
+        let dir = scratch_dir("fresh");
+        let path = dir.join("config.toml");
+
+        write(&path, b"token = \"secret\"\n").expect("write");
+
+        assert_eq!(mode_of(&path), OWNER_ONLY, "mode is {:o}", mode_of(&path));
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "token = \"secret\"\n"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The install that already exists. Renaming replaces the inode, so the
+    /// old permissions do not survive the next save.
+    #[test]
+    fn saving_over_a_world_readable_config_takes_it_private() {
+        let dir = scratch_dir("existing");
+        let path = dir.join("config.toml");
+        std::fs::write(&path, b"old\n").expect("seed");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("seed mode");
+        assert_eq!(mode_of(&path), 0o644, "the seed has to start wrong");
+
+        write(&path, b"new\n").expect("write");
+
+        assert_eq!(mode_of(&path), OWNER_ONLY);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new\n");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The reader who set a token once and never opened settings again: their
+    /// file is never rewritten, so the fix has to reach it on the way in.
+    #[test]
+    fn reading_an_old_config_tightens_it_in_place() {
+        let dir = scratch_dir("harden");
+        let path = dir.join("config.toml");
+        std::fs::write(&path, b"token = \"secret\"\n").expect("seed");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("seed mode");
+
+        harden(&path);
+
+        assert_eq!(mode_of(&path), OWNER_ONLY);
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "token = \"secret\"\n",
+            "hardening must not disturb the contents"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A missing file is the first-run case, not an error to shout about.
+    #[test]
+    fn hardening_something_that_is_not_there_is_quiet() {
+        let dir = scratch_dir("absent");
+        harden(&dir.join("config.toml"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The scratch file is an implementation detail and must not outlive the
+    /// call — least of all beside a config, where it would be a second copy
+    /// of the same credentials.
+    #[test]
+    fn a_save_leaves_nothing_beside_the_config() {
+        let dir = scratch_dir("litter");
+        let path = dir.join("config.toml");
+
+        write(&path, b"a\n").expect("first");
+        write(&path, b"b\n").expect("second");
+
+        let left: Vec<_> = std::fs::read_dir(&dir)
+            .expect("listing")
+            .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().into_owned()))
+            .collect();
+        assert_eq!(
+            left,
+            vec!["config.toml".to_string()],
+            "left behind: {left:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/components/registry/RegistrySettings.tsx
+++ b/src/components/registry/RegistrySettings.tsx
@@ -652,6 +652,14 @@ export function RegistrySettings() {
               onChange={(event) => setEditToken(event.target.value)}
             />
           )}
+          {/* The same truth the integration form tells. A registry password
+           *  lands in the same file by the same path, and the reader pasting
+           *  one here was the only one not being told. */}
+          {selectedRegistry.authType !== "none" && (
+            <p className="text-[11px] leading-snug text-fg-fnt">
+              {t("settings", "credentialStorageNote")}
+            </p>
+          )}
           {selectedRegistry.authType !== "none" &&
             (selectedRegistry.username ||
               selectedRegistry.authType === "bearer") && (

--- a/src/components/resources/NodeList.tsx
+++ b/src/components/resources/NodeList.tsx
@@ -21,12 +21,13 @@ import { createNameColumn } from "@/components/resources/columns";
 import { SpotMark } from "@/components/resources/spot-mark";
 import type { RowGrouping } from "@/components/ui/row-grouping";
 import { describePool, poolFacts, poolOf, spotMark } from "@/lib/node-pool";
-import type { NodeInfo, NodeMetrics } from "@/generated/types";
+import type { DrainReport, NodeInfo, NodeMetrics } from "@/generated/types";
 import { STALE_TIMES } from "@/lib/refresh";
 import { queryKeys } from "@/lib/query-keys";
 import { RealtimeAge } from "@/components/ui/realtime";
 import { getResourceRowId } from "@/lib/table-utils";
 import { useResourceWatch } from "@/hooks/useResourceWatch";
+import type { DrainChoices } from "@/components/resources/drain-dialog";
 import { DrainDialog } from "@/components/resources/drain-dialog";
 import { useT } from "@/i18n/useT";
 
@@ -254,15 +255,29 @@ export function NodeList() {
   });
 
   const drainMutation = useMutation({
-    mutationFn: (nodeName: string) => commands.drainNode(nodeName, true, true),
-    onSuccess: (_, nodeName) => {
+    mutationFn: ({ node, choices }: { node: string; choices: DrainChoices }) =>
+      commands.drainNode(
+        node,
+        true,
+        choices.evictUnmanagedPods,
+        choices.evictPodsWithLocalData
+      ),
+    onSuccess: (report, { node }) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.resources(ResourceType.Node, null),
       });
-      toast({
-        title: t("action", "nodeDrained"),
-        description: t("action", "nodeDrainedDetail", { name: nodeName }),
-      });
+      // An empty node is the whole story, and a toast tells it without
+      // keeping a dialog open over a list. Anything left behind is not a
+      // story a toast can hold: it is a list of pods and a reason each.
+      if (report.refused.length === 0) {
+        setDraining(null);
+        toast({
+          title: t("action", "nodeDrained"),
+          description: t("action", "nodeDrainedDetail", { name: node }),
+        });
+        return;
+      }
+      setDrainReport(report);
     },
     onError: (error) => {
       toast({
@@ -274,6 +289,7 @@ export function NodeList() {
   });
 
   const [draining, setDraining] = useState<string | null>(null);
+  const [drainReport, setDrainReport] = useState<DrainReport | null>(null);
 
   const nodeColumns = useMemo(
     () => columns(nodeMetricsByName),
@@ -335,12 +351,15 @@ export function NodeList() {
       />
       <DrainDialog
         node={draining}
-        onOpenChange={(open) => !open && setDraining(null)}
-        busy={drainMutation.isPending}
-        onConfirm={(node) => {
-          setDraining(null);
-          drainMutation.mutate(node);
+        report={drainReport}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDraining(null);
+            setDrainReport(null);
+          }
         }}
+        busy={drainMutation.isPending}
+        onConfirm={(node, choices) => drainMutation.mutate({ node, choices })}
       />
     </>
   );

--- a/src/components/resources/drain-dialog.test.tsx
+++ b/src/components/resources/drain-dialog.test.tsx
@@ -1,0 +1,241 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { DrainDialog } from "./drain-dialog";
+import type { DrainReport, RefusedPod } from "@/generated/types";
+
+const wrap = (ui: ReactNode) =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+
+const refused = (over: Partial<RefusedPod> = {}): RefusedPod => ({
+  namespace: "prod",
+  name: "api-7f9",
+  refusal: "notNow",
+  message: null,
+  ...over,
+});
+
+const report = (over: Partial<DrainReport> = {}): DrainReport => ({
+  evicted: 12,
+  alreadyGone: 0,
+  daemonsetPodsLeft: 0,
+  refused: [refused()],
+  ...over,
+});
+
+describe("confirming a drain", () => {
+  /**
+   * The whole of the security report, as a test of the click. The old list
+   * called `drainNode(node, true, true)` — both opt-ins hard on, no way to
+   * turn them off — so every drain was authorised to end pods nothing would
+   * bring back.
+   */
+  it("asks for nothing destructive unless it is ticked", async () => {
+    const onConfirm = vi.fn();
+    wrap(
+      <DrainDialog
+        node="node-7"
+        report={null}
+        onOpenChange={() => {}}
+        onConfirm={onConfirm}
+        busy={false}
+      />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /drain/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith("node-7", {
+      evictUnmanagedPods: false,
+      evictPodsWithLocalData: false,
+    });
+  });
+
+  it("carries a ticked opt-in through to the caller", async () => {
+    const onConfirm = vi.fn();
+    wrap(
+      <DrainDialog
+        node="node-7"
+        report={null}
+        onOpenChange={() => {}}
+        onConfirm={onConfirm}
+        busy={false}
+      />
+    );
+
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: /nothing would replace/i })
+    );
+    await userEvent.click(screen.getByRole("button", { name: /drain/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith("node-7", {
+      evictUnmanagedPods: true,
+      evictPodsWithLocalData: false,
+    });
+  });
+
+  /**
+   * Each node is its own decision. An opt-in answered for one node that
+   * carried over to the next would be the dialog answering a question this
+   * reader was never asked — and the question ends pods.
+   */
+  it("starts the next node from a clean pair of opt-ins", async () => {
+    const onConfirm = vi.fn();
+    const view = wrap(
+      <DrainDialog
+        node="node-7"
+        report={null}
+        onOpenChange={() => {}}
+        onConfirm={onConfirm}
+        busy={false}
+      />
+    );
+
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: /nothing would replace/i })
+    );
+
+    view.rerender(
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <MemoryRouter>
+          <DrainDialog
+            node="node-8"
+            report={null}
+            onOpenChange={() => {}}
+            onConfirm={onConfirm}
+            busy={false}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /drain/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith("node-8", {
+      evictUnmanagedPods: false,
+      evictPodsWithLocalData: false,
+    });
+  });
+
+  /** It says what will happen, and what will not. */
+  it("does not promise to wait", () => {
+    wrap(
+      <DrainDialog
+        node="node-7"
+        report={null}
+        onOpenChange={() => {}}
+        onConfirm={() => {}}
+        busy={false}
+      />
+    );
+
+    expect(
+      screen.getByText(/moves what it can and stops at the rest/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/keep waiting/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("reading what a drain left behind", () => {
+  it("names every pod that stayed and why", () => {
+    wrap(
+      <DrainDialog
+        node="node-7"
+        report={report({
+          refused: [
+            refused(),
+            refused({
+              name: "batch-1",
+              namespace: "ops",
+              refusal: "nothingWouldReplaceIt",
+            }),
+          ],
+        })}
+        onOpenChange={() => {}}
+        onConfirm={() => {}}
+        busy={false}
+      />
+    );
+
+    expect(screen.getByText("prod/api-7f9")).toBeInTheDocument();
+    expect(screen.getByText(/refused for now/i)).toBeInTheDocument();
+    expect(screen.getByText("ops/batch-1")).toBeInTheDocument();
+    expect(screen.getByText(/nothing would replace it/i)).toBeInTheDocument();
+  });
+
+  /**
+   * A 429 is not knowably the budget — Kubernetes answers the same code when
+   * it is pacing itself, and nothing in the response tells the two apart. So
+   * the line hedges, on purpose.
+   */
+  it("does not claim the budget was the reason", () => {
+    wrap(
+      <DrainDialog
+        node="node-7"
+        report={report()}
+        onOpenChange={() => {}}
+        onConfirm={() => {}}
+        busy={false}
+      />
+    );
+
+    expect(
+      screen.getByText(/usually a disruption budget/i)
+    ).toBeInTheDocument();
+  });
+
+  /** When the app has no name for a failure, the server's own words run. */
+  it("quotes the server for a failure it cannot name", () => {
+    wrap(
+      <DrainDialog
+        node="node-7"
+        report={report({
+          refused: [
+            refused({
+              refusal: "other",
+              message: 'pods "api-7f9" is forbidden',
+            }),
+          ],
+        })}
+        onOpenChange={() => {}}
+        onConfirm={() => {}}
+        busy={false}
+      />
+    );
+
+    expect(screen.getByText(/is forbidden/)).toBeInTheDocument();
+  });
+
+  /** The counts have to add up to what was on the node. */
+  it("accounts for the pods it neither moved nor was refused", () => {
+    wrap(
+      <DrainDialog
+        node="node-7"
+        report={report({ alreadyGone: 2, daemonsetPodsLeft: 3 })}
+        onOpenChange={() => {}}
+        onConfirm={() => {}}
+        busy={false}
+      />
+    );
+
+    expect(screen.getByText(/3 DaemonSet pods stay/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/2 pods had already gone on their own/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/resources/drain-dialog.tsx
+++ b/src/components/resources/drain-dialog.tsx
@@ -2,20 +2,31 @@
  * The drain confirmation, and the one thing it is worth reading first.
  *
  * A drain is where a PodDisruptionBudget stops being a number on a workload
- * page and becomes the reason a command sits there. `kubectl drain` does not
- * fail on a spent budget — the eviction API returns 429 and the drain retries,
- * forever if nothing changes — so a reader watching a drain that is not
- * finishing has no way to tell "slow" from "will never finish" without going
- * and finding the budget by hand. This says which one, before the click.
+ * page and becomes the reason a command sits there. This dialog says which
+ * budget, before the click, so that a drain which does not finish is legible
+ * without going and finding the budget by hand.
  *
- * **It does not block, it tells**, on the same terms as the delivery
- * intercept: draining into a spent budget is a legitimate thing to do, the
- * eviction simply waits, and a tool that refuses gets worked around.
+ * **It does not block, it tells.** Draining into a spent budget is a
+ * legitimate thing to do; the eviction is simply refused for now, and a tool
+ * that refuses to let you try gets worked around.
+ *
+ * What it must never do is *promise* one thing and do another. An earlier
+ * version said here that the drain would wait for the budget, while the
+ * backend answered every refused eviction with a direct `DELETE` — the one
+ * call that does not consult a budget at all. The words were the honest half
+ * and the code was not. Both now say the same thing: what can move, moves;
+ * what cannot, stays and is named.
+ *
+ * The two opt-ins are the other half of the same honesty. They decide which
+ * pods are in the set, never how they leave it, and both start off, because
+ * each one ends something the cluster will not bring back.
  */
 
+import { useState } from "react";
 import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -23,24 +34,95 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import type { DrainRefusal, DrainReport } from "@/generated/types";
 import { useConnections } from "@/hooks/useConnections";
 import { budgetRule, drainBlockers } from "@/lib/governance";
 import { ResourceType } from "@/lib/resource-registry";
+import type { en } from "@/i18n/catalogue";
+import type { T } from "@/i18n/useT";
 import { useT } from "@/i18n/useT";
+
+/** What the operator asked for, alongside the node. */
+export type DrainChoices = {
+  evictUnmanagedPods: boolean;
+  evictPodsWithLocalData: boolean;
+};
+
+const REFUSAL_LABEL: Record<DrainRefusal, keyof typeof en.cluster> = {
+  notNow: "refusalNotNow",
+  nothingWouldReplaceIt: "refusalNothingWouldReplaceIt",
+  holdsLocalData: "refusalHoldsLocalData",
+  other: "refusalOther",
+};
 
 export function DrainDialog({
   node,
+  report,
   onOpenChange,
   onConfirm,
   busy,
 }: {
   /** The node to drain, or `null` for a closed dialog. */
   node: string | null;
+  /** Set once a drain has run and left something behind. */
+  report: DrainReport | null;
   onOpenChange: (open: boolean) => void;
-  onConfirm: (node: string) => void;
+  onConfirm: (node: string, choices: DrainChoices) => void;
   busy: boolean;
 }) {
   const t = useT();
+
+  return (
+    <Dialog open={!!node} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {t("action", "drainNamed", { name: node ?? "" })}
+          </DialogTitle>
+        </DialogHeader>
+        {report ? (
+          <DrainOutcome
+            report={report}
+            t={t}
+            onClose={() => onOpenChange(false)}
+          />
+        ) : (
+          // Keyed by node so each one starts from a clean pair of opt-ins.
+          // Carrying the last node's answers over would be the dialog
+          // answering a question this reader was never asked.
+          <DrainConfirm
+            key={node ?? ""}
+            node={node}
+            busy={busy}
+            t={t}
+            onCancel={() => onOpenChange(false)}
+            onConfirm={onConfirm}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Everything read and decided before the drain runs. */
+function DrainConfirm({
+  node,
+  busy,
+  t,
+  onCancel,
+  onConfirm,
+}: {
+  node: string | null;
+  busy: boolean;
+  t: T;
+  onCancel: () => void;
+  onConfirm: (node: string, choices: DrainChoices) => void;
+}) {
+  const [choices, setChoices] = useState<DrainChoices>({
+    evictUnmanagedPods: false,
+    evictPodsWithLocalData: false,
+  });
+
   // Asked for only while the dialog is open: a node's neighbourhood is every
   // pod on it in every namespace, which is not a read to make from a list row.
   const query = useConnections(
@@ -52,71 +134,183 @@ export function DrainDialog({
   const blockers = drainBlockers(query.data);
 
   return (
-    <Dialog open={!!node} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>
-            {t("action", "drainNamed", { name: node ?? "" })}
-          </DialogTitle>
-        </DialogHeader>
-        <div className="flex flex-col gap-1.5">
-          <p className="text-xs text-fg-mut">{t("empty", "drainExplained")}</p>
-          {query.isPending && node && (
-            <p className="text-[11px] text-fg-fnt">
-              {t("empty", "readingWhatRefusesToMove")}
+    <>
+      <div className="flex flex-col gap-1.5">
+        <p className="text-xs text-fg-mut">{t("empty", "drainExplained")}</p>
+        {query.isPending && node && (
+          <p className="text-[11px] text-fg-fnt">
+            {t("empty", "readingWhatRefusesToMove")}
+          </p>
+        )}
+        {blockers.length > 0 && (
+          <div className="flex flex-col gap-1 pt-1">
+            <p className="text-xs font-medium text-warn">
+              {t("count", "budgetsAllowNoEviction", { n: blockers.length })}
             </p>
-          )}
-          {blockers.length > 0 && (
-            <div className="flex flex-col gap-1 pt-1">
-              <p className="text-xs font-medium text-warn">
-                {t("count", "budgetsAllowNoEviction", { n: blockers.length })}
+            {blockers.map(({ budget, pods }) => (
+              <p
+                key={`${budget.object.namespace}/${budget.object.name}`}
+                className="text-[11px] text-fg-fnt"
+              >
+                <span className="font-mono text-fg-mid">
+                  {budget.object.namespace}/{budget.object.name}
+                </span>{" "}
+                —{" "}
+                {t("empty", "budgetRuleHealthyCovering", {
+                  rule: budgetRule(budget.facts, t),
+                  healthy: budget.facts.currentHealthy,
+                  expected: budget.facts.expectedPods,
+                  pods: t("cluster", "podCount", { n: pods }),
+                })}
               </p>
-              {blockers.map(({ budget, pods }) => (
-                <p
-                  key={`${budget.object.namespace}/${budget.object.name}`}
-                  className="text-[11px] text-fg-fnt"
-                >
-                  <span className="font-mono text-fg-mid">
-                    {budget.object.namespace}/{budget.object.name}
-                  </span>{" "}
-                  —{" "}
-                  {t("empty", "budgetRuleHealthyCovering", {
-                    rule: budgetRule(budget.facts, t),
-                    healthy: budget.facts.currentHealthy,
-                    expected: budget.facts.expectedPods,
-                    pods: t("cluster", "podCount", { n: pods }),
-                  })}
-                </p>
-              ))}
-              <p className="text-[11px] text-fg-fnt">
-                {t("empty", "drainWillWait")}
-              </p>
-            </div>
-          )}
-          {node && (
-            <Link
-              to={`/nodes/${node}`}
-              className="pt-1 text-[11px] text-info hover:underline"
-            >
-              {t("action", "openTheNodeFirst")}
-            </Link>
-          )}
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            {t("action", "cancel")}
-          </Button>
-          <Button
-            variant="destructive"
+            ))}
+          </div>
+        )}
+        <p className="pt-1 text-[11px] text-fg-fnt">
+          {t("empty", "drainStopsAtRefusals")}
+        </p>
+        <div className="flex flex-col border-t border-hair pt-1.5">
+          <OptIn
+            checked={choices.evictUnmanagedPods}
+            onChange={(next) =>
+              setChoices((was) => ({ ...was, evictUnmanagedPods: next }))
+            }
+            label={t("action", "evictUnmanagedPods")}
+            explained={t("empty", "evictUnmanagedPodsExplained")}
             disabled={busy}
-            onClick={() => node && onConfirm(node)}
+          />
+          <OptIn
+            checked={choices.evictPodsWithLocalData}
+            onChange={(next) =>
+              setChoices((was) => ({ ...was, evictPodsWithLocalData: next }))
+            }
+            label={t("action", "evictPodsWithLocalData")}
+            explained={t("empty", "evictPodsWithLocalDataExplained")}
+            disabled={busy}
+          />
+        </div>
+        {node && (
+          <Link
+            to={`/nodes/${node}`}
+            className="pt-1 text-[11px] text-info hover:underline"
           >
-            {blockers.length > 0
-              ? t("action", "drainAnyway")
-              : t("action", "drain")}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+            {t("action", "openTheNodeFirst")}
+          </Link>
+        )}
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel}>
+          {t("action", "cancel")}
+        </Button>
+        <Button
+          variant="destructive"
+          disabled={busy}
+          onClick={() => node && onConfirm(node, choices)}
+        >
+          {blockers.length > 0
+            ? t("action", "drainAnyway")
+            : t("action", "drain")}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+/**
+ * What the drain actually did.
+ *
+ * Only reached when something stayed — a drain that emptied the node says so
+ * in a toast and closes, because there is nothing here to read.
+ */
+function DrainOutcome({
+  report,
+  t,
+  onClose,
+}: {
+  report: DrainReport;
+  t: T;
+  onClose: () => void;
+}) {
+  const anyNotNow = report.refused.some((pod) => pod.refusal === "notNow");
+
+  return (
+    <>
+      <div className="flex flex-col gap-1.5">
+        <p className="text-xs text-fg-mut">
+          {t("count", "podsMovedOff", { n: report.evicted })}{" "}
+          {t("count", "podsStayedOnTheNode", { n: report.refused.length })}
+        </p>
+        {/* The rest of what was on the node, so the counts add up to what
+         *  was there rather than trailing off. */}
+        {report.daemonsetPodsLeft > 0 && (
+          <p className="text-[11px] text-fg-fnt">
+            {t("count", "daemonsetPodsStay", { n: report.daemonsetPodsLeft })}
+          </p>
+        )}
+        {report.alreadyGone > 0 && (
+          <p className="text-[11px] text-fg-fnt">
+            {t("count", "podsHadAlreadyLeft", { n: report.alreadyGone })}
+          </p>
+        )}
+        <div className="flex flex-col gap-1 pt-1">
+          {report.refused.map((pod) => (
+            <p
+              key={`${pod.namespace}/${pod.name}`}
+              className="text-[11px] text-fg-fnt"
+            >
+              <span className="font-mono text-fg-mid">
+                {pod.namespace}/{pod.name}
+              </span>{" "}
+              — {pod.message ?? t("cluster", REFUSAL_LABEL[pod.refusal])}
+            </p>
+          ))}
+        </div>
+        {anyNotNow && (
+          <>
+            <p className="pt-1 text-[11px] text-fg-fnt">
+              {t("empty", "notNowExplained")}
+            </p>
+            <p className="text-[11px] text-fg-fnt">
+              {t("empty", "podsStayedExplained")}
+            </p>
+          </>
+        )}
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose}>
+          {t("action", "close")}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+/** One opt-in, with the consequence under it rather than in a tooltip. */
+function OptIn({
+  checked,
+  onChange,
+  label,
+  explained,
+  disabled,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  label: string;
+  explained: string;
+  disabled: boolean;
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-2 py-1">
+      <Checkbox
+        className="mt-0.5"
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={(next) => onChange(next === true)}
+      />
+      <span className="flex flex-col gap-0.5">
+        <span className="text-xs text-fg-mid">{label}</span>
+        <span className="text-[11px] text-fg-fnt">{explained}</span>
+      </span>
+    </label>
   );
 }

--- a/src/components/settings/ConnectIntegration.tsx
+++ b/src/components/settings/ConnectIntegration.tsx
@@ -277,7 +277,7 @@ function ConnectForm({
             {/* Where it goes, said plainly, because the reader is about to
              *  paste a credential and is owed the truth about the file. */}
             <p className="text-[11px] leading-snug text-fg-fnt">
-              {t("settings", "tokenStorageNote")}
+              {t("settings", "credentialStorageNote")}
             </p>
           </div>
         )}

--- a/src/generated/commands.ts
+++ b/src/generated/commands.ts
@@ -33,6 +33,7 @@ import type {
   DeploymentInfo,
   DetectedExtension,
   Diagnostics,
+  DrainReport,
   EndpointsInfo,
   EventFilters,
   EventInfo,
@@ -962,9 +963,15 @@ export async function uncordonNode(name: string): Promise<void> {
 export async function drainNode(
   name: string,
   ignoreDaemonsets: boolean | null,
-  force: boolean | null
-): Promise<void> {
-  return invoke<void>("drain_node", { name, ignoreDaemonsets, force });
+  evictUnmanagedPods: boolean | null,
+  evictPodsWithEmptydir: boolean | null
+): Promise<DrainReport> {
+  return invoke<DrainReport>("drain_node", {
+    name,
+    ignoreDaemonsets,
+    evictUnmanagedPods,
+    evictPodsWithEmptydir,
+  });
 }
 
 export async function listNamespaces(): Promise<NamespaceInfo[]> {

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -591,6 +591,20 @@ export interface NamespaceInfo {
   createdAt: string | null;
 }
 
+export interface DrainReport {
+  evicted: number;
+  alreadyGone: number;
+  daemonsetPodsLeft: number;
+  refused: RefusedPod[];
+}
+
+export interface RefusedPod {
+  namespace: string;
+  name: string;
+  refusal: DrainRefusal;
+  message: string | null;
+}
+
 export interface NodeInfo {
   name: string;
   uid: string;
@@ -1727,6 +1741,9 @@ export type SearchFailureKind =
 
 export type SearchContextStatus =
   "connecting" | "searching" | "done" | "failed" | "skipped";
+
+export type DrainRefusal =
+  "notNow" | "nothingWouldReplaceIt" | "holdsLocalData" | "other";
 
 export type MetricsStatusKind =
   "available" | "notInstalled" | "forbidden" | "error";

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -629,6 +629,8 @@ export const en = {
     latestN: "Latest {n}",
     drainNamed: "Drain {name}",
     drainAnyway: "Drain anyway",
+    evictUnmanagedPods: "Also move pods nothing would replace",
+    evictPodsWithLocalData: "Also move pods holding local data",
     openTheNodeFirst: "Open the node first",
     loadOlder: "Load older",
     hideHistory: "Hide history",
@@ -2152,6 +2154,10 @@ export const en = {
     nodeCordonedWord: "cordoned",
   },
   cluster: {
+    refusalNotNow: "Refused for now",
+    refusalNothingWouldReplaceIt: "Nothing would replace it",
+    refusalHoldsLocalData: "Holds local data",
+    refusalOther: "Refused",
     nameMissingParens: "{name} (missing)",
     noClusterSelected: "No cluster selected",
     metricsNotInstalled: "Metrics server not installed",
@@ -2366,8 +2372,8 @@ export const en = {
       "Forwarding {target} to {local}. Left off, the row stays in the sidebar and pressing it opens the tunnel — kept per cluster, on this machine only.",
     tokenUnchangedPlaceholder: "unchanged — type to replace it",
     tokenNewPlaceholder: "pasted here, kept out of this window afterwards",
-    tokenStorageNote:
-      "Stored in this app’s config file in plain text, beside the registry passwords it already keeps there, and sent only from the backend — it is never handed back to this window.",
+    credentialStorageNote:
+      "Stored in plain text in this app’s config file, which only your account can read. It is sent only from the backend and never handed back to this window.",
     lookingEllipsis: "Looking…",
     findVendorInCluster: "Find {vendor} in this cluster",
     probeAnswered: "Answered in {ms}ms",
@@ -3062,8 +3068,16 @@ export const en = {
     drainExplained:
       "The node is cordoned and every pod on it that a controller can replace is evicted. DaemonSet pods stay.",
     readingWhatRefusesToMove: "Reading what would refuse to move…",
-    drainWillWait:
-      "The drain will not fail on these — it will wait, and keep waiting until another replica is ready somewhere else.",
+    drainStopsAtRefusals:
+      "The drain moves what it can and stops at the rest. Nothing is deleted to get past a budget, and the node stays closed to scheduling either way.",
+    evictUnmanagedPodsExplained:
+      "Nothing would bring these back, so moving them ends them.",
+    evictPodsWithLocalDataExplained:
+      "Whatever their emptyDir holds does not survive the move.",
+    podsStayedExplained:
+      "Run the drain again once a replacement is ready — these move as soon as the cluster allows it.",
+    notNowExplained:
+      "Kubernetes refuses these for a time rather than for good: usually a disruption budget with nothing spare, sometimes the API pacing itself.",
     budgetRuleHealthyCovering:
       "{rule}, {healthy} of {expected} healthy, covering {pods} here.",
     couldNotReadClusterState: "Could not read cluster state",
@@ -4209,6 +4223,22 @@ export const en = {
     warningEvents: { one: "{n} warning", other: "{n} warning" },
     normalEvents: { one: "{n} normal", other: "{n} normal" },
     latestKept: "latest {n}",
+    podsStayedOnTheNode: {
+      one: "One pod stayed on the node.",
+      other: "{n} pods stayed on the node.",
+    },
+    daemonsetPodsStay: {
+      one: "One DaemonSet pod stays, as it always does.",
+      other: "{n} DaemonSet pods stay, as they always do.",
+    },
+    podsHadAlreadyLeft: {
+      one: "One pod had already gone on its own.",
+      other: "{n} pods had already gone on their own.",
+    },
+    podsMovedOff: {
+      one: "One pod moved off.",
+      other: "{n} pods moved off.",
+    },
     budgetsAllowNoEviction: {
       one: "One disruption budget on this node allows nothing to be evicted.",
       other: "{n} disruption budgets on this node allow nothing to be evicted.",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -595,6 +595,8 @@ export const ru: Catalogue = {
     latestN: "Последние {n}",
     drainNamed: "Освободить узел {name}",
     drainAnyway: "Всё равно освободить",
+    evictUnmanagedPods: "Двигать и поды, которые никто не пересоздаст",
+    evictPodsWithLocalData: "Двигать и поды с локальными данными",
     openTheNodeFirst: "Сначала открыть узел",
     loadOlder: "Загрузить более ранние",
     hideHistory: "Скрыть историю",
@@ -2296,6 +2298,10 @@ export const ru: Catalogue = {
     nodeCordonedWord: "закрыт для планирования",
   },
   cluster: {
+    refusalNotNow: "Пока отказано",
+    refusalNothingWouldReplaceIt: "Некому пересоздать",
+    refusalHoldsLocalData: "Держит локальные данные",
+    refusalOther: "Отказано",
     nameMissingParens: "{name} (отсутствует)",
     noClusterSelected: "Кластер не выбран",
     metricsNotInstalled: "metrics-server не установлен",
@@ -2528,8 +2534,8 @@ export const ru: Catalogue = {
       "Проброс {target} на {local}. Если выключено, строка остаётся в боковой панели и открывает туннель по нажатию — хранится для каждого кластера и только на этой машине.",
     tokenUnchangedPlaceholder: "без изменений — введите, чтобы заменить",
     tokenNewPlaceholder: "вставьте сюда, дальше в это окно он не возвращается",
-    tokenStorageNote:
-      "Хранится в конфиге приложения открытым текстом, рядом с паролями реестров, которые уже лежат там, и отправляется только из бэкенда — обратно в это окно он не попадает.",
+    credentialStorageNote:
+      "Хранится открытым текстом в конфиге приложения, который может прочитать только ваша учётная запись. Отправляется только из бэкенда, обратно в это окно не попадает.",
     lookingEllipsis: "Ищем…",
     findVendorInCluster: "Найти {vendor} в этом кластере",
     probeAnswered: "Ответил за {ms} мс",
@@ -3275,8 +3281,16 @@ export const ru: Catalogue = {
     drainExplained:
       "Узел закрывается для планирования, и каждый под на нём, который контроллер может пересоздать, вытесняется. Поды DaemonSet остаются.",
     readingWhatRefusesToMove: "Читаем, что откажется переезжать…",
-    drainWillWait:
-      "Из-за них освобождение не завершится ошибкой — оно будет ждать, пока другая реплика не поднимется где-то ещё.",
+    drainStopsAtRefusals:
+      "Освобождение перевезёт что сможет и остановится на остальном. Ничего не удаляется ради обхода бюджета, и узел в любом случае остаётся закрыт для планирования.",
+    evictUnmanagedPodsExplained:
+      "Их некому вернуть, поэтому переезд для них — конец.",
+    evictPodsWithLocalDataExplained:
+      "То, что лежит в их emptyDir, переезда не переживёт.",
+    podsStayedExplained:
+      "Повторите освобождение, когда поднимется замена, — они уедут, как только кластер позволит.",
+    notNowExplained:
+      "Kubernetes отказывает им на время, а не насовсем: обычно это бюджет прерываний без запаса, иногда — сам API, придерживающий поток.",
     budgetRuleHealthyCovering:
       "{rule}, работоспособны {healthy} из {expected}, покрывает здесь {pods}.",
     couldNotReadClusterState: "Не удалось прочитать состояние кластера",
@@ -4554,6 +4568,30 @@ export const ru: Catalogue = {
       other: "{n} обычных",
     },
     latestKept: "последние {n}",
+    podsStayedOnTheNode: {
+      one: "На узле остался {n} под.",
+      few: "На узле осталось {n} пода.",
+      many: "На узле осталось {n} подов.",
+      other: "На узле осталось {n} пода.",
+    },
+    daemonsetPodsStay: {
+      one: "{n} под DaemonSet остаётся, как и всегда.",
+      few: "{n} пода DaemonSet остаются, как и всегда.",
+      many: "{n} подов DaemonSet остаются, как и всегда.",
+      other: "{n} пода DaemonSet остаются, как и всегда.",
+    },
+    podsHadAlreadyLeft: {
+      one: "{n} под ушёл сам ещё раньше.",
+      few: "{n} пода ушли сами ещё раньше.",
+      many: "{n} подов ушли сами ещё раньше.",
+      other: "{n} пода ушли сами ещё раньше.",
+    },
+    podsMovedOff: {
+      one: "Уехал {n} под.",
+      few: "Уехало {n} пода.",
+      many: "Уехало {n} подов.",
+      other: "Уехало {n} пода.",
+    },
     budgetsAllowNoEviction: {
       one: "{n} бюджет прерываний на этом узле не разрешает вытеснить ничего.",
       few: "{n} бюджета прерываний на этом узле не разрешают вытеснить ничего.",


### PR DESCRIPTION
Two problems found in 4.6.0 by an outside reader who mailed them in privately. Both reproduce on `5d15c54`; I verified each against the code before touching anything.

## 1. Drain went around PodDisruptionBudget

`NodeList.tsx:257` was the only drain path and it called `drainNode(node, true, true)`. In `nodes.rs`, *any* eviction error with `force` set fell through to a direct `DELETE` — the one call that does not consult a budget.

The dialog made it worse than the reporter knew. When a budget allowed nothing, it told the reader:

> The drain will not fail on these — it will wait, and keep waiting until another replica is ready somewhere else.

and then deleted the pods. An operator who read that sentence and clicked **Drain anyway** believed they were queueing a wait.

The root cause is one flag standing for two of kubectl's. `--force` means "include pods no controller owns"; bypassing a budget is `--disable-eviction`, separate and documented as dangerous. Rubick collapsed them, and shipped the dangerous half switched permanently on.

**Now:** eviction only, with no flag to bring the fallback back. Pods that stay are listed with a reason. Membership is two opt-ins, both off, each stating what it ends.

The refusal is deliberately not named "budget". Kubernetes answers 429 for its own throttling too, and `kube::core::ErrorResponse` (0.97) is flattened to status/message/reason/code — no `details.causes`, no `Retry-After`. Which one it was is not knowable there, so it is not claimed; the dialog reads the budgets from the cluster and names them from that.

## 2. Credentials sat in a world-readable file

`config.toml` holds the Prometheus and Loki bearer tokens and the registry password. `std::fs::write` creates `0666 & ~umask` — `0644` on a stock account. Confirmed on my own machine: `-rw-r--r--`.

**Now:** written through a `0600` scratch file and a rename, so there is no window where it is readable and an existing `0644` file heals on the next save. Reading one tightens it in place, for the reader who sets a token once and never opens settings again. The rename also makes the write atomic, which it was not.

Storing them in plain text stays deliberate and documented — a second secret store for one field leaves two rules about where secrets live and only one of them true. The integration form already said so; the registry form, where the password is actually pasted, did not. Now both do.

## Verification

- 16 new Rust tests, 8 new dialog tests. Every one sabotage-checked — the security assertions fail when the old behaviour is put back.
- Permissions tested by execution against a real filesystem, not by reasoning about umask.
- `cargo clippy -D warnings` clean, 455 Rust tests, 2089 frontend tests, build green.

## Not in this PR

The dialog no longer promises to wait, because the drain does not. Making that promise true — retry with progress and cancel, the way `kubectl drain` behaves — is a feature, and it should not ride in on a security fix. The infrastructure for it exists (the search commands are exactly this shape).