### PR TITLE
The sentences the backend wrote in English

### DIFF
--- a/src-tauri/src/auth/interactive/exec.rs
+++ b/src-tauri/src/auth/interactive/exec.rs
@@ -8,7 +8,7 @@
 
 use crate::commands::kubectl::kubectl_manager;
 use crate::error::{AuthError, Error, Result};
-use crate::state::{AppEvent, AppState};
+use crate::state::{AppEvent, AppState, AuthOutcome};
 use kube::config::{ExecAuthCluster, ExecConfig, ExecInteractiveMode};
 use std::collections::HashMap;
 use std::fmt::Write as _;
@@ -122,7 +122,7 @@ pub(super) async fn run_exec_auth(
             state.emit(AppEvent::AuthFlowCancelled {
                 session_id: session_id.clone(),
                 context: context.to_string(),
-                message: Some("Authentication cancelled.".to_string()),
+                why: None,
             });
             return Err(Error::Auth(AuthError::Kubeconfig(
                 "Authentication cancelled".to_string(),
@@ -244,7 +244,7 @@ pub(super) async fn run_exec_auth(
                 state.emit(AppEvent::AuthFlowCancelled {
                     session_id,
                     context: context.to_string(),
-                    message: Some("Authentication cancelled.".to_string()),
+                    why: None,
                 });
                 return Err(Error::Auth(AuthError::Kubeconfig("Authentication cancelled".to_string())));
             }
@@ -257,7 +257,7 @@ pub(super) async fn run_exec_auth(
                 session_id,
                 context: context.to_string(),
                 success: false,
-                message: Some("Authentication timed out.".to_string()),
+                why: Some(AuthOutcome::TimedOut),
             });
             return Err(Error::Timeout("Authentication timed out".to_string()));
         }
@@ -286,7 +286,7 @@ pub(super) async fn run_exec_auth(
             session_id,
             context: context.to_string(),
             success: false,
-            message: Some(msg.clone()),
+            why: Some(AuthOutcome::Said { text: msg.clone() }),
         });
         return Err(Error::Auth(AuthError::Kubeconfig(msg)));
     }
@@ -326,7 +326,7 @@ pub(super) async fn run_exec_auth(
             session_id,
             context: context.to_string(),
             success: false,
-            message: Some("Exec credentials missing token.".to_string()),
+            why: Some(AuthOutcome::NoTokenInCredential),
         });
         return Err(Error::Auth(AuthError::Kubeconfig(
             "Exec credentials missing token".to_string(),
@@ -337,7 +337,7 @@ pub(super) async fn run_exec_auth(
         session_id,
         context: context.to_string(),
         success: true,
-        message: None,
+        why: None,
     });
 
     Ok(status)

--- a/src-tauri/src/auth/interactive/oidc.rs
+++ b/src-tauri/src/auth/interactive/oidc.rs
@@ -7,7 +7,7 @@ use crate::auth::kubeconfig_tokens::{
 };
 use crate::auth::{AuthProvider as _, AuthResult, OidcAuth};
 use crate::error::{AuthError, Error, Result};
-use crate::state::{AppEvent, AppState};
+use crate::state::{AppEvent, AppState, AuthOutcome};
 use base64::Engine as _;
 use kube::config::AuthProviderConfig;
 use std::collections::HashMap;
@@ -228,7 +228,7 @@ pub(super) async fn run_oidc_auth(
             state.emit(AppEvent::AuthFlowCancelled {
                 session_id,
                 context: context.to_string(),
-                message: Some("Authentication cancelled.".to_string()),
+                why: None,
             });
             return Err(Error::Auth(AuthError::Oidc("Authentication cancelled".to_string())));
         }
@@ -247,7 +247,7 @@ pub(super) async fn run_oidc_auth(
                 session_id,
                 context: context.to_string(),
                 success: false,
-                message: Some(message.clone()),
+                why: Some(AuthOutcome::Said { text: message.clone() }),
             });
             return Err(Error::Timeout(message));
         }
@@ -261,7 +261,9 @@ pub(super) async fn run_oidc_auth(
                 session_id,
                 context: context.to_string(),
                 success: false,
-                message: Some(err.to_string()),
+                why: Some(AuthOutcome::Said {
+                    text: err.to_string(),
+                }),
             });
             return Err(err);
         }
@@ -273,7 +275,7 @@ pub(super) async fn run_oidc_auth(
             session_id,
             context: context.to_string(),
             success: false,
-            message: Some("OIDC state mismatch.".to_string()),
+            why: Some(AuthOutcome::StateMismatch),
         });
         return Err(Error::Auth(AuthError::Oidc(
             "OIDC state mismatch".to_string(),
@@ -289,7 +291,7 @@ pub(super) async fn run_oidc_auth(
         session_id,
         context: context.to_string(),
         success: true,
-        message: None,
+        why: None,
     });
 
     Ok(auth_result)

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -12,7 +12,7 @@ pub fn cancel_auth_session(session_id: String, state: State<'_, AppState>) -> Re
         state.emit(crate::state::AppEvent::AuthFlowCancelled {
             session_id,
             context: session.context,
-            message: Some("Authentication cancelled.".to_string()),
+            why: None,
         });
     }
     Ok(())

--- a/src-tauri/src/commands/certificates.rs
+++ b/src-tauri/src/commands/certificates.rs
@@ -14,7 +14,7 @@ use tauri::State;
 
 use crate::commands::helpers::ResourceContext;
 use crate::error::Result;
-use crate::resources::{read_certificate, CertificateFacts};
+use crate::resources::{read_certificate, CertificateFacts, CertificateProblem};
 use crate::state::AppState;
 
 /// One Secret's certificate, or the stated reason there is none to read.
@@ -26,9 +26,8 @@ use crate::state::AppState;
 pub struct TlsCertificate {
     pub secret_name: String,
     pub certificate: Option<CertificateFacts>,
-    /// Why there is nothing to describe: no such Secret, no `tls.crt` in it,
-    /// or bytes that are not a certificate.
-    pub problem: Option<String>,
+    /// Why there is nothing to describe, named — see [`CertificateProblem`].
+    pub problem: Option<CertificateProblem>,
 }
 
 /// Read the certificate out of each named Secret in one namespace.
@@ -52,12 +51,14 @@ pub async fn get_tls_certificates(
             Err(kube::Error::Api(err)) if err.code == 404 => TlsCertificate {
                 secret_name: name,
                 certificate: None,
-                problem: Some("no Secret of that name in this namespace".to_string()),
+                problem: Some(CertificateProblem::NoSecret),
             },
             Err(err) => TlsCertificate {
                 secret_name: name,
                 certificate: None,
-                problem: Some(format!("the Secret could not be read: {err}")),
+                problem: Some(CertificateProblem::SecretUnreadable {
+                    said: err.to_string(),
+                }),
             },
         });
     }
@@ -76,10 +77,7 @@ fn read_tls_certificate(name: &str, secret: &Secret) -> TlsCertificate {
             Ok(facts) => (Some(facts), None),
             Err(why) => (None, Some(why)),
         },
-        None => (
-            None,
-            Some("this Secret holds no tls.crt, so there is no certificate in it".to_string()),
-        ),
+        None => (None, Some(CertificateProblem::NoTlsCrt)),
     };
 
     TlsCertificate {
@@ -111,11 +109,11 @@ mod tests {
     fn a_secret_without_a_certificate_says_which_way_it_is_empty() {
         let read = read_tls_certificate("app-config", &secret_with("password", b"hunter2"));
         assert!(read.certificate.is_none());
-        assert!(read.problem.unwrap().contains("no tls.crt"));
+        assert_eq!(read.problem, Some(CertificateProblem::NoTlsCrt));
 
         let read = read_tls_certificate("shop-tls", &secret_with("tls.crt", b"garbage"));
         assert!(read.certificate.is_none());
-        assert!(read.problem.unwrap().contains("no PEM certificate"));
+        assert_eq!(read.problem, Some(CertificateProblem::NoPemCertificate));
     }
 
     /// Would break if the private key next to the certificate were ever
@@ -125,6 +123,6 @@ mod tests {
         let key = include_str!("../../tests/fixtures/leaf.key.pem");
         let read = read_tls_certificate("shop-tls", &secret_with("tls.key", key.as_bytes()));
         assert!(read.certificate.is_none());
-        assert!(read.problem.unwrap().contains("no tls.crt"));
+        assert_eq!(read.problem, Some(CertificateProblem::NoTlsCrt));
     }
 }

--- a/src-tauri/src/commands/cluster.rs
+++ b/src-tauri/src/commands/cluster.rs
@@ -115,7 +115,7 @@ pub async fn connect_cluster(context: String, state: State<'_, AppState>) -> Res
         state.emit(crate::state::AppEvent::AuthFlowCancelled {
             session_id,
             context: context.clone(),
-            message: Some("Authentication superseded by a new attempt.".to_string()),
+            why: Some(crate::state::AuthOutcome::Superseded),
         });
     }
 
@@ -200,7 +200,7 @@ pub fn disconnect_cluster(context: String, state: State<'_, AppState>) -> Result
         state.emit(crate::state::AppEvent::AuthFlowCancelled {
             session_id,
             context: context.clone(),
-            message: Some("Authentication cancelled — switched away.".to_string()),
+            why: Some(crate::state::AuthOutcome::SwitchedAway),
         });
     }
 

--- a/src-tauri/src/commands/overview.rs
+++ b/src-tauri/src/commands/overview.rs
@@ -1614,7 +1614,6 @@ mod tests {
                 }]),
                 ..Default::default()
             }),
-            ..Default::default()
         }
     }
 

--- a/src-tauri/src/commands/overview.rs
+++ b/src-tauri/src/commands/overview.rs
@@ -99,6 +99,33 @@ pub enum ProblemSeverity {
     Warning,
 }
 
+/// What the detail line on a problem row says.
+///
+/// Two unlike things arrived in this one field and only one of them may be
+/// translated: most rows quote the object's own status message, which is the
+/// cluster's wording and stays as written, while three are sentences this app
+/// composes. Naming the variant is what lets the reader see the second kind
+/// in their own language without the app rewriting the first.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "says", rename_all = "camelCase")]
+pub enum ProblemDetail {
+    /// The object's own words, quoted.
+    Said { text: String },
+    /// A pod restarting more than the screen tolerates.
+    Restarts { n: i32 },
+    /// A Deployment short of replicas whose own condition said nothing.
+    ReplicasReady { ready: i32, desired: i32 },
+    /// A node marked unschedulable.
+    Unschedulable,
+}
+
+impl ProblemDetail {
+    /// The cluster's own message, where it wrote one.
+    fn said(message: Option<String>) -> Option<Self> {
+        message.map(|text| Self::Said { text })
+    }
+}
+
 /// One actionable row in the problems list. `kind` + `namespace` + `name`
 /// is enough for the frontend to build a deep link to the detail page.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,9 +137,8 @@ pub struct ClusterProblem {
     pub namespace: Option<String>,
     /// Short machine-ish label: `CrashLoopBackOff`, `Pending`, `NotReady`.
     pub reason: String,
-    /// Human sentence explaining the reason, taken from the object's own
-    /// status message where one exists.
-    pub detail: Option<String>,
+    /// Why, named rather than written — see [`ProblemDetail`].
+    pub detail: Option<ProblemDetail>,
     /// RFC3339 timestamp the condition started, for "N minutes ago".
     pub since: Option<String>,
     pub restarts: Option<i32>,
@@ -385,7 +411,7 @@ fn pod_problem(pod: &Pod, now: DateTime<Utc>) -> Option<ClusterProblem> {
             name,
             namespace,
             reason,
-            detail: message,
+            detail: ProblemDetail::said(message),
             since: created,
             restarts: Some(restarts),
         });
