### PR TITLE
A fixture that only changes when something did

### DIFF
--- a/src/lib/__fixtures__/live-route-status.json
+++ b/src/lib/__fixtures__/live-route-status.json
@@ -7,7 +7,7 @@
       },
       "conditions": [
         {
-          "lastTransitionTime": "2026-08-30T07:48:36Z",
+          "lastTransitionTime": "2026-08-30T00:00:00Z",
           "message": "claimed",
           "observedGeneration": 1,
           "reason": "Accepted",
@@ -32,7 +32,7 @@
       "className": "netbird-private",
       "conditions": [
         {
-          "lastTransitionTime": "2026-08-30T07:48:36Z",
+          "lastTransitionTime": "2026-08-30T00:00:00Z",
           "message": "ok",
           "observedGeneration": 1,
           "reason": "Accepted",
@@ -40,7 +40,7 @@
           "type": "Accepted"
         },
         {
-          "lastTransitionTime": "2026-08-30T07:48:36Z",
+          "lastTransitionTime": "2026-08-30T00:00:00Z",
           "message": "programmed",
           "observedGeneration": 1,
           "reason": "Programmed",
@@ -58,7 +58,7 @@
           "certificateRefs": [],
           "conditions": [
             {
-              "lastTransitionTime": "2026-08-30T07:48:36Z",
+              "lastTransitionTime": "2026-08-30T00:00:00Z",
               "message": "ok",
               "observedGeneration": null,
               "reason": "Accepted",
@@ -66,7 +66,7 @@
               "type": "Accepted"
             },
             {
-              "lastTransitionTime": "2026-08-30T07:48:36Z",
+              "lastTransitionTime": "2026-08-30T00:00:00Z",
               "message": "ok",
               "observedGeneration": null,
               "reason": "Programmed",
@@ -74,7 +74,7 @@
               "type": "Programmed"
             },
             {
-              "lastTransitionTime": "2026-08-30T07:48:36Z",
+              "lastTransitionTime": "2026-08-30T00:00:00Z",
               "message": "ok",
               "observedGeneration": null,
               "reason": "ResolvedRefs",

--- a/test-manifests/no-route-status-play-controller.sh
+++ b/test-manifests/no-route-status-play-controller.sh
@@ -5,7 +5,11 @@
 set -euo pipefail
 
 CTX="${K8S_GUI_SHAPE_CONTEXT:-kind-rubick-gw}"
-NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# Fixed, not `date`. The fixture this scene produces is committed, and a
+# wall-clock stamp made every regeneration a diff — which would bury a real
+# change in noise the one time it mattered. Kubernetes does not care what the
+# value is, only that it parses.
+NOW="2026-08-30T00:00:00Z"
 
 kubectl --context "$CTX" patch gatewayclass netbird-private --subresource=status --type=merge -p \
   "{\"status\":{\"conditions\":[{\"type\":\"Accepted\",\"status\":\"True\",\"reason\":\"Accepted\",\"lastTransitionTime\":\"$NOW\",\"observedGeneration\":1,\"message\":\"claimed\"}]}}"


### PR DESCRIPTION
The script that plays the controller for `no-route-status.yaml` stamped its conditions with `date -u`, so regenerating the committed fixture always produced a diff — six changed lines, all timestamps.

That is noise in the one file whose whole value is that a diff means something: the fixture is the backend's own output, so a change to it should mean the Rust side started reading that cluster differently. Buried in timestamp churn, the one time it mattered nobody would look.

Fixed stamp instead. Kubernetes only cares that the value parses.

Verified by running the regeneration twice: the second one changes nothing.