### PR TITLE
A gateway that keeps its address private is not broken

### DIFF
--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -3873,6 +3873,11 @@ export const en = {
     gwNotProgrammedTitle: "The controller refuses this Gateway",
     gwNotProgrammedBody:
       "{said}. Nothing behind it serves until the Gateway itself is fixed — this is upstream of every route attached to it.",
+    gwNoAddressPublishedSay: "Gateway {name} publishes no address",
+    gwNoAddressPublishedShort: "{name} publishes no address",
+    gwNoAddressPublishedTitle: "No address to read",
+    gwNoAddressPublishedBody:
+      "The controller reports this Gateway as Programmed, and status.addresses is optional — an implementation on a private or overlay network has nothing to publish there. So this app cannot say where traffic arrives, which is not the same as saying it does not.",
     gwNoAddressSay: "Gateway {name} has no address yet",
     gwNoAddressShort: "{name} has no address yet",
     gwNoAddressTitle: "No address to send traffic to",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -4104,6 +4104,11 @@ export const ru: Catalogue = {
     gwNotProgrammedTitle: "Контроллер отвергает этот Gateway",
     gwNotProgrammedBody:
       "{said}. Ничего за ним не обслуживается, пока не починен сам Gateway — это выше всех привязанных к нему маршрутов.",
+    gwNoAddressPublishedSay: "Gateway {name} не публикует адрес",
+    gwNoAddressPublishedShort: "{name} не публикует адрес",
+    gwNoAddressPublishedTitle: "Адреса не прочитать",
+    gwNoAddressPublishedBody:
+      "Контроллер сообщает, что Gateway запрограммирован, а поле status.addresses необязательное — реализации в приватной или оверлейной сети публиковать там нечего. Значит приложение не может сказать, куда приходит трафик, а это не то же самое, что сказать, что он не приходит.",
     gwNoAddressSay: "У Gateway {name} ещё нет адреса",
     gwNoAddressShort: "у {name} ещё нет адреса",
     gwNoAddressTitle: "Некуда отправлять трафик",

--- a/src/lib/route-trace.test.ts
+++ b/src/lib/route-trace.test.ts
@@ -511,15 +511,22 @@ describe("routeTraces", () => {
     expect(trace.steps[2].detail?.body).toContain("No controller");
   });
 
-  it("stops at the gateway while its address is still pending", () => {
+  /**
+   * Was "stops at the gateway while its address is still pending", asserting
+   * an error. It cannot: a cloud LoadBalancer mid-provision and an overlay
+   * that never publishes an address look identical from here, and calling
+   * both broken was wrong about the second. Dashed, and it says why.
+   */
+  it("goes dashed at a programmed gateway with no address to read", () => {
     const [trace] = routeTraces(
-      route("pending"),
+      route("healthy"),
       sources({ gateways: [gateway("edge", { addresses: [] })] }),
       t
     );
 
-    expect(trace.stopStep).toBe(2);
+    expect(trace.steps[1].state).toBe("blind");
     expect(trace.steps[1].detail?.body).toContain("address");
+    expect(trace.stopStep).toBe(null);
   });
 
   it("goes dashed, not red, where the gateway list cannot be read", () => {
@@ -712,5 +719,70 @@ describe("routeTraces", () => {
       address: "203.0.113.10",
       port: 80,
     });
+  });
+});
+
+describe("a gateway that publishes no address", () => {
+  /**
+   * Reported against 4.6.0 by a reader whose Netbird gateway worked
+   * perfectly while five routes under it read "traffic has nowhere to
+   * arrive". `status.addresses` is optional in the spec, and an overlay
+   * implementation has nothing to publish there — so an empty list, next to
+   * a controller saying Programmed, is this app not seeing where traffic
+   * arrives. Which is not what it said.
+   */
+  it("does not call a programmed gateway broken for keeping its address private", () => {
+    const trace = routeTraces(
+      route("healthy"),
+      sources({
+        gateways: [
+          gateway("edge", {
+            addresses: [],
+            conditions: [condition("Programmed", "True", "Programmed")],
+          }),
+        ],
+      }),
+      t
+    )[0];
+
+    const step = trace.steps.find((s) => s.id === "gateway");
+    expect(step?.state).toBe("blind");
+    expect(trace.serving).toBe(true);
+    // And it says so: a verdict nobody checked must not read as checked.
+    expect(trace.servingKnown).toBe(false);
+  });
+
+  /** Nothing vouched for it and there is no address: both halves unknown,
+   *  and the old reading is the right one. */
+  it("still reports an unvouched gateway with no address as broken", () => {
+    const trace = routeTraces(
+      route("healthy"),
+      sources({
+        gateways: [gateway("edge", { addresses: [], conditions: [] })],
+      }),
+      t
+    )[0];
+
+    expect(trace.steps.find((s) => s.id === "gateway")?.state).toBe("err");
+    expect(trace.serving).toBe(false);
+  });
+
+  /** A controller that said no is an answer, not a silence. */
+  it("keeps reporting a gateway the controller refused", () => {
+    const trace = routeTraces(
+      route("healthy"),
+      sources({
+        gateways: [
+          gateway("edge", {
+            addresses: [],
+            conditions: [condition("Programmed", "False", "Pending")],
+          }),
+        ],
+      }),
+      t
+    )[0];
+
+    expect(trace.steps.find((s) => s.id === "gateway")?.state).toBe("err");
+    expect(trace.servingKnown).toBe(true);
   });
 });

--- a/src/lib/route-trace.test.ts
+++ b/src/lib/route-trace.test.ts
@@ -513,9 +513,11 @@ describe("routeTraces", () => {
 
   /**
    * Was "stops at the gateway while its address is still pending", asserting
-   * an error. It cannot: a cloud LoadBalancer mid-provision and an overlay
-   * that never publishes an address look identical from here, and calling
-   * both broken was wrong about the second. Dashed, and it says why.
+   * an error on the assumption that no address means an address is coming.
+   * A Gateway actually waiting for one says so — `Programmed: False`, reason
+   * `AddressNotAssigned` — and still stops at the test below. What is left
+   * here is an implementation that publishes no address because it has none
+   * to publish, and calling that broken was simply wrong.
    */
   it("goes dashed at a programmed gateway with no address to read", () => {
     const [trace] = routeTraces(

--- a/src/lib/route-trace.ts
+++ b/src/lib/route-trace.ts
@@ -336,6 +336,31 @@ function gatewayStep(
     };
   }
   if (gateway.addresses.length === 0) {
+    // `status.addresses` is optional in the spec, and an implementation on a
+    // private or overlay network has nothing to publish there. So when the
+    // controller has already said Programmed, an empty list is this app
+    // failing to see where traffic arrives — not the traffic having nowhere
+    // to arrive. Blind rather than err, which is what keeps `servingKnown`
+    // honest instead of confidently wrong.
+    //
+    // Reported against 4.6.0: a Netbird gateway, programmed and working,
+    // with five routes under it all reading "traffic has nowhere to arrive".
+    if (programmed?.status === "True") {
+      return {
+        id: "gateway",
+        state: "blind",
+        say: t("empty", "gwNoAddressPublishedSay", { name: gateway.name }),
+        who: "infra",
+        short: t("empty", "gwNoAddressPublishedShort", { name: gateway.name }),
+        subject,
+        detail: {
+          title: t("empty", "gwNoAddressPublishedTitle"),
+          body: t("empty", "gwNoAddressPublishedBody"),
+        },
+      };
+    }
+    // Nothing has vouched for it and there is no address: the old reading
+    // stands, because now neither half is known good.
     return {
       id: "gateway",
       state: "err",


### PR DESCRIPTION
Reported by @syorito-hatsuki in #69: a Netbird gateway, `programmed`, working, and every route under it reading **"Gateway private has no address yet — traffic has nowhere to arrive"**.

## What was wrong

`route-trace.ts` treated an empty `status.addresses` as an error unconditionally — before ever looking at what the controller had said. But `status.addresses` is **optional** in the Gateway API spec, and an implementation on a private or overlay network has nothing to publish there.

Proven by running it, not by reading it. A gateway with `Programmed: True` and no addresses produced:

```
state: err | serving: false | servingKnown: true
say: Gateway edge has no address yet
```

`servingKnown: true` is the part that stings: the app was not merely wrong, it was *confident*. That flag exists precisely so a verdict nobody checked does not read as checked.

## What it does now

| gateway | before | now |
|---|---|---|
| `Programmed: True`, no address | **err** — "traffic has nowhere to arrive" | **blind** — "publishes no address", `servingKnown: false` |
| no condition, no address | err | err (unchanged — both halves unknown) |
| `Programmed: False` | err | err (unchanged — the controller answered) |

The blind state is not new machinery: the test one row down, *"goes dashed, not red, where the gateway list cannot be read"*, is the same principle. This extends it from "cannot read the list" to "cannot read the address".

## Not a trade after all

I first wrote this up as one — a cloud LoadBalancer mid-provision looking the
same as an overlay, and both going dashed. That was wrong, and checking beat
guessing: a Gateway waiting for an address reports `Programmed: False` with
reason `AddressNotAssigned`, so it stops at the branch above and stays red,
exactly as before. This branch only ever catches an implementation that has no
address to publish.

## Verification

- Three new tests, one rewritten. Sabotage-checked: restoring the old `err` fails two of them.
- 1060 frontend tests, `tsc` and `lint` clean.

Touches `route-trace.ts`, which #89 also edits — trivially separable regions, but worth merging in a deliberate order.
