### PR TITLE
The drain specimens, where the test can find them

### DIFF
--- a/src-tauri/tests/live_drain.rs
+++ b/src-tauri/tests/live_drain.rs
@@ -37,7 +37,12 @@
 //! kubectl delete pdb held-pdb -n draintest
 //! ```
 //!
-//! Set up with `kind create cluster` and the manifest in the session notes.
+//! Set up:
+//!
+//! ```text
+//! kind create cluster --config test-manifests/drain-kind.yaml
+//! kubectl apply -f test-manifests/drain-scene.yaml
+//! ```
 
 use std::collections::BTreeMap;
 use std::time::Duration;

--- a/test-manifests/README.md
+++ b/test-manifests/README.md
@@ -75,6 +75,36 @@ kubectl delete pv k8s-gui-test-pv
 | Ingress   | `api-ingress`       | -                    | No TLS, with a path rewrite                      |
 | Endpoints | `external-db`       | -                    | Written by hand rather than by the control plane |
 
+## Draining a node
+
+`drain-scene.yaml` and `drain-kind.yaml` are separate, because draining wants a
+node it is allowed to empty and a second one to be the control plane.
+
+```bash
+kind create cluster --config test-manifests/drain-kind.yaml
+kubectl apply -f test-manifests/drain-scene.yaml
+K8S_GUI_DRAIN_CONTEXT=kind-rubick-drain \
+  cargo test --test live_drain -- --ignored --nocapture
+```
+
+Every specimen is there for a rule that is otherwise unobservable:
+
+|                        | why it is in the scene                                                                                                                       |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `held` ×2 + `held-pdb` | a budget with nothing spare — eviction is refused 429 forever                                                                                |
+| `movable`              | no budget, so it has to actually leave                                                                                                       |
+| `scratchy`             | an `emptyDir`, out of the set unless asked for                                                                                               |
+| `lonely`               | no controller, out of the set unless asked for                                                                                               |
+| `stubborn`             | tolerates the cordon, so its replacement lands back on the node — without it, "the drain does not chase its own replacements" cannot be seen |
+| `slowpoke`             | ignores SIGTERM, so "accepted" and "gone" are 25s apart and a premature "drained" is measurable                                              |
+
+`drained_means_the_pods_are_gone` drains the node completely, which `held-pdb`
+would forbid forever — delete the budget first:
+
+```bash
+kubectl delete pdb held-pdb -n draintest
+```
+
 ## What there is to check
 
 ### Lists

--- a/test-manifests/drain-kind.yaml
+++ b/test-manifests/drain-kind.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: rubick-drain
+nodes:
+  - role: control-plane
+  - role: worker

--- a/test-manifests/drain-scene.yaml
+++ b/test-manifests/drain-scene.yaml
@@ -1,0 +1,120 @@
+# Specimens for `src-tauri/tests/live_drain.rs`, which is ignored by default.
+#
+#   kind create cluster --config test-manifests/drain-kind.yaml
+#   kubectl apply -f test-manifests/drain-scene.yaml
+#   K8S_GUI_DRAIN_CONTEXT=kind-rubick-drain \
+#     cargo test --test live_drain -- --ignored --nocapture
+#
+# Everything is pinned to the worker. Each one is here for a rule that is
+# otherwise unobservable — see the test's module docs for which.
+apiVersion: v1
+kind: Namespace
+metadata: { name: draintest }
+---
+# Two replicas with a budget that allows no disruption at all.
+# Its eviction must be refused (429) on every attempt, forever.
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: held, namespace: draintest }
+spec:
+  replicas: 2
+  selector: { matchLabels: { app: held } }
+  template:
+    metadata: { labels: { app: held } }
+    spec:
+      nodeSelector: { kubernetes.io/hostname: rubick-drain-worker }
+      terminationGracePeriodSeconds: 1
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: { name: held-pdb, namespace: draintest }
+spec:
+  minAvailable: 2
+  selector: { matchLabels: { app: held } }
+---
+# No budget: this one must actually leave.
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: movable, namespace: draintest }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: movable } }
+  template:
+    metadata: { labels: { app: movable } }
+    spec:
+      nodeSelector: { kubernetes.io/hostname: rubick-drain-worker }
+      terminationGracePeriodSeconds: 1
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+---
+# Owned, but holding an emptyDir: out of the set unless asked for.
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: scratchy, namespace: draintest }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: scratchy } }
+  template:
+    metadata: { labels: { app: scratchy } }
+    spec:
+      nodeSelector: { kubernetes.io/hostname: rubick-drain-worker }
+      terminationGracePeriodSeconds: 1
+      volumes:
+        - name: scratch
+          emptyDir: {}
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+          volumeMounts: [{ name: scratch, mountPath: /scratch }]
+---
+# No controller at all: nothing would bring it back.
+apiVersion: v1
+kind: Pod
+metadata: { name: lonely, namespace: draintest, labels: { app: lonely } }
+spec:
+  nodeSelector: { kubernetes.io/hostname: rubick-drain-worker }
+  terminationGracePeriodSeconds: 1
+  containers:
+    - name: pause
+      image: registry.k8s.io/pause:3.9
+---
+# Tolerates everything, so it lands on the node even after the cordon.
+# This is what makes a re-listing drain chase its own replacements.
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: stubborn, namespace: draintest }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: stubborn } }
+  template:
+    metadata: { labels: { app: stubborn } }
+    spec:
+      nodeSelector: { kubernetes.io/hostname: rubick-drain-worker }
+      tolerations: [{ operator: Exists }]
+      terminationGracePeriodSeconds: 1
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+---
+# Ignores SIGTERM, so the kubelet waits out the whole grace period before
+# killing it. "Accepted" and "gone" end up 25 seconds apart, which is far
+# enough to measure.
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: slowpoke, namespace: draintest }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: slowpoke } }
+  template:
+    metadata: { labels: { app: slowpoke } }
+    spec:
+      nodeSelector: { kubernetes.io/hostname: rubick-drain-worker }
+      terminationGracePeriodSeconds: 25
+      containers:
+        - name: stubbornly-alive
+          image: busybox:1.36
+          command: ["sh", "-c", "trap '' TERM; sleep 3600"]


### PR DESCRIPTION
`src-tauri/tests/live_drain.rs` — merged in #92 — documented its setup as "the manifest in the session notes". Those notes were a scratch directory on my machine, so the test could not be re-run by anyone else. This is that manifest, beside the ones the other live tests use.

The README table says why each specimen exists, because none of them is decoration:

- `stubborn` tolerates the cordon, so its replacement lands back on the node. Without it, "the drain does not chase its own replacements" cannot be observed — my first sabotage check passed against the fixed code *and* the broken code until this was added.
- `slowpoke` ignores SIGTERM, so "eviction accepted" and "pod gone" end up 25 seconds apart. Without it, a drain reporting success on acceptance is indistinguishable from one that waits.

No code changes.