@@ -404,7 +430,7 @@ fn pod_problem(pod: &Pod, now: DateTime<Utc>) -> Option<ClusterProblem> {
                 .reason
                 .clone()
                 .unwrap_or_else(|| "Failed".to_string()),
-            detail: status.message.clone(),
+            detail: ProblemDetail::said(status.message.clone()),
             since: created,
             restarts: (restarts > 0).then_some(restarts),
         });
@@ -434,9 +460,11 @@ fn pod_problem(pod: &Pod, now: DateTime<Utc>) -> Option<ClusterProblem> {
             name,
             namespace,
             reason: "Pending".to_string(),
-            detail: scheduled
-                .and_then(|c| c.message.clone())
-                .or_else(|| status.message.clone()),
+            detail: ProblemDetail::said(
+                scheduled
+                    .and_then(|c| c.message.clone())
+                    .or_else(|| status.message.clone()),
+            ),
             since: pending_since.map(|t| t.to_rfc3339()),
             restarts: None,
         });
@@ -454,7 +482,7 @@ fn pod_problem(pod: &Pod, now: DateTime<Utc>) -> Option<ClusterProblem> {
             name,
             namespace,
             reason: "Restarting".to_string(),
-            detail: Some(format!("{restarts} restarts since creation")),
+            detail: Some(ProblemDetail::Restarts { n: restarts }),
             // Dated by the restart, not by the pod. `since: created` put a
             // twelve-day-old date on something that happened minutes ago.
             since: last_restart_at.map(|t| t.to_rfc3339()).or(created),
@@ -499,10 +527,8 @@ fn deployment_problems(deployments: &[Deployment]) -> Vec<ClusterProblem> {
                 name: d.metadata.name.clone().unwrap_or_default(),
                 namespace: d.metadata.namespace.clone(),
                 reason: "NotAvailable".to_string(),
-                detail: condition
-                    .as_ref()
-                    .and_then(|c| c.message.clone())
-                    .or_else(|| Some(format!("{ready}/{desired} replicas ready"))),
+                detail: ProblemDetail::said(condition.as_ref().and_then(|c| c.message.clone()))
+                    .or(Some(ProblemDetail::ReplicasReady { ready, desired })),
                 since: condition
                     .as_ref()
                     .and_then(|c| c.last_transition_time.as_ref())
@@ -532,7 +558,7 @@ fn node_problems(nodes: &[Node]) -> Vec<ClusterProblem> {
                     name,
                     namespace: None,
                     reason: "NotReady".to_string(),
-                    detail: condition.as_ref().and_then(|c| c.message.clone()),
+                    detail: ProblemDetail::said(condition.as_ref().and_then(|c| c.message.clone())),
                     since: condition
                         .as_ref()
                         .and_then(|c| c.last_transition_time.as_ref())
@@ -553,7 +579,7 @@ fn node_problems(nodes: &[Node]) -> Vec<ClusterProblem> {
                     name,
                     namespace: None,
                     reason: "Cordoned".to_string(),
-                    detail: Some("Marked unschedulable — no new pods will land here".to_string()),
+                    detail: Some(ProblemDetail::Unschedulable),
                     since: None,
                     restarts: None,
                 });
@@ -1098,8 +1124,8 @@ mod tests {
     use k8s_openapi::api::batch::v1::{JobCondition, JobStatus};
     use k8s_openapi::api::core::v1::{
         Container, ContainerState, ContainerStateRunning, ContainerStateTerminated,
-        ContainerStateWaiting, ContainerStatus, NodeStatus, PodCondition, PodSpec, PodStatus,
-        ResourceRequirements,
+        ContainerStateWaiting, ContainerStatus, NodeCondition, NodeSpec, NodeStatus, PodCondition,
+        PodSpec, PodStatus, ResourceRequirements,
     };
     use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
@@ -1455,8 +1481,10 @@ mod tests {
         assert_eq!(problems[0].severity, ProblemSeverity::Critical);
         assert_eq!(problems[0].reason, "Evicted");
         assert_eq!(
-            problems[0].detail.as_deref(),
-            Some("The node was low on resource: memory")
+            problems[0].detail,
+            Some(ProblemDetail::Said {
+                text: "The node was low on resource: memory".to_string()
+            })
         );
     }
 
@@ -1532,6 +1560,62 @@ mod tests {
         assert_eq!(problems.len(), 1);
         assert_eq!(problems[0].reason, "Restarting");
         assert_eq!(problems[0].restarts, Some(7));
+    }
+
+    /// The distinction the field exists for. A row that quotes the cluster
+    /// has to keep the cluster's wording; a row this app composes has to
+    /// arrive as a name, or the reader's language never reaches it. Both
+    /// were `Option<String>` once, which is exactly how three English
+    /// sentences ended up on the first screen of a Russian interface.
+    #[test]
+    fn our_sentences_are_named_and_the_cluster_is_quoted() {
+        let now = Utc::now();
+
+        let ours = pod_problems(&[restarted_pod("flapper", now, 7, Some(120))], now);
+        assert_eq!(ours[0].detail, Some(ProblemDetail::Restarts { n: 7 }));
+
+        let cordoned = node_problems(&[unschedulable_node("worker-1")]);
+        assert_eq!(cordoned[0].detail, Some(ProblemDetail::Unschedulable));
+
+        let quoted = pod_problems(
+            &[pod(
+                "migrate",
+                PodStatus {
+                    phase: Some("Failed".to_string()),
+                    message: Some("The node was low on resource: memory".to_string()),
+                    ..Default::default()
+                },
+            )],
+            now,
+        );
+        assert_eq!(
+            quoted[0].detail,
+            Some(ProblemDetail::Said {
+                text: "The node was low on resource: memory".to_string()
+            })
+        );
+    }
+
+    fn unschedulable_node(name: &str) -> Node {
+        Node {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                ..Default::default()
+            },
+            spec: Some(NodeSpec {
+                unschedulable: Some(true),
+                ..Default::default()
+            }),
+            status: Some(NodeStatus {
+                conditions: Some(vec![NodeCondition {
+                    type_: "Ready".to_string(),
+                    status: "True".to_string(),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
     }
 
     /// The row shows the age of `since`. Dating it by the pod put "12d" on

--- a/src-tauri/src/integrations/cert_manager/mod.rs
+++ b/src-tauri/src/integrations/cert_manager/mod.rs
@@ -47,6 +47,37 @@ pub fn detect(crds: &[CustomResourceDefinition]) -> DetectedExtension {
 
 // --- the story --------------------------------------------------------
 
+/// What makes a step this step: the domain being proved, the revision
+/// being requested.
+///
+/// Named rather than written — the words belong to the reader's language,
+/// and the parts that are the cluster's (a challenge type, a domain) ride
+/// through as values.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "says", rename_all = "camelCase")]
+pub enum StepNote {
+    /// The controller's own message, quoted.
+    Said { text: String },
+    /// Which attempt at the certificate this request is.
+    Attempt { revision: i64 },
+    /// The challenge type and the domain it proves.
+    ChallengeOn { kind: String, domain: String },
+}
+
+/// Which object in the chain has not finished, in one short clause.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "says", rename_all = "camelCase")]
+pub enum Stalled {
+    /// Nothing has asked for the certificate yet.
+    NotRequested,
+    /// A request exists and no Order came of it.
+    RequestNotIssued,
+    /// A challenge is outstanding.
+    ChallengePending { kind: String, domain: String },
+    /// The Order itself has not finished.
+    OrderNotCompleted,
+}
+
 /// One object on the way from "I want a certificate" to a certificate.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -57,9 +88,8 @@ pub struct IssuanceStep {
     /// `errored`. Passed through rather than translated — a paraphrase of a
     /// controller's own state is a guess the reader cannot check.
     pub state: String,
-    /// What makes this step this step: the domain being proved, the
-    /// revision being requested.
-    pub note: Option<String>,
+    /// What makes this step this step, named — see [`StepNote`].
+    pub note: Option<StepNote>,
     /// Whether the walk stops here.
     pub failed: bool,
 }
@@ -84,10 +114,10 @@ pub struct IssuanceStory {
     /// Verbatim — a paraphrase of a controller's own words is a guess the
     /// reader cannot check.
     pub failure: Option<String>,
-    /// Which object has not finished, in one short clause. The verbatim
-    /// reason above runs to three wrapped lines of ACME URLs, which is
-    /// right on a page and wrong on a chain hop.
-    pub stalled: Option<String>,
+    /// Which object has not finished, in one short clause — see
+    /// [`Stalled`]. The verbatim reason above runs to three wrapped lines
+    /// of ACME URLs, which is right on a page and wrong on a chain hop.
+    pub stalled: Option<Stalled>,
     /// When the attempt now in flight started.
     pub since: Option<String>,
     /// `status.failedIssuanceAttempts` — how many times this has gone round.
@@ -169,7 +199,10 @@ pub async fn get_certificate_issuance(
         state: issuing
             .as_ref()
             .map_or_else(|| "pending".to_string(), |c| c.reason.clone()),
-        note: issuing.as_ref().and_then(|c| c.message.clone()),
+        note: issuing
+            .as_ref()
+            .and_then(|c| c.message.clone())
+            .map(|text| StepNote::Said { text }),
         failed: false,
     });
     let mut deepest = ready.as_ref().and_then(|c| c.message.clone());
@@ -188,7 +221,7 @@ pub async fn get_certificate_issuance(
 
     let Some(request) = request else {
         story.failure = deepest;
-        story.stalled = Some("no certificate has been requested yet".to_string());
+        story.stalled = Some(Stalled::NotRequested);
         return Ok(Some(story));
     };
     let request_ready = condition(&request.data, "Ready");
@@ -204,7 +237,7 @@ pub async fn get_certificate_issuance(
         state: request_ready
             .as_ref()
             .map_or_else(|| "pending".to_string(), |c| c.reason.to_lowercase()),
-        note: revision_of(&request).map(|revision| format!("attempt {revision}")),
+        note: revision_of(&request).map(|revision| StepNote::Attempt { revision }),
         failed: request_failed,
     });
 
@@ -225,7 +258,7 @@ pub async fn get_certificate_issuance(
 
     let Some(order) = order else {
         story.failure = deepest;
-        story.stalled = Some("the certificate request has not been issued".to_string());
+        story.stalled = Some(Stalled::RequestNotIssued);
         return Ok(Some(story));
     };
     let order_state = string_at(&order.data, &["status", "state"]).unwrap_or_default();
@@ -255,21 +288,20 @@ pub async fn get_certificate_issuance(
         }
         let kind = string_at(&challenge.data, &["spec", "type"]).unwrap_or_default();
         let domain = string_at(&challenge.data, &["spec", "dnsName"]).unwrap_or_default();
-        story.stalled = Some(format!(
-            "the {kind} challenge on {domain} has not completed"
-        ));
+        story.stalled = Some(Stalled::ChallengePending {
+            kind: kind.clone(),
+            domain: domain.clone(),
+        });
         story.steps.push(IssuanceStep {
             kind: "Challenge".to_string(),
             name: challenge.name_any(),
             state: state.clone(),
-            note: Some(format!("{kind} on {domain}")),
+            note: Some(StepNote::ChallengeOn { kind, domain }),
             failed: matches!(state.as_str(), "invalid" | "errored" | "expired"),
         });
     }
 
-    story.stalled = story
-        .stalled
-        .or_else(|| Some("the ACME order has not completed".to_string()));
+    story.stalled = story.stalled.or(Some(Stalled::OrderNotCompleted));
     story.failure = deepest;
     Ok(Some(story))
 }

--- a/src-tauri/src/integrations/loki/mod.rs
+++ b/src-tauri/src/integrations/loki/mod.rs
@@ -86,6 +86,12 @@ pub struct LokiProbe {
     /// Present only on failure, in the server's own words.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Nothing was configured to probe. Separate from `reason`, which is
+    /// the server's own words and has to survive untranslated: this is the
+    /// app's own observation, so the frontend says it in the reader's
+    /// language rather than receiving an English sentence here.
+    #[serde(default)]
+    pub no_address: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
     /// How far back this Loki says it keeps lines — **only where it said
@@ -257,7 +263,8 @@ pub async fn probe_loki(
                     ok: false,
                     at: now_ms(),
                     latency_ms: 0,
-                    reason: Some("no address configured".into()),
+                    reason: None,
+                    no_address: true,
                     version: None,
                     retention: None,
                     labels: Vec::new(),
@@ -296,6 +303,7 @@ pub async fn probe_loki(
                 at: now_ms(),
                 latency_ms,
                 reason: None,
+                no_address: false,
                 version,
                 retention,
                 labels,
@@ -306,6 +314,7 @@ pub async fn probe_loki(
             at: now_ms(),
             latency_ms,
             reason: Some(reason),
+            no_address: false,
             version: None,
             retention: None,
             labels: Vec::new(),

--- a/src-tauri/src/integrations/prometheus/mod.rs
+++ b/src-tauri/src/integrations/prometheus/mod.rs
@@ -79,6 +79,12 @@ pub struct PrometheusProbe {
     /// Present only on failure.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Nothing was configured to probe. Separate from `reason`, which is
+    /// the server's own words and has to survive untranslated: this is the
+    /// app's own observation, so the frontend says it in the reader's
+    /// language rather than receiving an English sentence here.
+    #[serde(default)]
+    pub no_address: bool,
     /// The build version, where `/api/v1/status/buildinfo` answered.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
@@ -230,7 +236,8 @@ pub async fn probe_prometheus(
                     ok: false,
                     at: now_ms(),
                     latency_ms: 0,
-                    reason: Some("no address configured".into()),
+                    reason: None,
+                    no_address: true,
                     version: None,
                 })
             }
@@ -258,6 +265,7 @@ pub async fn probe_prometheus(
                 at: now_ms(),
                 latency_ms,
                 reason: None,
+                no_address: false,
                 version,
             })
         }
@@ -266,6 +274,7 @@ pub async fn probe_prometheus(
             at: now_ms(),
             latency_ms,
             reason: Some(reason),
+            no_address: false,
             version: None,
         }),
     }

--- a/src-tauri/src/metrics/parse.rs
+++ b/src-tauri/src/metrics/parse.rs
@@ -36,10 +36,10 @@ pub(super) fn metrics_status_from_error(err: &kube::Error) -> MetricsStatus {
             },
             _ => MetricsStatus {
                 status: MetricsStatusKind::Error,
-                message: Some(format!(
-                    "Metrics API error {}: {}",
-                    api_err.code, api_err.message
-                )),
+                // The banner's title already says this is a metrics error,
+                // in the reader's language. What is left to add is the
+                // server's own code and words.
+                message: Some(format!("{}: {}", api_err.code, api_err.message)),
             },
         },
         _ => MetricsStatus {

--- a/src-tauri/src/resources/connections.rs
+++ b/src-tauri/src/resources/connections.rs
@@ -436,14 +436,32 @@ pub struct ResourceConnections {
 #[serde(rename_all = "camelCase")]
 pub struct UnexploredKind {
     pub kind: String,
-    pub why: String,
+    pub why: Unread,
+}
+
+/// Why a kind went unread, named rather than written.
+///
+/// The sentence belongs to the reader's language and this runs before the
+/// backend knows what that is. `Unanswered` carries the API server's own
+/// refusal inside it — that half stays exactly as the cluster wrote it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "says", rename_all = "camelCase")]
+pub enum Unread {
+    /// The app asked for this version and got no usable answer.
+    Unanswered { version: String, said: String },
+    /// The claims held by the pods on a node — one list per namespace, not
+    /// made here.
+    NodeClaimsNotRead,
+    /// What mounts a volume's claim — one list in the claim's namespace,
+    /// which is the claim's own page.
+    VolumeMountsNotRead,
 }
 
 impl UnexploredKind {
-    fn new(kind: &str, why: &str) -> Self {
+    fn new(kind: &str, why: Unread) -> Self {
         Self {
             kind: kind.to_string(),
-            why: why.to_string(),
+            why,
         }
     }
 
@@ -457,9 +475,10 @@ impl UnexploredKind {
     pub fn unanswered(kind: &str, version: &str, why: &str) -> Self {
         Self::new(
             kind,
-            &format!(
-                "the app asked for {version} and the cluster did not answer ({why}), so it cannot say whether one applies here"
-            ),
+            Unread::Unanswered {
+                version: version.to_string(),
+                said: why.to_string(),
+            },
         )
     }
 
@@ -496,7 +515,7 @@ impl UnexploredKind {
         let mut unread = Self::governance(None, budgets);
         unread.push(Self::new(
             "PersistentVolumeClaim",
-            "the app does not read the claims the pods on this node hold, so it cannot say which volumes would have to detach before those pods start elsewhere",
+            Unread::NodeClaimsNotRead,
         ));
         unread
     }
@@ -510,10 +529,7 @@ impl UnexploredKind {
     /// a read made here on every open.
     #[must_use]
     pub fn on_a_volume() -> Vec<Self> {
-        vec![Self::new(
-            "Pod",
-            "the app does not read what mounts this volume's claim, so it cannot say whether anything is still writing to it",
-        )]
+        vec![Self::new("Pod", Unread::VolumeMountsNotRead)]
     }
 }
 
@@ -780,8 +796,13 @@ mod tests {
         let unread = UnexploredKind::governance(Some("404 Not Found"), None);
         assert_eq!(unread.len(), 1);
         assert_eq!(unread[0].kind, "HorizontalPodAutoscaler");
-        assert!(unread[0].why.contains("autoscaling/v2"));
-        assert!(unread[0].why.contains("404 Not Found"));
+        assert_eq!(
+            unread[0].why,
+            Unread::Unanswered {
+                version: "autoscaling/v2".to_string(),
+                said: "404 Not Found".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/src-tauri/src/resources/tls.rs
+++ b/src-tauri/src/resources/tls.rs
@@ -43,7 +43,27 @@ pub struct CertificateFacts {
 /// Stated rather than left blank: "this Ingress has no readable certificate"
 /// and "the app did not look" are different claims, and only one of them
 /// belongs to the app.
-pub type CertificateProblem = String;
+///
+/// Named rather than written, because the reader's language is not in scope
+/// here and never can be — this runs in the backend, before anything knows
+/// who is reading. The two variants that quote the API server carry its
+/// words untouched; the rest are the app's own sentence and it is the
+/// frontend that chooses it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "says", rename_all = "camelCase")]
+pub enum CertificateProblem {
+    /// The namespace has no Secret of that name.
+    NoSecret,
+    /// The Secret exists and the API server refused or failed the read.
+    SecretUnreadable { said: String },
+    /// A Secret with no `tls.crt` key in it.
+    NoTlsCrt,
+    /// A `tls.crt` with no PEM certificate anywhere in it — a key on its
+    /// own, most often.
+    NoPemCertificate,
+    /// PEM that is not a certificate this app can parse.
+    Unparseable { said: String },
+}
 
 /// Read the leaf certificate out of a PEM bundle.
 ///
@@ -64,11 +84,14 @@ pub fn read_certificate(pem_bytes: &[u8]) -> Result<CertificateFacts, Certificat
     }
 
     let Some(leaf) = blocks.first() else {
-        return Err("tls.crt holds no PEM certificate".to_string());
+        return Err(CertificateProblem::NoPemCertificate);
     };
 
-    let (_, cert) = X509Certificate::from_der(&leaf.contents)
-        .map_err(|err| format!("tls.crt is not a certificate the app can read: {err}"))?;
+    let (_, cert) = X509Certificate::from_der(&leaf.contents).map_err(|err| {
+        CertificateProblem::Unparseable {
+            said: err.to_string(),
+        }
+    })?;
 
     let subject = first_common_name(cert.subject());
     let issuer = issuer_name(cert.issuer());

--- a/src-tauri/src/resources/tls.rs
+++ b/src-tauri/src/resources/tls.rs
@@ -161,6 +161,14 @@ fn first_common_name(name: &X509Name) -> Option<String> {
         .filter(|cn| !cn.is_empty())
 }
 
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().fold(String::new(), |mut out, byte| {
+        let _ = write!(out, "{byte:02x}");
+        out
+    })
+}
+
 fn format_ip(bytes: &[u8]) -> String {
     match bytes.len() {
         4 => bytes
@@ -175,7 +183,10 @@ fn format_ip(bytes: &[u8]) -> String {
                 .collect();
             groups.join(":")
         }
-        _ => "an address the app cannot render".to_string(),
+        // Neither 4 nor 16 bytes is not a length any address has, and the
+        // bytes themselves say more than a sentence about them would — and
+        // say it in every language.
+        _ => format!("0x{}", hex(bytes)),
     }
 }
 

--- a/src-tauri/src/state/events.rs
+++ b/src-tauri/src/state/events.rs
@@ -164,6 +164,29 @@ pub fn readable_cause(error: &crate::error::Error) -> String {
     }
 }
 
+/// Why an interactive sign-in ended without a credential.
+///
+/// `Said` is the provider's or the helper's own words and is quoted; the
+/// rest are the app's own observation, named so the reader sees them in
+/// their own language. A plain cancellation carries nothing: the toast
+/// already says the flow was cancelled, in the reader's language.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "says", rename_all = "camelCase")]
+pub enum AuthOutcome {
+    /// The provider's or the credential helper's own words.
+    Said { text: String },
+    /// The wait for the browser ran out.
+    TimedOut,
+    /// The exec plugin answered without a token in it.
+    NoTokenInCredential,
+    /// The callback's `state` did not match the one sent.
+    StateMismatch,
+    /// A newer attempt on the same context took over.
+    Superseded,
+    /// The reader moved to another cluster while this was waiting.
+    SwitchedAway,
+}
+
 /// Events that can be broadcast to frontend
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(tag = "type", content = "data")]
@@ -276,13 +299,13 @@ pub enum AppEvent {
         session_id: String,
         context: String,
         success: bool,
-        message: Option<String>,
+        why: Option<AuthOutcome>,
     },
     /// Auth flow cancelled
     AuthFlowCancelled {
         session_id: String,
         context: String,
-        message: Option<String>,
+        why: Option<AuthOutcome>,
     },
     /// Auth terminal session created (for interactive exec auth)
     AuthTerminalSessionCreated {
@@ -450,21 +473,21 @@ impl AppEvent {
                 session_id,
                 context,
                 success,
-                message,
+                why,
             } => serde_json::json!({
                 "session_id": session_id,
                 "context": context,
                 "success": success,
-                "message": message,
+                "why": why,
             }),
             AppEvent::AuthFlowCancelled {
                 session_id,
                 context,
-                message,
+                why,
             } => serde_json::json!({
                 "session_id": session_id,
                 "context": context,
-                "message": message,
+                "why": why,
             }),
             AppEvent::AuthTerminalSessionCreated {
                 auth_session_id,
@@ -542,7 +565,7 @@ mod tests {
                 session_id: "auth-1".into(),
                 context: "infra-eu1".into(),
                 success: true,
-                message: None,
+                why: None,
             },
             AppEvent::Error {
                 code: "X".into(),

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -11,8 +11,8 @@ mod events;
 mod sessions;
 
 pub use events::{
-    is_missing_previous_run, readable_cause, AppEvent, LogLineEvent, StreamFailureKind,
-    WatchChange, WatchOp,
+    is_missing_previous_run, readable_cause, AppEvent, AuthOutcome, LogLineEvent,
+    StreamFailureKind, WatchChange, WatchOp,
 };
 pub use sessions::{AuthSessionControl, LogStream, PortForwardSession, Session};
 

--- a/src-tauri/tests/live_connections.rs
+++ b/src-tauri/tests/live_connections.rs
@@ -67,7 +67,7 @@ fn describe(what: &str, answer: &ResourceConnections) {
         println!("  STOP {stop:?}");
     }
     for gap in &answer.not_looked_at {
-        println!("  not looked at: {} — {}", gap.kind, gap.why);
+        println!("  not looked at: {} — {:?}", gap.kind, gap.why);
     }
 }
 

--- a/src/components/logs/LogViewer.tsx
+++ b/src/components/logs/LogViewer.tsx
@@ -132,7 +132,7 @@ function StreamFailureNotice({
   // the container is no longer running, and the exit code, the reason
   // and the time are sitting in the pod's own status the whole while.
   const termination = info ? lastTermination(info) : null;
-  const when = termination ? terminationWhen(termination) : null;
+  const when = termination ? terminationWhen(termination, t) : null;
 
   return (
     <div
@@ -443,7 +443,7 @@ function FocusNotice({
 function FinishedNotice({ container }: { container: ContainerInfo }) {
   const t = useT();
   const termination = lastTermination(container);
-  const when = termination ? terminationWhen(termination) : null;
+  const when = termination ? terminationWhen(termination, t) : null;
   const kind =
     container.phase === "sidecar"
       ? t("empty", "aSidecar")

--- a/src/components/overview/health.test.tsx
+++ b/src/components/overview/health.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 
 import { ProblemsPanel, WarningsPanel } from "./health";
 import type { ClusterProblem, WarningGroup } from "@/generated/types";
+import { useLocaleStore } from "@/stores/localeStore";
 
 const wrap = (ui: ReactNode) => render(<MemoryRouter>{ui}</MemoryRouter>);
 
@@ -27,7 +28,7 @@ const problem: ClusterProblem = {
   name: "meshed-demo",
   namespace: "k8s-gui-test",
   reason: "ScalingReplicaSet",
-  detail: MESSAGE,
+  detail: { says: "said", text: MESSAGE },
   since: new Date().toISOString(),
   restarts: null,
 };
@@ -85,5 +86,61 @@ describe("the overview's two event panels", () => {
     );
 
     expect(screen.getByText("ScalingReplicaSet")).toBeInTheDocument();
+  });
+});
+
+describe("the detail line on a problem row", () => {
+  /** The row carries two unlike things. `said` is the cluster's own
+   *  message and has to survive a language switch untouched; the rest are
+   *  sentences this app composes and have to follow the reader. They were
+   *  one `string` field until 2026-08-30, which is how "Marked
+   *  unschedulable — no new pods will land here" came to sit on the first
+   *  screen of a Russian interface. */
+  it("follows the reader for our words and leaves the cluster's alone", () => {
+    const panel = (problem: ClusterProblem) => (
+      <ProblemsPanel
+        problems={[problem]}
+        problemsTruncated={0}
+        pods={{
+          running: 1,
+          pending: 0,
+          succeeded: 0,
+          failed: 0,
+          unknown: 0,
+          crashLooping: 0,
+        }}
+        nodes={[]}
+      />
+    );
+    const cordoned: ClusterProblem = {
+      severity: "warning",
+      kind: "Node",
+      name: "worker-1",
+      namespace: null,
+      reason: "Cordoned",
+      detail: { says: "unschedulable" },
+      since: null,
+      restarts: null,
+    };
+
+    useLocaleStore.setState({ choice: "en" });
+    const english = wrap(panel(cordoned));
+    expect(english.getByText(/no new pods will land here/)).toBeInTheDocument();
+    english.unmount();
+
+    useLocaleStore.setState({ choice: "ru" });
+    const russian = wrap(panel(cordoned));
+    expect(russian.getByText(/новые поды сюда не поедут/)).toBeInTheDocument();
+    expect(russian.queryByText(/no new pods/)).toBeNull();
+    russian.unmount();
+
+    // And the cluster's own sentence is still linkified, not looked up.
+    useLocaleStore.setState({ choice: "ru" });
+    const quoted = wrap(panel(problem));
+    expect(
+      quoted.getByRole("link", { name: "ReplicaSet meshed-demo-65d47b457f" })
+    ).toBeInTheDocument();
+    quoted.unmount();
+    useLocaleStore.setState({ choice: null });
   });
 });

--- a/src/components/overview/health.tsx
+++ b/src/components/overview/health.tsx
@@ -18,12 +18,37 @@ import type {
   ClusterOverview,
   ClusterProblem,
   NodeSummary,
+  ProblemDetail,
   PodComposition,
   ResourcePressure,
   SchedulerPressure,
   WarningGroup,
 } from "@/generated/types";
-import { useT } from "@/i18n/useT";
+import { useT, type T } from "@/i18n/useT";
+
+/**
+ * The detail line, for the rows this app writes itself.
+ *
+ * The `said` variant is deliberately not here: it carries the cluster's own
+ * message, which {@link ResourceMessage} draws with the object names in it
+ * turned into links. Only the sentences the app composes are looked up.
+ */
+function composedDetail(
+  detail: Exclude<ProblemDetail, { says: "said" }>,
+  t: T
+): string {
+  switch (detail.says) {
+    case "restarts":
+      return t("readings", "problemRestarts", { n: detail.n });
+    case "replicasReady":
+      return t("readings", "problemReplicasReady", {
+        ready: detail.ready,
+        desired: detail.desired,
+      });
+    case "unschedulable":
+      return t("readings", "problemUnschedulable");
+  }
+}
 
 /** Reserved share past which the scheduler is the binding constraint. */
 const PRESSURE_WARN = 0.85;
@@ -161,14 +186,18 @@ function ProblemRow({ problem }: { problem: ClusterProblem }) {
         {problem.detail && (
           <span className="text-fg-fnt">
             {" — "}
-            <ResourceMessage
-              message={problem.detail}
-              subject={{
-                kind: problem.kind,
-                name: problem.name,
-                namespace: problem.namespace,
-              }}
-            />
+            {problem.detail.says === "said" ? (
+              <ResourceMessage
+                message={problem.detail.text}
+                subject={{
+                  kind: problem.kind,
+                  name: problem.name,
+                  namespace: problem.namespace,
+                }}
+              />
+            ) : (
+              composedDetail(problem.detail, t)
+            )}
           </span>
         )}
       </span>

--- a/src/components/overview/health.tsx
+++ b/src/components/overview/health.tsx
@@ -216,7 +216,7 @@ function ProblemRow({ problem }: { problem: ClusterProblem }) {
         )}
       </span>
       <span className="text-right text-[11px] text-fg-fnt">
-        {formatAge(problem.since)}
+        {formatAge(problem.since, t)}
       </span>
     </>
   );
@@ -631,6 +631,7 @@ export function WarningsPanel({ warnings }: { warnings: WarningGroup[] }) {
 }
 
 function WarningRow({ warning }: { warning: WarningGroup }) {
+  const t = useT();
   // Every row here is a Warning, so severity owns the colour outright and the
   // family mark contributes only shape — the feed's rule, applied to the one
   // event surface that was still rendering a reason as a bare word.
@@ -682,7 +683,7 @@ function WarningRow({ warning }: { warning: WarningGroup }) {
         )}
       </span>
       <span className="text-right text-[11px] text-fg-fnt">
-        {formatAge(warning.lastSeen)}
+        {formatAge(warning.lastSeen, t)}
       </span>
     </div>
   );

--- a/src/components/resources/CertificateFacts.tsx
+++ b/src/components/resources/CertificateFacts.tsx
@@ -15,6 +15,7 @@ import {
   expiryOf,
   expiryText,
   issuedBy,
+  problemWords,
   uncoveredHosts,
 } from "@/lib/certificates";
 import { TONE_CLASS } from "./key-values";
@@ -51,7 +52,11 @@ export function CertificateLine({
     );
   }
   if (!read.certificate) {
-    return <span className="text-[11px] text-warn">{read.problem}</span>;
+    return (
+      <span className="block text-[11px] text-warn">
+        {read.problem && problemWords(read.problem, t)}
+      </span>
+    );
   }
 
   const cert = read.certificate;
@@ -102,7 +107,9 @@ export function CertificateSection({
     return (
       <Section>
         <SectionHeader title={t("columns", "certificate")} />
-        <p className="text-xs text-warn">{read.problem}</p>
+        <p className="text-xs text-warn">
+          {read.problem && problemWords(read.problem, t)}
+        </p>
       </Section>
     );
   }

--- a/src/components/resources/ConnectionsPanel.test.tsx
+++ b/src/components/resources/ConnectionsPanel.test.tsx
@@ -69,11 +69,15 @@ describe("ConnectionsPanel", () => {
             notLookedAt: [
               {
                 kind: "HorizontalPodAutoscaler",
-                why: "the app does not read HorizontalPodAutoscalers, so it cannot say whether one scales this",
+                why: {
+                  says: "unanswered",
+                  version: "autoscaling/v2",
+                  said: "404",
+                },
               },
               {
                 kind: "PodDisruptionBudget",
-                why: "the app does not read PodDisruptionBudgets, so it cannot say what protects this during a drain",
+                why: { says: "unanswered", version: "policy/v1", said: "403" },
               },
             ],
           }),
@@ -85,7 +89,9 @@ describe("ConnectionsPanel", () => {
     expect(screen.getByText("Autoscaling")).toBeInTheDocument();
     expect(screen.getByText("Disruption budget")).toBeInTheDocument();
     expect(
-      screen.getByText(/does not read HorizontalPodAutoscalers/)
+      screen.getByText(
+        /asked for autoscaling\/v2 and the cluster did not answer/
+      )
     ).toBeInTheDocument();
   });
 

--- a/src/components/resources/IssuanceChain.test.tsx
+++ b/src/components/resources/IssuanceChain.test.tsx
@@ -109,7 +109,11 @@ describe("IssuanceSection", () => {
                     kind: "Challenge",
                     name: "shop-tls-1-1948-394",
                     state: "invalid",
-                    note: "http-01 on shop.k8s-gui.test",
+                    note: {
+                      says: "challengeOn",
+                      kind: "http-01",
+                      domain: "shop.k8s-gui.test",
+                    },
                     failed: true,
                   },
                 ],

--- a/src/components/resources/IssuanceChain.tsx
+++ b/src/components/resources/IssuanceChain.tsx
@@ -18,6 +18,7 @@
 
 import { Section, SectionHeader } from "@/components/ui/section";
 import { cn } from "@/lib/utils";
+import { stalledWords, stepNoteWords } from "@/lib/certificates";
 import type { Issuance } from "@/hooks/useCertificateIssuance";
 import type { IssuanceStep, IssuanceStory } from "@/generated/types";
 import { T } from "@/i18n/T";
@@ -43,6 +44,7 @@ function issuerLine(story: IssuanceStory): string {
 }
 
 function Step({ step, last }: { step: IssuanceStep; last: boolean }) {
+  const t = useT();
   return (
     <div className="grid grid-cols-[7px_minmax(0,1fr)] gap-x-2.5">
       <div className="flex flex-col items-center">
@@ -67,7 +69,11 @@ function Step({ step, last }: { step: IssuanceStep; last: boolean }) {
             {step.kind} · {step.state}
           </span>
         </span>
-        {step.note && <p className="text-[11px] text-fg-mut">{step.note}</p>}
+        {step.note && (
+          <p className="text-[11px] text-fg-mut">
+            {stepNoteWords(step.note, t)}
+          </p>
+        )}
       </div>
     </div>
   );
@@ -231,7 +237,7 @@ export function RenewalNote({
       {story.since
         ? `, ${t("empty", "startedWhen", { when: relative(t, story.since) })}`
         : ""}
-      {story.stalled ? ` — ${story.stalled}` : ""}
+      {story.stalled ? ` — ${stalledWords(story.stalled, t)}` : ""}
     </p>
   );
 }

--- a/src/components/resources/PodList.tsx
+++ b/src/components/resources/PodList.tsx
@@ -34,6 +34,19 @@ import { useT } from "@/i18n/useT";
 type PodRow = WithNodeSilence<PodWithMetrics>;
 
 /**
+ * How long ago the last restart was.
+ *
+ * A component rather than an expression in the column literal: the age now
+ * needs the translator, and a hook is only legal inside one.
+ */
+function RestartAge({ at }: { at: string }) {
+  const t = useT();
+  return (
+    <T section="action" k="agoSuffix" values={{ age: formatAge(at, t) }} />
+  );
+}
+
+/**
  * A pod on a node that stopped reporting keeps whatever the kubelet last
  * wrote. The label stays kubectl's — this is what the cluster holds — but
  * the colour drops to neutral, because confident green about a machine
@@ -124,12 +137,7 @@ export const columns: ColumnDef<PodRow>[] = [
           <span className="text-fg-fnt">
             {" "}
             (
-            <T
-              section="action"
-              k="agoSuffix"
-              values={{ age: formatAge(row.original.lastRestartAt) }}
-            />
-            )
+            <RestartAge at={row.original.lastRestartAt} />)
           </span>
         )}
       </span>

--- a/src/components/resources/container-rows.tsx
+++ b/src/components/resources/container-rows.tsx
@@ -282,7 +282,7 @@ function ContainerBlock({
     // says when it finished, is the same fact three times.
     const death = step?.mark === "done" ? null : lastTermination(container);
     if (death) {
-      const when = terminationWhen(death);
+      const when = terminationWhen(death, t);
       items.push({
         label: t("columns", "lastExit"),
         value: `${describeTermination(death)}${when ? ` · ${when}` : ""}`,

--- a/src/components/resources/usage-block.test.tsx
+++ b/src/components/resources/usage-block.test.tsx
@@ -66,6 +66,7 @@ const ANSWERED: PrometheusProbe = {
   ok: true,
   at: 1_700_000_000_000,
   latencyMs: 4,
+  noAddress: false,
   version: "2.55.1",
 };
 
@@ -487,6 +488,7 @@ describe("UsageBlock and a history supplier", () => {
       ok: false,
       at: 1_700_000_000_000,
       latencyMs: 12,
+      noAddress: false,
       reason: "no route to host",
     });
 

--- a/src/components/terminal/PodShell.tsx
+++ b/src/components/terminal/PodShell.tsx
@@ -132,7 +132,7 @@ function noShell(pod: PodInfo, t: T): NoShell {
   if (dead.length === all.length && all.length > 0) {
     const last = dead[dead.length - 1];
     const death = lastTermination(last);
-    const when = death ? terminationWhen(death) : null;
+    const when = death ? terminationWhen(death, t) : null;
     return {
       headline,
       hint: null,

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { toSingularNoun } from "@/lib/resource-registry";
 import { useNavigate } from "react-router-dom";
 import {
   flexRender,
@@ -889,7 +890,7 @@ export function DataTable<TData extends RowData>({
               ? t("readings", "rowCount", { n: filteredRows })
               : filteredRows === totalRows
                 ? `${totalRows} ${
-                    totalRows === 1 ? rowLabel.replace(/s$/, "") : rowLabel
+                    totalRows === 1 ? toSingularNoun(rowLabel) : rowLabel
                   }`
                 : t("readings", "rowsOfTotal", {
                     shown: filteredRows,

--- a/src/components/ui/row-grouping.tsx
+++ b/src/components/ui/row-grouping.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { toSingularNoun } from "@/lib/resource-registry";
 
 /**
  * What turns a flat list into captioned runs of it.
@@ -40,7 +41,9 @@ export function byNamespace<TData>(rowLabel: string): RowGrouping<TData> {
         {ns}{" "}
         <span className="font-mono text-fg-mut">
           ·{" "}
-          {`${rows.length} ${rows.length === 1 ? rowLabel.replace(/s$/, "") : rowLabel}`}
+          {`${rows.length} ${
+            rows.length === 1 ? toSingularNoun(rowLabel) : rowLabel
+          }`}
         </span>
       </>
     ),

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -1576,6 +1576,7 @@ export interface PrometheusProbe {
   at: number;
   latencyMs: number;
   reason?: string;
+  noAddress: boolean;
   version?: string;
 }
 
@@ -1601,7 +1602,7 @@ export interface IssuanceStory {
   renewalTime: string | null;
   inFlight: boolean;
   failure: string | null;
-  stalled: string | null;
+  stalled: Stalled | null;
   since: string | null;
   attempts: number | null;
   steps: IssuanceStep[];
@@ -1611,7 +1612,7 @@ export interface IssuanceStep {
   kind: string;
   name: string;
   state: string;
-  note: string | null;
+  note: StepNote | null;
   failed: boolean;
 }
 
@@ -1632,6 +1633,7 @@ export interface LokiProbe {
   at: number;
   latencyMs: number;
   reason?: string;
+  noAddress: boolean;
   version?: string;
   retention?: string;
   labels: string[];
@@ -1842,3 +1844,14 @@ export type CertificateProblem =
   | { says: "noTlsCrt" }
   | { says: "noPemCertificate" }
   | { says: "unparseable"; said: string };
+
+export type StepNote =
+  | { says: "said"; text: string }
+  | { says: "attempt"; revision: number }
+  | { says: "challengeOn"; kind: string; domain: string };
+
+export type Stalled =
+  | { says: "notRequested" }
+  | { says: "requestNotIssued" }
+  | { says: "challengePending"; kind: string; domain: string }
+  | { says: "orderNotCompleted" };

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -238,7 +238,7 @@ export interface ClusterProblem {
   name: string;
   namespace: string | null;
   reason: string;
-  detail: string | null;
+  detail: ProblemDetail | null;
   since: string | null;
   restarts: number | null;
 }
@@ -1674,6 +1674,12 @@ export type ContextAuth =
   | { kind: "basic"; username: string | null }
   | { kind: "authProvider"; name: string }
   | { kind: "unrecognised" };
+
+export type ProblemDetail =
+  | { says: "said"; text: string }
+  | { says: "restarts"; n: number }
+  | { says: "replicasReady"; ready: number; desired: number }
+  | { says: "unschedulable" };
 
 export type ProblemSeverity = "critical" | "warning";
 

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -1044,7 +1044,7 @@ export interface ResourceConnections {
 
 export interface UnexploredKind {
   kind: string;
-  why: string;
+  why: Unread;
 }
 
 export interface ConnectionEdge {
@@ -1761,6 +1761,11 @@ export type ContainerState =
   | { type: "waiting"; reason: string | null }
   | { type: "terminated"; termination: TerminationInfo }
   | { type: "unknown" };
+
+export type Unread =
+  | { says: "unanswered"; version: string; said: string }
+  | { says: "nodeClaimsNotRead" }
+  | { says: "volumeMountsNotRead" };
 
 export type ChainStop =
   | { reason: "backendMissing"; ingress: ObjectRef; service: ObjectRef }

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -1547,7 +1547,7 @@ export interface ListQuery {
 export interface TlsCertificate {
   secretName: string;
   certificate: CertificateFacts | null;
-  problem: string | null;
+  problem: CertificateProblem | null;
 }
 
 export interface CertificateFacts {
@@ -1830,3 +1830,10 @@ export type Usage =
   | { how: "ingressTls"; hosts: string[] };
 
 export type Severity = "blocking" | "misconfigured" | "optional";
+
+export type CertificateProblem =
+  | { says: "noSecret" }
+  | { says: "secretUnreadable"; said: string }
+  | { says: "noTlsCrt" }
+  | { says: "noPemCertificate" }
+  | { says: "unparseable"; said: string };

--- a/src/hooks/useAuthFlowEvents.tsx
+++ b/src/hooks/useAuthFlowEvents.tsx
@@ -3,7 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { open } from "@tauri-apps/plugin-shell";
 import { useToast } from "@/components/ui/use-toast";
-import { useT } from "@/i18n/useT";
+import { useT, type T } from "@/i18n/useT";
 import { ToastAction } from "@/components/ui/toast";
 import { commands } from "@/lib/commands";
 
@@ -18,17 +18,50 @@ interface AuthUrlRequestedPayload {
   redirect_uri?: string | null;
 }
 
+/**
+ * Why a sign-in ended without a credential.
+ *
+ * Hand-mirrored, like every event payload here: the generator only emits
+ * types a command signature reaches, and these arrive on an event. `said`
+ * is the provider's own words and is quoted; the rest are named so the
+ * reader sees them in their own language.
+ */
+type AuthOutcome =
+  | { says: "said"; text: string }
+  | { says: "timedOut" }
+  | { says: "noTokenInCredential" }
+  | { says: "stateMismatch" }
+  | { says: "superseded" }
+  | { says: "switchedAway" };
+
+function outcomeWords(why: AuthOutcome, t: T): string {
+  switch (why.says) {
+    case "said":
+      return why.text;
+    case "timedOut":
+      return t("readings", "authTimedOut");
+    case "noTokenInCredential":
+      return t("readings", "authNoTokenInCredential");
+    case "stateMismatch":
+      return t("readings", "authStateMismatch");
+    case "superseded":
+      return t("readings", "authSuperseded");
+    case "switchedAway":
+      return t("readings", "authSwitchedAway");
+  }
+}
+
 interface AuthFlowCompletedPayload {
   session_id: string;
   context: string;
   success: boolean;
-  message?: string | null;
+  why?: AuthOutcome | null;
 }
 
 interface AuthFlowCancelledPayload {
   session_id: string;
   context: string;
-  message?: string | null;
+  why?: AuthOutcome | null;
 }
 
 interface AuthTerminalSessionCreatedPayload {
@@ -293,7 +326,7 @@ export function useAuthFlowEvents() {
             toastRef.current({
               title: tRef.current("auth", "failed"),
               description:
-                payload.message ||
+                (payload.why && outcomeWords(payload.why, tRef.current)) ||
                 tRef.current("auth", "failedFor", { context: payload.context }),
               variant: "destructive",
             });
@@ -319,7 +352,7 @@ export function useAuthFlowEvents() {
           toastRef.current({
             title: tRef.current("auth", "cancelled"),
             description:
-              payload.message ||
+              (payload.why && outcomeWords(payload.why, tRef.current)) ||
               tRef.current("auth", "cancelledFor", {
                 context: payload.context,
               }),

--- a/src/hooks/useRealtimeAge.ts
+++ b/src/hooks/useRealtimeAge.ts
@@ -10,6 +10,7 @@
 import { useSyncExternalStore, useCallback } from "react";
 import { tickStore, type TickChannel } from "@/stores/tickStore";
 import { formatAge } from "@/lib/utils";
+import { useT } from "@/i18n/useT";
 
 /**
  * Determine which tick channel to use based on age in seconds
@@ -48,6 +49,7 @@ function getAgeSeconds(timestamp: string | null): number {
  * ```
  */
 export function useRealtimeAge(timestamp: string | null): string {
+  const t = useT();
   // Calculate initial age and channel
   const ageSeconds = getAgeSeconds(timestamp);
   const channel = getChannelForAge(ageSeconds);
@@ -72,7 +74,7 @@ export function useRealtimeAge(timestamp: string | null): string {
   useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   // Recalculate age on each render (triggered by tick)
-  return formatAge(timestamp);
+  return formatAge(timestamp, t);
 }
 
 /**

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -1699,6 +1699,14 @@ export const en = {
       "the app does not read the claims the pods on this node hold, so it cannot say which volumes would have to detach before those pods start elsewhere",
     unreadVolumeMounts:
       "the app does not read what mounts this volume's claim, so it cannot say whether anything is still writing to it",
+    connNoAddress: "no address is configured",
+    stepAttempt: "attempt {revision}",
+    stepChallengeOn: "{kind} on {domain}",
+    stalledNotRequested: "no certificate has been requested yet",
+    stalledRequestNotIssued: "the certificate request has not been issued",
+    stalledChallengePending:
+      "the {kind} challenge on {domain} has not completed",
+    stalledOrderNotCompleted: "the ACME order has not completed",
     verbatimLine: "{said}",
     gcpStatusOnDomain: "{status} on {domain}",
     awsIngressClassParams: {

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -1680,6 +1680,12 @@ export const en = {
       one: "every {n} hour, at :{minute}",
       other: "every {n} hours, at :{minute}",
     },
+    problemRestarts: {
+      one: "{n} restart since creation",
+      other: "{n} restarts since creation",
+    },
+    problemReplicasReady: "{ready}/{desired} replicas ready",
+    problemUnschedulable: "marked unschedulable — no new pods will land here",
     verbatimLine: "{said}",
     gcpStatusOnDomain: "{status} on {domain}",
     awsIngressClassParams: {

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -1707,6 +1707,11 @@ export const en = {
     stalledChallengePending:
       "the {kind} challenge on {domain} has not completed",
     stalledOrderNotCompleted: "the ACME order has not completed",
+    authTimedOut: "the wait for the browser ran out",
+    authNoTokenInCredential: "the credential helper answered without a token",
+    authStateMismatch: "the callback did not match the request this app sent",
+    authSuperseded: "a newer attempt on this context took over",
+    authSwitchedAway: "you moved to another cluster while this was waiting",
     verbatimLine: "{said}",
     gcpStatusOnDomain: "{status} on {domain}",
     awsIngressClassParams: {

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -1693,6 +1693,12 @@ export const en = {
     certNoPem: "tls.crt holds no PEM certificate",
     certUnparseable: "tls.crt is not a certificate the app can read — {said}",
     certCrossNamespace: "cross-namespace, needs a ReferenceGrant",
+    unreadUnanswered:
+      "the app asked for {version} and the cluster did not answer ({said}), so it cannot say whether one applies here",
+    unreadNodeClaims:
+      "the app does not read the claims the pods on this node hold, so it cannot say which volumes would have to detach before those pods start elsewhere",
+    unreadVolumeMounts:
+      "the app does not read what mounts this volume's claim, so it cannot say whether anything is still writing to it",
     verbatimLine: "{said}",
     gcpStatusOnDomain: "{status} on {domain}",
     awsIngressClassParams: {

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -1686,6 +1686,13 @@ export const en = {
     },
     problemReplicasReady: "{ready}/{desired} replicas ready",
     problemUnschedulable: "marked unschedulable — no new pods will land here",
+    certNoSecret: "no Secret of that name in this namespace",
+    certSecretUnreadable: "the Secret could not be read — {said}",
+    certNoTlsCrt:
+      "this Secret holds no tls.crt, so there is no certificate in it",
+    certNoPem: "tls.crt holds no PEM certificate",
+    certUnparseable: "tls.crt is not a certificate the app can read — {said}",
+    certCrossNamespace: "cross-namespace, needs a ReferenceGrant",
     verbatimLine: "{said}",
     gcpStatusOnDomain: "{status} on {domain}",
     awsIngressClassParams: {

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -1754,6 +1754,12 @@ export const ru: Catalogue = {
     stalledRequestNotIssued: "по запросу сертификат так и не выпущен",
     stalledChallengePending: "проверка {kind} для {domain} не завершилась",
     stalledOrderNotCompleted: "заказ ACME не завершился",
+    authTimedOut: "ожидание браузера вышло",
+    authNoTokenInCredential: "помощник вернул ответ без токена",
+    authStateMismatch:
+      "ответ не совпал с запросом, который отправило приложение",
+    authSuperseded: "эту попытку сменила новая",
+    authSwitchedAway: "вы ушли на другой кластер, пока это ждало",
     verbatimLine: "{said}",
     gcpStatusOnDomain: "{status} на {domain}",
     awsIngressClassParams: {

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -1741,6 +1741,12 @@ export const ru: Catalogue = {
     certUnparseable:
       "tls.crt — не сертификат, который приложение умеет читать — {said}",
     certCrossNamespace: "из другого пространства имён, нужен ReferenceGrant",
+    unreadUnanswered:
+      "приложение спросило {version}, а кластер не ответил ({said}) — значит, сказать, есть ли он здесь, нельзя",
+    unreadNodeClaims:
+      "приложение не читает заявки подов этого узла, поэтому не может сказать, какие тома придётся отцепить, прежде чем эти поды поедут в другое место",
+    unreadVolumeMounts:
+      "приложение не читает, кто монтирует заявку этого тома, поэтому не может сказать, пишет ли в него ещё кто-нибудь",
     verbatimLine: "{said}",
     gcpStatusOnDomain: "{status} на {domain}",
     awsIngressClassParams: {

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -1726,6 +1726,14 @@ export const ru: Catalogue = {
       many: "каждые {n} часов, в :{minute}",
       other: "каждые {n} часа, в :{minute}",
     },
+    problemRestarts: {
+      one: "{n} перезапуск с момента создания",
+      few: "{n} перезапуска с момента создания",
+      many: "{n} перезапусков с момента создания",
+      other: "{n} перезапуска с момента создания",
+    },
+    problemReplicasReady: "готовы {ready} из {desired} реплик",
+    problemUnschedulable: "помечен неназначаемым — новые поды сюда не поедут",
     verbatimLine: "{said}",
     gcpStatusOnDomain: "{status} на {domain}",
     awsIngressClassParams: {

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -1734,6 +1734,13 @@ export const ru: Catalogue = {
     },
     problemReplicasReady: "готовы {ready} из {desired} реплик",
     problemUnschedulable: "помечен неназначаемым — новые поды сюда не поедут",
+    certNoSecret: "в этом пространстве имён нет Secret с таким именем",
+    certSecretUnreadable: "Secret не удалось прочитать — {said}",
+    certNoTlsCrt: "в этом Secret нет tls.crt, а значит нет и сертификата",
+    certNoPem: "в tls.crt нет PEM-сертификата",
+    certUnparseable:
+      "tls.crt — не сертификат, который приложение умеет читать — {said}",
+    certCrossNamespace: "из другого пространства имён, нужен ReferenceGrant",
     verbatimLine: "{said}",
     gcpStatusOnDomain: "{status} на {domain}",
     awsIngressClassParams: {

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -1747,6 +1747,13 @@ export const ru: Catalogue = {
       "приложение не читает заявки подов этого узла, поэтому не может сказать, какие тома придётся отцепить, прежде чем эти поды поедут в другое место",
     unreadVolumeMounts:
       "приложение не читает, кто монтирует заявку этого тома, поэтому не может сказать, пишет ли в него ещё кто-нибудь",
+    connNoAddress: "адрес не задан",
+    stepAttempt: "попытка {revision}",
+    stepChallengeOn: "{kind} для {domain}",
+    stalledNotRequested: "сертификат ещё никто не запросил",
+    stalledRequestNotIssued: "по запросу сертификат так и не выпущен",
+    stalledChallengePending: "проверка {kind} для {domain} не завершилась",
+    stalledOrderNotCompleted: "заказ ACME не завершился",
     verbatimLine: "{said}",
     gcpStatusOnDomain: "{status} на {domain}",
     awsIngressClassParams: {

--- a/src/integrations/argocd/page.tsx
+++ b/src/integrations/argocd/page.tsx
@@ -447,7 +447,7 @@ function AppRow({
             under={
               app.lastSyncAt
                 ? t("empty", "lastSyncedAgo", {
-                    age: formatAge(app.lastSyncAt),
+                    age: formatAge(app.lastSyncAt, t),
                   })
                 : t("empty", "neverSynced")
             }
@@ -492,7 +492,7 @@ function SourceLine({ app }: { app: ArgoApp }) {
             <span className="text-fg-fnt">
               {app.lastSyncAt
                 ? `— ${t("empty", "syncedAgo", {
-                    age: formatAge(app.lastSyncAt),
+                    age: formatAge(app.lastSyncAt, t),
                   })}`
                 : `— ${t("empty", "neverSynced")}`}
             </span>
@@ -811,7 +811,7 @@ function describeFinding(
     case "syncFailing":
       return {
         title: finding.since
-          ? t("empty", "syncFailingFor", { age: formatAge(finding.since) })
+          ? t("empty", "syncFailingFor", { age: formatAge(finding.since, t) })
           : t("empty", "syncFailing"),
         verbatim: finding.message,
         note:
@@ -823,7 +823,9 @@ function describeFinding(
     case "syncFailedOnce":
       return {
         title: finding.since
-          ? t("empty", "lastSyncFailedAgo", { age: formatAge(finding.since) })
+          ? t("empty", "lastSyncFailedAgo", {
+              age: formatAge(finding.since, t),
+            })
           : t("empty", "lastSyncFailed"),
         verbatim: finding.message,
         note: t("empty", "nothingRetryingSync"),
@@ -833,7 +835,7 @@ function describeFinding(
       return {
         title: finding.since
           ? t("empty", "outOfSyncLastSynced", {
-              age: formatAge(finding.since),
+              age: formatAge(finding.since, t),
             })
           : t("empty", "outOfSyncNeverSynced"),
         note: t("empty", "driftedNote"),

--- a/src/integrations/flux/page.tsx
+++ b/src/integrations/flux/page.tsx
@@ -334,7 +334,7 @@ function ReconcilerRow({
                   })
                 : reconciler.lastReconciledAt
                   ? t("action", "agoSuffix", {
-                      age: formatAge(reconciler.lastReconciledAt),
+                      age: formatAge(reconciler.lastReconciledAt, t),
                     })
                   : t("empty", "neverApplied")
             }
@@ -479,7 +479,9 @@ function describe(
     case "suspended":
       return {
         title: finding.at
-          ? t("empty", "fluxSuspendedTitleAgo", { age: formatAge(finding.at) })
+          ? t("empty", "fluxSuspendedTitleAgo", {
+              age: formatAge(finding.at, t),
+            })
           : t("empty", "fluxSuspendedTitle"),
         note: finding.wasReady
           ? t("empty", "fluxSuspendedWasReady", {
@@ -669,7 +671,7 @@ function SourceRow({
         </span>
         <span className="min-w-0 truncate">
           {source.artifact
-            ? `${revisionText(source.artifact.revision, t)}${source.artifact.at ? ` · ${t("action", "agoSuffix", { age: formatAge(source.artifact.at) })}` : ""}`
+            ? `${revisionText(source.artifact.revision, t)}${source.artifact.at ? ` · ${t("action", "agoSuffix", { age: formatAge(source.artifact.at, t) })}` : ""}`
             : t("action", "never")}
         </span>
         <span className="font-mono text-fg-mid">
@@ -737,7 +739,7 @@ function SourceFinding({
                 revision: revisionText(source.artifact?.revision ?? null, t),
                 fetched: source.artifact?.at
                   ? t("empty", "fluxFetchedAgo", {
-                      age: formatAge(source.artifact.at),
+                      age: formatAge(source.artifact.at, t),
                     })
                   : "",
               })

--- a/src/integrations/ingress-nginx/page.tsx
+++ b/src/integrations/ingress-nginx/page.tsx
@@ -75,6 +75,7 @@ import {
   type NginxRoute,
   type NginxSources,
 } from "./model";
+import { problemWords } from "@/lib/certificates";
 import { T } from "@/i18n/T";
 import { useT } from "@/i18n/useT";
 import type { en } from "@/i18n/catalogue";
@@ -989,7 +990,9 @@ function describeFinding(
           title: t("empty", "secretNotACertificate", {
             name: finding.secretName,
           }),
-          note: finding.read?.problem ?? t("empty", "secretNotParsable"),
+          note: finding.read?.problem
+            ? problemWords(finding.read.problem, t)
+            : t("empty", "secretNotParsable"),
         };
       }
       return {

--- a/src/integrations/loki/index.ts
+++ b/src/integrations/loki/index.ts
@@ -97,17 +97,19 @@ export default defineVendor({
           return {
             ok: false,
             at: answer.at,
-            reason: shape
-              ? {
-                  key: "connReasonAndShape",
-                  values: {
-                    said: said ?? "",
-                    shape: explain(shape),
-                  },
-                }
-              : said === null
-                ? { key: "connDidNotSayWhy" }
-                : { key: "verbatimLine", values: { said } },
+            reason: answer.noAddress
+              ? { key: "connNoAddress" }
+              : shape
+                ? {
+                    key: "connReasonAndShape",
+                    values: {
+                      said: said ?? "",
+                      shape: explain(shape),
+                    },
+                  }
+                : said === null
+                  ? { key: "connDidNotSayWhy" }
+                  : { key: "verbatimLine", values: { said } },
           };
         }
         return {

--- a/src/integrations/prometheus/index.ts
+++ b/src/integrations/prometheus/index.ts
@@ -99,17 +99,19 @@ export default defineVendor({
           return {
             ok: false,
             at: answer.at,
-            reason: shape
-              ? {
-                  key: "connReasonAndShape",
-                  values: {
-                    said: said ?? "",
-                    shape: explain(shape),
-                  },
-                }
-              : said === null
-                ? { key: "connDidNotSayWhy" }
-                : { key: "verbatimLine", values: { said } },
+            reason: answer.noAddress
+              ? { key: "connNoAddress" }
+              : shape
+                ? {
+                    key: "connReasonAndShape",
+                    values: {
+                      said: said ?? "",
+                      shape: explain(shape),
+                    },
+                  }
+                : said === null
+                  ? { key: "connDidNotSayWhy" }
+                  : { key: "verbatimLine", values: { said } },
           };
         }
         return {

--- a/src/integrations/traefik/page.tsx
+++ b/src/integrations/traefik/page.tsx
@@ -114,6 +114,7 @@ import {
   UNNAMED_TARGET,
 } from "./model";
 import { describePath, fullyRead } from "./rule";
+import { problemWords } from "@/lib/certificates";
 import { useT } from "@/i18n/useT";
 import type { en } from "@/i18n/catalogue";
 
@@ -1169,7 +1170,9 @@ function describeFinding(
           title: t("empty", "secretNotACertificate", {
             name: finding.secretName,
           }),
-          note: finding.read?.problem ?? t("empty", "secretNotParsable"),
+          note: finding.read?.problem
+            ? problemWords(finding.read.problem, t)
+            : t("empty", "secretNotParsable"),
         };
       }
       return {

--- a/src/lib/certificates.test.ts
+++ b/src/lib/certificates.test.ts
@@ -7,11 +7,13 @@ import {
   type Expiry,
   managedExpiryOf,
   overdueBy,
+  problemWords,
   uncoveredHosts,
 } from "./certificates";
 
 import { translate } from "@/i18n";
 import type { T } from "@/i18n/useT";
+import type { CertificateProblem } from "@/generated/types";
 
 /** The English catalogue — what these expectations are written in. */
 const t: T = (section, key, values) => translate("en", section, key, values);
@@ -327,5 +329,39 @@ describe("covers", () => {
     expect(
       uncoveredHosts(cert, ["shop.example.com", "api.example.com"])
     ).toEqual(["api.example.com"]);
+  });
+});
+
+describe("problemWords", () => {
+  const ru: T = (section, key, values) => translate("ru", section, key, values);
+  const every: CertificateProblem[] = [
+    { says: "noSecret" },
+    { says: "secretUnreadable", said: "connection refused" },
+    { says: "noTlsCrt" },
+    { says: "noPemCertificate" },
+    { says: "unparseable", said: "InvalidLength" },
+  ];
+
+  /** These five were English sentences composed in Rust until 2026-08-30,
+   *  which no scan of `src/` could ever have found: the words were not in
+   *  this half of the app. */
+  it("says every reason in the reader's language", () => {
+    for (const problem of every) {
+      const words = problemWords(problem, ru);
+      expect(words).toMatch(/[а-яё]/i);
+      expect(words).not.toBe(problemWords(problem, t));
+    }
+  });
+
+  /** The API server's own words ride inside our sentence and stay as it
+   *  wrote them — translating a cluster's error would be the app putting
+   *  words in its mouth. */
+  it("carries the cluster's words through untouched", () => {
+    expect(
+      problemWords({ says: "secretUnreadable", said: "connection refused" }, ru)
+    ).toContain("connection refused");
+    expect(
+      problemWords({ says: "unparseable", said: "InvalidLength" }, t)
+    ).toContain("InvalidLength");
   });
 });

--- a/src/lib/certificates.ts
+++ b/src/lib/certificates.ts
@@ -30,7 +30,7 @@
 
 import { sayWords, spanWords, type Saying } from "@/i18n/say";
 import type { T } from "@/i18n/useT";
-import type { CertificateFacts } from "@/generated/types";
+import type { CertificateFacts, CertificateProblem } from "@/generated/types";
 
 /** The last point a normal change still fits, or a third of the lifetime. */
 const ACT_SOON_DAYS = 14;
@@ -280,4 +280,26 @@ export function uncoveredHosts(
   return hosts.filter(
     (host) => host && host !== "*" && !covers(facts.dnsNames, host)
   );
+}
+
+/**
+ * Why there is nothing to describe, in the reader's language.
+ *
+ * The backend names the reason instead of writing it: it runs before anyone
+ * knows who is reading, and two of the five carry the API server's own words
+ * inside a sentence that is ours.
+ */
+export function problemWords(problem: CertificateProblem, t: T): string {
+  switch (problem.says) {
+    case "noSecret":
+      return t("readings", "certNoSecret");
+    case "secretUnreadable":
+      return t("readings", "certSecretUnreadable", { said: problem.said });
+    case "noTlsCrt":
+      return t("readings", "certNoTlsCrt");
+    case "noPemCertificate":
+      return t("readings", "certNoPem");
+    case "unparseable":
+      return t("readings", "certUnparseable", { said: problem.said });
+  }
 }

--- a/src/lib/certificates.ts
+++ b/src/lib/certificates.ts
@@ -30,7 +30,12 @@
 
 import { sayWords, spanWords, type Saying } from "@/i18n/say";
 import type { T } from "@/i18n/useT";
-import type { CertificateFacts, CertificateProblem } from "@/generated/types";
+import type {
+  CertificateFacts,
+  CertificateProblem,
+  Stalled,
+  StepNote,
+} from "@/generated/types";
 
 /** The last point a normal change still fits, or a third of the lifetime. */
 const ACT_SOON_DAYS = 14;
@@ -301,5 +306,42 @@ export function problemWords(problem: CertificateProblem, t: T): string {
       return t("readings", "certNoPem");
     case "unparseable":
       return t("readings", "certUnparseable", { said: problem.said });
+  }
+}
+
+/**
+ * What makes a step in the issuance chain that step.
+ *
+ * `said` is the controller's own message and is quoted; the other two are
+ * the app's own clause, with the cluster's words as values inside it.
+ */
+export function stepNoteWords(note: StepNote, t: T): string {
+  switch (note.says) {
+    case "said":
+      return note.text;
+    case "attempt":
+      return t("readings", "stepAttempt", { revision: note.revision });
+    case "challengeOn":
+      return t("readings", "stepChallengeOn", {
+        kind: note.kind,
+        domain: note.domain,
+      });
+  }
+}
+
+/** Which object in the issuance chain has not finished. */
+export function stalledWords(stalled: Stalled, t: T): string {
+  switch (stalled.says) {
+    case "notRequested":
+      return t("readings", "stalledNotRequested");
+    case "requestNotIssued":
+      return t("readings", "stalledRequestNotIssued");
+    case "challengePending":
+      return t("readings", "stalledChallengePending", {
+        kind: stalled.kind,
+        domain: stalled.domain,
+      });
+    case "orderNotCompleted":
+      return t("readings", "stalledOrderNotCompleted");
   }
 }

--- a/src/lib/connections.test.ts
+++ b/src/lib/connections.test.ts
@@ -868,7 +868,7 @@ describe("the groups", () => {
         [
           {
             kind: "HorizontalPodAutoscaler",
-            why: "the app does not read HorizontalPodAutoscalers, so it cannot say whether one scales this",
+            why: { says: "unanswered", version: "autoscaling/v2", said: "404" },
           },
         ]
       ),
@@ -1147,7 +1147,7 @@ describe("what the Service publishes", () => {
         [
           {
             kind: "EndpointSlice",
-            why: "readiness here is each pod's own Ready condition",
+            why: { says: "volumeMountsNotRead" },
           },
         ]
       ),

--- a/src/lib/connections.ts
+++ b/src/lib/connections.ts
@@ -42,6 +42,7 @@ import type {
   ResourceConnections,
   ServicePublished,
   TlsCertificate,
+  Unread,
   Usage,
 } from "@/generated/types";
 
@@ -1031,6 +1032,26 @@ const UNASKED_LABEL: Record<string, "autoscaling" | "disruptionBudget"> = {
   PodDisruptionBudget: "disruptionBudget",
 };
 
+/**
+ * Why a kind went unread, in the reader's language.
+ *
+ * The backend names the reason: it decides this inside a query, where no
+ * language is in scope. The cluster's own refusal rides through untouched.
+ */
+function unreadWhy(why: Unread, t: T): string {
+  switch (why.says) {
+    case "unanswered":
+      return t("readings", "unreadUnanswered", {
+        version: why.version,
+        said: why.said,
+      });
+    case "nodeClaimsNotRead":
+      return t("readings", "unreadNodeClaims");
+    case "volumeMountsNotRead":
+      return t("readings", "unreadVolumeMounts");
+  }
+}
+
 /** The same, for the group that names what was never read. */
 function unaskedLabel(kind: string, t: T): string {
   const key = UNASKED_LABEL[kind];
@@ -1429,7 +1450,7 @@ export function connectionGroups(
         key: entry.kind,
         label: unaskedLabel(entry.kind, t),
         object: null,
-        detail: entry.why,
+        detail: unreadWhy(entry.why, t),
         ways: [],
         unasked: true,
       })),

--- a/src/lib/container-sequence.ts
+++ b/src/lib/container-sequence.ts
@@ -341,7 +341,7 @@ function noteFor(
 
   if (mark === "failed") {
     const death = container.lastTerminated ?? null;
-    const when = death ? terminationWhen(death) : null;
+    const when = death ? terminationWhen(death, t) : null;
     if (container.restartCount > 0) {
       return t("readings", "logsAttemptsLast", {
         attempts: t("count", "attemptsCount", { n: container.restartCount }),
@@ -360,7 +360,7 @@ function noteFor(
     const took = termination
       ? runDuration(termination.startedAt, termination.finishedAt)
       : null;
-    const when = termination ? terminationWhen(termination) : null;
+    const when = termination ? terminationWhen(termination, t) : null;
     // Said out loud because a finished container looks identical to a
     // silent one in a log pane, and Follow does nothing on either.
     return t("readings", "logsFinishedComplete", {

--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -348,7 +348,7 @@ export function deliveryLine(
     const since = source.lastAppliedAt
       ? t("readings", "delSince", {
           name: source.owner.name,
-          ago: formatAge(source.lastAppliedAt),
+          ago: formatAge(source.lastAppliedAt, t),
         })
       : "";
     return {
@@ -422,7 +422,7 @@ export function deliveryCell(
     return {
       text: source.lastAppliedAt
         ? t("readings", "delOutOfSyncAge", {
-            ago: formatAge(source.lastAppliedAt),
+            ago: formatAge(source.lastAppliedAt, t),
           })
         : t("readings", "delOutOfSync"),
       tone: "warn",

--- a/src/lib/governance.test.ts
+++ b/src/lib/governance.test.ts
@@ -140,7 +140,7 @@ describe("reading the two governing kinds", () => {
       conns([], workload, [
         {
           kind: "HorizontalPodAutoscaler",
-          why: "the app asked for autoscaling/v2 and the cluster did not answer",
+          why: { says: "unanswered", version: "autoscaling/v2", said: "404" },
         },
       ]),
       t

--- a/src/lib/governance.ts
+++ b/src/lib/governance.ts
@@ -275,7 +275,7 @@ export function autoscalerReplicas(facts: AutoscalerFacts, t: T): string {
   ];
   if (facts.lastScaleTime)
     parts.push(
-      t("readings", "hpaLastScaled", { ago: formatAge(facts.lastScaleTime) })
+      t("readings", "hpaLastScaled", { ago: formatAge(facts.lastScaleTime, t) })
     );
   return parts.join(" · ");
 }
@@ -289,7 +289,7 @@ export function autoscalerReplicas(facts: AutoscalerFacts, t: T): string {
  */
 export function lastScaled(facts: AutoscalerFacts, t: T): string | null {
   return facts.lastScaleTime
-    ? t("readings", "hpaLastScaled", { ago: formatAge(facts.lastScaleTime) })
+    ? t("readings", "hpaLastScaled", { ago: formatAge(facts.lastScaleTime, t) })
     : null;
 }
 

--- a/src/lib/pod-status.ts
+++ b/src/lib/pod-status.ts
@@ -28,9 +28,14 @@ export function describeTermination(termination: TerminationInfo): string {
 }
 
 /** "4m ago", or nothing when the API did not stamp the termination. */
-export function terminationWhen(termination: TerminationInfo): string | null {
+export function terminationWhen(
+  termination: TerminationInfo,
+  t: T
+): string | null {
   if (!termination.finishedAt) return null;
-  return `${formatAge(termination.finishedAt)} ago`;
+  return t("action", "agoSuffix", {
+    age: formatAge(termination.finishedAt, t),
+  });
 }
 
 /** The wall-clock stamp, for a `title` beside the relative age. */
@@ -131,6 +136,6 @@ export function describeRestarts(
   }
   return t("count", "restartsWithLast", {
     n: pod.restartCount,
-    ago: formatAge(pod.lastRestartAt),
+    ago: formatAge(pod.lastRestartAt, t),
   });
 }

--- a/src/lib/resource-registry.test.ts
+++ b/src/lib/resource-registry.test.ts
@@ -4,6 +4,7 @@ import {
   RESOURCE_REGISTRY,
   listQueryFor,
   toPlural,
+  toSingularNoun,
   type ResourceKind,
 } from "./resource-registry";
 
@@ -58,5 +59,23 @@ describe("the question that asks whether a kind may be listed", () => {
         query.group !== ""
       );
     }
+  });
+});
+
+describe("toSingularNoun", () => {
+  /** Trimming a letter was the old way, and it printed "1 ingresse" for a
+   *  namespace with one Ingress in it. The API's plurals are not all
+   *  noun + "s", and the registry already holds the singular. */
+  it("reads the singular off the registry rather than trimming a letter", () => {
+    expect(toSingularNoun("ingresses")).toBe("ingress");
+    expect(toSingularNoun("storageclasses")).toBe("storageclass");
+    expect(toSingularNoun("pods")).toBe("pod");
+    expect(toSingularNoun("services")).toBe("service");
+  });
+
+  /** A kind the registry does not carry keeps whatever it was given —
+   *  a wrong singular is worse than a plural that reads as one. */
+  it("leaves a plural it does not know alone", () => {
+    expect(toSingularNoun("widgets")).toBe("widgets");
   });
 });

--- a/src/lib/resource-registry.ts
+++ b/src/lib/resource-registry.ts
@@ -347,6 +347,18 @@ export function toPlural(resourceKind: ResourceKind): string {
   );
 }
 
+/**
+ * One of whatever the plural names, spelled the way the cluster spells it.
+ *
+ * Read out of the registry rather than made by trimming a letter: the API's
+ * plurals are not all `noun + "s"`, and `"ingresses".replace(/s$/, "")` —
+ * which is what a group caption used to print — says "1 ingresse".
+ */
+export function toSingularNoun(plural: string): string {
+  const lower = plural.toLowerCase();
+  return RESOURCE_BY_PLURAL.get(lower)?.kind.toLowerCase() ?? lower;
+}
+
 export function toKind(resourceType: string): ResourceKind | null {
   if (RESOURCE_BY_KIND.has(resourceType as ResourceKind)) {
     return resourceType as ResourceKind;

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { formatAge } from "./utils";
+import { translate } from "@/i18n";
+import type { T } from "@/i18n/useT";
+
+const en: T = (section, key, values) => translate("en", section, key, values);
+const ru: T = (section, key, values) => translate("ru", section, key, values);
+
+describe("formatAge", () => {
+  /** `d`/`h`/`m`/`s` are `kubectl`'s notation, and the reader is matching
+   *  this against a terminal. Translating them would break the comparison
+   *  the compact form exists for. */
+  it("keeps the units the cluster's own tooling prints", () => {
+    const anHourAgo = new Date(Date.now() - 3600_000).toISOString();
+    expect(formatAge(anHourAgo, en)).toBe("1h");
+    expect(formatAge(anHourAgo, ru)).toBe("1h");
+  });
+
+  /** The absence is a word, and a word has to be said in the reader's
+   *  language. It returned the literal "Unknown" until 2026-08-30 — a bare
+   *  word in a utility file, which is why every scan by sentence missed it. */
+  it("says the absence in the reader's language", () => {
+    expect(formatAge(null, en)).toBe("Unknown");
+    expect(formatAge(null, ru)).toBe("Неизвестно");
+    expect(formatAge("not a date", ru)).toBe("Неизвестно");
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { type ClassValue, clsx } from "clsx";
+import type { T } from "@/i18n/useT";
 import { twMerge } from "tailwind-merge";
 
 /**
@@ -12,16 +13,22 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
- * Format age from a timestamp string
+ * How long ago, in the compact notation the cluster's own tooling uses.
+ *
+ * The units stay `d`/`h`/`m`/`s` in every language on purpose — that is
+ * `kubectl`'s notation and the reader matches it against a terminal. The one
+ * word here is the absence, and a word has to be said in the reader's
+ * language, so the translator comes in as an argument: this is called from
+ * modules where a hook is not legal.
  *
  * @param createdAt - ISO timestamp string or null
- * @returns Formatted age string (e.g., "5d", "2h", "30m", "10s") or "Unknown"
+ * @returns "5d", "2h", "30m", "10s", or what the reader calls unknown
  */
-export function formatAge(createdAt: string | null): string {
-  if (!createdAt) return "Unknown";
+export function formatAge(createdAt: string | null, t: T): string {
+  if (!createdAt) return t("cluster", "unknownAge");
 
   const created = new Date(createdAt);
-  if (Number.isNaN(created.getTime())) return "Unknown";
+  if (Number.isNaN(created.getTime())) return t("cluster", "unknownAge");
   const now = new Date();
   const diffMs = now.getTime() - created.getTime();
   const diffSecs = Math.max(0, Math.floor(diffMs / 1000));

--- a/src/pages/GatewayDetail.tsx
+++ b/src/pages/GatewayDetail.tsx
@@ -217,8 +217,9 @@ function ListenerRows({ gateway }: { gateway: GatewayInfo }) {
                               namespace={ref.namespace}
                               showKind={false}
                               showNamespace
-                            />{" "}
-                            — cross-namespace, needs a ReferenceGrant
+                            />
+                            {" — "}
+                            {t("readings", "certCrossNamespace")}
                           </span>
                         )
                       )}

--- a/src/pages/PodDetail.tsx
+++ b/src/pages/PodDetail.tsx
@@ -133,7 +133,7 @@ function describeWaiting(
         ? t("empty", "crashRestartsWithLastRun", {
             n: container.restartCount,
             how: `${describeTermination(last)}${
-              terminationWhen(last) ? `, ${terminationWhen(last)}` : ""
+              terminationWhen(last, t) ? `, ${terminationWhen(last, t)}` : ""
             }`,
           })
         : t("empty", "crashRestartsNoLastRun", { n: container.restartCount }),


### PR DESCRIPTION
The Russian interface still spoke English on its first screen. A cordoned node read:

> **Cordoned** — rubick-ls-control-plane — Marked unschedulable — no new pods will land here

That sentence is written in Rust. Every i18n pass so far scanned `src/`, and the words were in the other half of the app — so no scan could have found them. This one was found by opening the application and looking at it.

**The shape of the bug, which is the interesting part.** `ClusterProblem.detail` was one `Option<String>` carrying two unlike things: usually the object's own status message, which is the cluster's wording and must survive untranslated, and in three branches a sentence this app composes. One type for both meant the second kind could never reach the reader's language, and the field's own doc comment claimed only the first existed.

So each of these fields becomes a named variant — the same shape `ChainStop` already uses — and the frontend picks the words. Where the cluster's own words belong inside our sentence, they ride through as a value.

| Field | What it said in English | Now |
|---|---|---|
| `ClusterProblem.detail` | cordoned, restart count, replicas ready | `ProblemDetail`, with `Said` for the cluster's message |
| `TlsCertificate.problem` | five reasons a certificate cannot be read | `CertificateProblem` |
| `UnexploredKind.why` | three reasons a kind went unread | `Unread` |
| `IssuanceStep.note`, `IssuanceStory.stalled` | attempt/challenge clauses | `StepNote`, `Stalled` |
| `AuthFlow{Completed,Cancelled}` | timed out, no token, state mismatch, superseded, switched away | `AuthOutcome` |
| Loki/Prometheus probe | "no address configured" in a field documented as the server's own words | `noAddress`, said on the frontend |

Three more, found on the way:

- `formatAge` returned the literal `"Unknown"` — in `src/`, so it survived every earlier pass by being one bare word in a utility file. It takes the translator now; `d`/`h`/`m`/`s` stay, because that is `kubectl`'s notation and the reader is matching it against a terminal.
- `terminationWhen` built `"4m ago"` by concatenation — the pattern a literal scan cannot see, because the string is never whole.
- A group caption made its singular with `replace(/s$/, "")`, so a namespace with one Ingress read **1 ingresse**. The registry already holds the singular.

Also: the certificate line ran straight into the TLS mode with no separator — `Terminateno Secret of that name…` — and `— cross-namespace, needs a ReferenceGrant` was a hard-coded English literal in the markup.

**Verified on a live cluster**, not only by test: both screens re-checked in the running app after the change, in Russian. 2132 frontend tests, 464 Rust tests, clippy clean.
