### PR TITLE
fix: a client certificate returned by a credential plugin now reaches the cluster

### DIFF
--- a/src-tauri/src/auth/interactive/mod.rs
+++ b/src-tauri/src/auth/interactive/mod.rs
@@ -139,14 +139,24 @@ fn apply_exec_credentials(
     auth_info: &mut AuthInfo,
     status: ExecCredentialStatus,
 ) -> Option<chrono::DateTime<chrono::Utc>> {
+    use base64::Engine;
+
     if let Some(token) = status.token {
         auth_info.token = Some(SecretString::from(token));
     }
+    // A plugin hands back PEM, but the fields it lands in are kubeconfig
+    // fields, and kube reads those through a base64 decode. Storing the PEM
+    // as-is leaves the decode to fail, and the failure is swallowed — the
+    // client is then built with no certificate at all, and the server
+    // answers the anonymous request with a denial that names no cause.
     if let Some(cert) = status.client_certificate_data {
-        auth_info.client_certificate_data = Some(cert);
+        auth_info.client_certificate_data =
+            Some(base64::engine::general_purpose::STANDARD.encode(cert));
     }
     if let Some(key) = status.client_key_data {
-        auth_info.client_key_data = Some(SecretString::from(key));
+        auth_info.client_key_data = Some(SecretString::from(
+            base64::engine::general_purpose::STANDARD.encode(key),
+        ));
     }
     // A plugin that names no expiry, or names one this cannot parse, leaves
     // the deadline unknown — which is a different thing from "does not

--- a/src-tauri/src/auth/interactive/mod.rs
+++ b/src-tauri/src/auth/interactive/mod.rs
@@ -166,3 +166,45 @@ fn apply_exec_credentials(
         .and_then(|stamp| chrono::DateTime::parse_from_rfc3339(&stamp).ok())
         .map(|stamp| stamp.with_timezone(&chrono::Utc))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use secrecy::ExposeSecret;
+
+    const CERT: &str = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n";
+    const KEY: &str = "-----BEGIN EC PRIVATE KEY-----\nMHcC\n-----END EC PRIVATE KEY-----\n";
+
+    /// A plugin answers in PEM, and the kubeconfig fields this lands in are
+    /// read through a base64 decode: kube swallows the failure and builds
+    /// the client with no certificate at all, so the server refuses an
+    /// anonymous request and names no cause. Would break if the PEM went
+    /// into the fields as it came.
+    #[test]
+    fn a_plugins_pem_certificate_is_stored_the_way_kubeconfig_is_read() {
+        let mut auth_info = AuthInfo::default();
+        apply_exec_credentials(
+            &mut auth_info,
+            ExecCredentialStatus {
+                expiration_timestamp: None,
+                token: None,
+                client_certificate_data: Some(CERT.to_string()),
+                client_key_data: Some(KEY.to_string()),
+            },
+        );
+
+        let decoded = |field: &str| {
+            base64::engine::general_purpose::STANDARD
+                .decode(field)
+                .expect("a kubeconfig field is base64")
+        };
+        let cert = auth_info
+            .client_certificate_data
+            .as_deref()
+            .expect("the certificate");
+        assert_eq!(decoded(cert), CERT.as_bytes());
+        let key = auth_info.client_key_data.as_ref().expect("the key");
+        assert_eq!(decoded(key.expose_secret()), KEY.as_bytes());
+    }
+}


### PR DESCRIPTION
## What is wrong today

A credential plugin that answers with a client certificate instead of a token (Teleport's `tsh`, corporate PKI plugins) gets its certificate silently dropped. The plugin returns PEM in `clientCertificateData` and `clientKeyData`, as the ExecCredential API specifies, and the app copies the PEM straight into the kubeconfig fields `client-certificate-data` and `client-key-data`. kube reads those through a base64 decode, the decode fails, kube swallows the failure with `.ok()` and builds the client with no identity at all. The server then refuses an anonymous request, and the error names no cause.

## What changes

The PEM is base64-encoded before it is written into the two kubeconfig fields, which is what those fields hold in a kubeconfig on disk. The fix is Igor DC's commit from the `igordcard/rubick` fork, cherry-picked with authorship kept; a unit test on `apply_exec_credentials` is added on top, and fails with the PEM stored as it came.

## How to check it

`cargo test --lib -p k8s-gui auth::interactive`. On a cluster whose exec plugin returns a certificate, connect from the app: with this change the requests are made with the certificate and the lists load; without it every list shows the refusal.

## Risk and rollback

Only the two certificate fields of an exec answer change; token answers are untouched. Reverting the two commits restores the previous behaviour.
