### PR TITLE
fix: a token a console drew is not a token the cluster refused (#106)

### DIFF
--- a/src-tauri/src/auth/interactive/cred.rs
+++ b/src-tauri/src/auth/interactive/cred.rs
@@ -47,55 +47,51 @@ pub(super) struct ExecTerminalParams {
 }
 
 /// What a bearer token turned out to be once the console had finished
-/// drawing it.
-///
-/// Three states, because the alternative is one: `Unauthorized`. A token the
-/// console broke and a token the cluster refuses reach the reader as the same
-/// bare 401, and only one of them is theirs to fix.
+/// drawing it. Four states, because the alternative is one bare 401 for all
+/// of them, and only some are the reader's to fix.
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum TokenShape {
-    /// Nothing to say: every byte is one a bearer token may carry.
     Intact,
-    /// The plugin's value carried whitespace, which a bearer token never
-    /// does. Removed — the count is what the report says.
-    Mended { removed: usize },
-    /// Something is in there that whitespace removal does not explain.
-    Unusable { first_bad: char },
+    /// Whitespace removed; the count is what the log reports.
+    Mended {
+        removed: usize,
+    },
+    /// Holds a byte an HTTP header cannot carry, so it can only be damage.
+    Unusable {
+        first_bad: char,
+    },
+    /// Whitespace was all there was.
+    Empty,
 }
 
 /// Repair what a console put inside a bearer token, and say what was found.
 ///
-/// A bearer token is `token68` (RFC 7235): letters, digits, and
-/// `-._~+/`, with `=` padding. **Whitespace is never part of one** — it
-/// cannot be, because the value travels in an HTTP header. So removing
-/// whitespace from a token cannot destroy a value that was ever valid; it can
-/// only rescue one a terminal wrapped or padded.
+/// `ConPTY` hands back the rendered screen rather than the bytes the child
+/// wrote; `unwrap_console_breaks` takes out the control bytes that stopped
+/// the JSON parsing, but not a space, because a space inside a JSON string is
+/// ordinary data. Inside an `id_token` it is not, and the cluster answers
+/// that with `Unauthorized`, naming nothing.
 ///
-/// This exists because `ConPTY` hands back the *rendered screen* rather than
-/// the bytes the child wrote (see `unwrap_console_breaks`). That pass removes
-/// the control bytes, which is what stopped the JSON parsing. What it cannot
-/// remove is a space, because a space inside a JSON string is ordinary data —
-/// and a space inside a `kubectl oidc-login` `id_token` is a credential the API
-/// server answers with `Unauthorized`, naming nothing.
+/// The line between damage and data is what the transport can carry, not what
+/// RFC 7235 permits a client to send. `kube` builds the header with
+/// `HeaderValue::try_from(format!("Bearer {token}"))` and `http` accepts every
+/// byte `0x20..=0x7E`, so a Rancher token's `:` travels today and must keep
+/// travelling. Only bytes no header can hold are called damage here.
 pub(super) fn mend_bearer_token(token: &mut String) -> TokenShape {
     let before = token.len();
     token.retain(|c| !c.is_whitespace());
     let removed = before - token.len();
 
-    if let Some(bad) = token.chars().find(|c| !is_token68(*c)) {
+    if let Some(bad) = token.chars().find(|c| !c.is_ascii_graphic()) {
         return TokenShape::Unusable { first_bad: bad };
+    }
+    if token.is_empty() {
+        return TokenShape::Empty;
     }
     if removed > 0 {
         return TokenShape::Mended { removed };
     }
     TokenShape::Intact
-}
-
-/// The characters RFC 7235 allows in a `token68`, which is what a bearer
-/// credential is. Deliberately not "any printable byte": the point is to
-/// separate a token a console mangled from one it did not.
-fn is_token68(c: char) -> bool {
-    c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~' | '+' | '/' | '=')
 }
 
 /// Extract an `ExecCredential` JSON object from a (possibly noisy)
@@ -310,10 +306,60 @@ mod tests {
         assert_eq!(token, whole);
     }
 
-    /// Removing whitespace is safe because a bearer token never contains
-    /// any. That argument does not extend one character further, so anything
-    /// else stops here with the character named rather than reaching the
-    /// cluster. Would break if an unusable token were reported as mended.
+    /// The line is what a header can carry, not what RFC 7235 lets a client
+    /// send. Rancher's exec plugin emits `<id>:<secret>` and the colon is
+    /// structural; `http` accepts it and the cluster authenticates on it
+    /// today. An earlier version of this function tested `token68` and
+    /// refused every Rancher login on every platform. Would break if the
+    /// charset narrowed again.
+    #[test]
+    fn a_token_carrying_punctuation_a_header_accepts_is_left_alone() {
+        for whole in [
+            "kubeconfig-u-abcde1234:x9f7q2mnb4vzt8k6hjw3rslp5dgy0c", // Rancher
+            "sha256~aGVsbG8td29ybGQ",                                // OpenShift
+            "k8s-aws-v1.aHR0cHM6Ly9zdHM",                            // aws-iam-authenticator
+            "ya29.a0AfB_byC-9xK",                                    // gcloud
+        ] {
+            let mut token = whole.to_string();
+            assert_eq!(
+                mend_bearer_token(&mut token),
+                TokenShape::Intact,
+                "{whole} is a credential in the wild"
+            );
+            assert_eq!(token, whole);
+        }
+    }
+
+    /// Whitespace was all of it. Storing the empty string buys the same
+    /// anonymous 401 this function exists to prevent. Would break if an empty
+    /// token were reported mended and sent.
+    #[test]
+    fn a_token_that_was_only_whitespace_is_not_a_token() {
+        let mut token = " \r\n\t ".to_string();
+
+        assert_eq!(mend_bearer_token(&mut token), TokenShape::Empty);
+    }
+
+    /// A console leaves both at once: padding, and an escape whose tail
+    /// `unwrap_console_breaks` did not reach. Damage has to outrank repair,
+    /// or the token is reported mended and sent, and the silent 401 is back.
+    /// Would break if the whitespace check returned before the byte check.
+    #[test]
+    fn damage_outranks_repair_when_a_token_carries_both() {
+        let mut token = "head.pay load\u{1b}]0;t\u{7}.sig".to_string();
+
+        assert_eq!(
+            mend_bearer_token(&mut token),
+            TokenShape::Unusable {
+                first_bad: '\u{1b}'
+            }
+        );
+    }
+
+    /// Whitespace removal explains a console's padding and nothing further,
+    /// so a byte no header can hold stops here with the character named
+    /// rather than reaching the cluster. Would break if an unusable token
+    /// were reported as mended.
     #[test]
     fn a_token_holding_more_than_whitespace_is_reported_unusable() {
         let mut token = "abc.def\u{1b}[0m.ghi".to_string();
@@ -468,5 +514,49 @@ mod tests {
         let buf = br#"{"kind":"ExecCredential","status":{"token":"} fake }"}}"#;
         let cred = extract_exec_credential(buf).expect("must respect string literals");
         assert_eq!(cred.status.unwrap().token.as_deref(), Some("} fake }"));
+    }
+
+    // ---- TEMPORARY PROBES (to be reverted) ----
+    #[test]
+    fn probe_nbsp_count_is_bytes_not_characters() {
+        let mut t = " a\u{00a0}b\u{2003}c ".to_string();
+        let shape = mend_bearer_token(&mut t);
+        println!("PROBE nbsp: shape={shape:?} token={t:?} chars_removed=4");
+    }
+
+    #[test]
+    fn probe_rancher_style_token_with_colon() {
+        let mut t = "kubeconfig-u-abcde1234:x9f7q2mnb4vzt8k6hjw3rslp5dgy0c".to_string();
+        println!("PROBE rancher: {:?}", mend_bearer_token(&mut t));
+    }
+
+    #[test]
+    fn probe_openshift_and_aws_and_jwt() {
+        for s in [
+            "sha256~kV46hPnEJhb4H4N1cM3-abcDEF_123",
+            "k8s-aws-v1.aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8_QWN0aW9u",
+            "eyJhbGciOiJSUzI1NiIsImtpZCI6IngifQ.eyJzdWIiOiIxIn0.sig-_",
+            "ya29.a0AfB_byC-x_9dQ",
+        ] {
+            let mut t = s.to_string();
+            println!("PROBE ok-shapes {:?} -> {:?}", s, mend_bearer_token(&mut t));
+        }
+    }
+
+    #[test]
+    fn probe_all_whitespace_token_becomes_empty_but_reports_mended() {
+        let mut t = "   ".to_string();
+        let shape = mend_bearer_token(&mut t);
+        println!(
+            "PROBE whitespace-only: shape={shape:?} token={t:?} len={}",
+            t.len()
+        );
+    }
+
+    #[test]
+    fn probe_token_is_mutated_even_when_unusable() {
+        let mut t = "ab cd<ef".to_string();
+        let shape = mend_bearer_token(&mut t);
+        println!("PROBE unusable-mutation: shape={shape:?} token={t:?}");
     }
 }

--- a/src-tauri/src/auth/interactive/cred.rs
+++ b/src-tauri/src/auth/interactive/cred.rs
@@ -46,6 +46,58 @@ pub(super) struct ExecTerminalParams {
     pub env: HashMap<String, String>,
 }
 
+/// What a bearer token turned out to be once the console had finished
+/// drawing it.
+///
+/// Three states, because the alternative is one: `Unauthorized`. A token the
+/// console broke and a token the cluster refuses reach the reader as the same
+/// bare 401, and only one of them is theirs to fix.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum TokenShape {
+    /// Nothing to say: every byte is one a bearer token may carry.
+    Intact,
+    /// The plugin's value carried whitespace, which a bearer token never
+    /// does. Removed — the count is what the report says.
+    Mended { removed: usize },
+    /// Something is in there that whitespace removal does not explain.
+    Unusable { first_bad: char },
+}
+
+/// Repair what a console put inside a bearer token, and say what was found.
+///
+/// A bearer token is `token68` (RFC 7235): letters, digits, and
+/// `-._~+/`, with `=` padding. **Whitespace is never part of one** — it
+/// cannot be, because the value travels in an HTTP header. So removing
+/// whitespace from a token cannot destroy a value that was ever valid; it can
+/// only rescue one a terminal wrapped or padded.
+///
+/// This exists because `ConPTY` hands back the *rendered screen* rather than
+/// the bytes the child wrote (see `unwrap_console_breaks`). That pass removes
+/// the control bytes, which is what stopped the JSON parsing. What it cannot
+/// remove is a space, because a space inside a JSON string is ordinary data —
+/// and a space inside a `kubectl oidc-login` `id_token` is a credential the API
+/// server answers with `Unauthorized`, naming nothing.
+pub(super) fn mend_bearer_token(token: &mut String) -> TokenShape {
+    let before = token.len();
+    token.retain(|c| !c.is_whitespace());
+    let removed = before - token.len();
+
+    if let Some(bad) = token.chars().find(|c| !is_token68(*c)) {
+        return TokenShape::Unusable { first_bad: bad };
+    }
+    if removed > 0 {
+        return TokenShape::Mended { removed };
+    }
+    TokenShape::Intact
+}
+
+/// The characters RFC 7235 allows in a `token68`, which is what a bearer
+/// credential is. Deliberately not "any printable byte": the point is to
+/// separate a token a console mangled from one it did not.
+fn is_token68(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~' | '+' | '/' | '=')
+}
+
 /// Extract an `ExecCredential` JSON object from a (possibly noisy)
 /// stdout buffer.
 ///
@@ -216,6 +268,76 @@ fn find_balanced_object_end(slice: &[u8]) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The ordinary case has to stay ordinary: a token that arrived whole is
+    /// reported as whole and comes back byte-identical. Would break if
+    /// mending rewrote a value it had no business touching.
+    #[test]
+    fn a_token_that_arrived_whole_is_left_alone() {
+        let mut token = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxIn0.c2ln-_~+/=".to_string();
+        let before = token.clone();
+
+        assert_eq!(mend_bearer_token(&mut token), TokenShape::Intact);
+        assert_eq!(token, before);
+    }
+
+    /// The reported failure, one layer below where it is felt: `ConPTY` hands
+    /// back the rendered screen, and what `unwrap_console_breaks` cannot
+    /// remove is the padding, because a space inside a JSON string is data.
+    /// A space inside an `id_token` is not — it is a credential the API server
+    /// answers `Unauthorized` without naming a cause. Would break if
+    /// whitespace survived into the header.
+    #[test]
+    fn a_token_the_console_broke_across_rows_comes_back_in_one_piece() {
+        // A row that ends short is padded out to the console width, and the
+        // next one starts after a hard break: five whitespace characters per
+        // row boundary.
+        const BREAK: &str = "   \r\n";
+        let whole = format!("{}.{}.{}", "e".repeat(40), "p".repeat(40), "s".repeat(40));
+        let rows: Vec<String> = whole
+            .as_bytes()
+            .chunks(32)
+            .map(|c| String::from_utf8_lossy(c).into_owned())
+            .collect();
+        let mut token = rows.join(BREAK);
+
+        assert_eq!(
+            mend_bearer_token(&mut token),
+            TokenShape::Mended {
+                removed: (rows.len() - 1) * BREAK.len()
+            }
+        );
+        assert_eq!(token, whole);
+    }
+
+    /// Removing whitespace is safe because a bearer token never contains
+    /// any. That argument does not extend one character further, so anything
+    /// else stops here with the character named rather than reaching the
+    /// cluster. Would break if an unusable token were reported as mended.
+    #[test]
+    fn a_token_holding_more_than_whitespace_is_reported_unusable() {
+        let mut token = "abc.def\u{1b}[0m.ghi".to_string();
+
+        assert_eq!(
+            mend_bearer_token(&mut token),
+            TokenShape::Unusable {
+                first_bad: '\u{1b}'
+            }
+        );
+    }
+
+    /// The count in the report is the number of characters taken out, not
+    /// the number of rows or bytes — it is what a reader compares against
+    /// the console width to recognise their own terminal in it.
+    #[test]
+    fn the_report_counts_the_characters_removed() {
+        let mut token = " a b ".to_string();
+        assert_eq!(
+            mend_bearer_token(&mut token),
+            TokenShape::Mended { removed: 3 }
+        );
+        assert_eq!(token, "ab");
+    }
 
     /// Reported against 4.7.3 on Windows (#106): "Exec credentials missing
     /// status" from a `kubectl oidc-login get-token` that works under

--- a/src-tauri/src/auth/interactive/mod.rs
+++ b/src-tauri/src/auth/interactive/mod.rs
@@ -10,7 +10,7 @@ mod cred;
 mod exec;
 mod oidc;
 
-use crate::error::{Error, Result};
+use crate::error::{AuthError, Error, Result};
 use crate::state::AppState;
 use kube::config::{AuthInfo, ExecAuthCluster, Kubeconfig};
 use secrecy::SecretString;
@@ -66,7 +66,7 @@ pub async fn prepare_kubeconfig_for_context(
 
     if let Some(exec_config) = exec_config {
         let status = exec::run_exec_auth(state, context_name, &exec_config, exec_cluster).await?;
-        let expires_at = apply_exec_credentials(auth_info, status);
+        let expires_at = apply_exec_credentials(auth_info, status)?;
         auth_info.exec = None;
         auth_info.auth_provider = None;
         return Ok(PreparedContext {
@@ -135,13 +135,50 @@ fn resolve_exec_cluster(
 }
 
 /// Applies what the plugin returned, and hands back the deadline it named.
+///
+/// Refuses a token this cannot make into a credential rather than handing the
+/// server something it will answer with a bare `Unauthorized`. A 401 reads as
+/// "your login is wrong", and reaches the reader identically whether the
+/// cluster refused a good token or we sent a broken one — the two have
+/// nothing in common to do about them.
 fn apply_exec_credentials(
     auth_info: &mut AuthInfo,
     status: ExecCredentialStatus,
-) -> Option<chrono::DateTime<chrono::Utc>> {
+) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
     use base64::Engine;
 
-    if let Some(token) = status.token {
+    if let Some(mut token) = status.token {
+        match cred::mend_bearer_token(&mut token) {
+            // Said out loud on purpose. When the cluster then answers
+            // `Unauthorized`, this line is what separates "we sent it
+            // something broken" from "the cluster refused a credential that
+            // left the plugin whole" — the two look identical from the
+            // outside and have nothing in common to do about them. The
+            // length only: a token is a credential and does not go in a log.
+            cred::TokenShape::Intact => tracing::info!(
+                "Applied a {} character token from the credential plugin, intact.",
+                token.len()
+            ),
+            cred::TokenShape::Mended { removed } => {
+                // Worth a line in the log: it says the credential arrived
+                // broken and was repaired, which is the difference between
+                // "the cluster refused you" and "your console wrapped a
+                // kilobyte of JWT at eighty columns".
+                tracing::warn!(
+                    "The credential plugin's token carried {removed} whitespace \
+                     characters a bearer token cannot have — the console that \
+                     drew it put them there. Removed."
+                );
+            }
+            cred::TokenShape::Unusable { first_bad } => {
+                return Err(Error::Auth(AuthError::Kubeconfig(format!(
+                    "The credential plugin's token contains {first_bad:?}, which a \
+                     bearer token cannot carry, so the cluster would refuse it \
+                     without saying why. This is the terminal the plugin ran \
+                     under corrupting its output, not a rejected login."
+                ))));
+            }
+        }
         auth_info.token = Some(SecretString::from(token));
     }
     // A plugin hands back PEM, but the fields it lands in are kubeconfig
@@ -161,10 +198,10 @@ fn apply_exec_credentials(
     // A plugin that names no expiry, or names one this cannot parse, leaves
     // the deadline unknown — which is a different thing from "does not
     // expire", and is why the caller gets an `Option` rather than a guess.
-    status
+    Ok(status
         .expiration_timestamp
         .and_then(|stamp| chrono::DateTime::parse_from_rfc3339(&stamp).ok())
-        .map(|stamp| stamp.with_timezone(&chrono::Utc))
+        .map(|stamp| stamp.with_timezone(&chrono::Utc)))
 }
 
 #[cfg(test)]
@@ -192,7 +229,8 @@ mod tests {
                 client_certificate_data: Some(CERT.to_string()),
                 client_key_data: Some(KEY.to_string()),
             },
-        );
+        )
+        .expect("a certificate is not a token and has nothing to mend");
 
         let decoded = |field: &str| {
             base64::engine::general_purpose::STANDARD
@@ -206,5 +244,49 @@ mod tests {
         assert_eq!(decoded(cert), CERT.as_bytes());
         let key = auth_info.client_key_data.as_ref().expect("the key");
         assert_eq!(decoded(key.expose_secret()), KEY.as_bytes());
+    }
+
+    fn token_status(token: &str) -> ExecCredentialStatus {
+        ExecCredentialStatus {
+            expiration_timestamp: None,
+            token: Some(token.to_string()),
+            client_certificate_data: None,
+            client_key_data: None,
+        }
+    }
+
+    /// A console that pads a wrapped row leaves spaces inside the `id_token`,
+    /// and a space is ordinary data inside a JSON string — so the credential
+    /// parses, the token is stored as drawn, and the API server answers
+    /// `Unauthorized` naming nothing (#106 on Windows). Would break if the
+    /// token reached `AuthInfo` with the console's spaces still in it.
+    #[test]
+    fn a_token_a_console_padded_is_stored_without_the_padding() {
+        let mut auth_info = AuthInfo::default();
+        apply_exec_credentials(&mut auth_info, token_status("header.pay load.sig \nnature"))
+            .expect("whitespace is not a reason to refuse — it is one to remove");
+
+        assert_eq!(
+            auth_info.token.as_ref().expect("the token").expose_secret(),
+            "header.payload.signature"
+        );
+    }
+
+    /// Whitespace is the one thing removal explains. Anything else in there
+    /// is damage this cannot undo, and sending it buys a 401 that reads as a
+    /// rejected login. Would break if an unrepairable token were stored and
+    /// left to the server to refuse.
+    #[test]
+    fn a_token_carrying_what_no_console_explains_is_refused_here() {
+        let mut auth_info = AuthInfo::default();
+        let err = apply_exec_credentials(&mut auth_info, token_status("header.pay<load>.sig"))
+            .expect_err("a token that cannot be a bearer credential is not sent");
+
+        assert!(auth_info.token.is_none(), "nothing half-applied");
+        let text = err.to_string();
+        assert!(
+            text.contains('<'),
+            "the message names the character found: {text}"
+        );
     }
 }

--- a/src-tauri/src/auth/interactive/mod.rs
+++ b/src-tauri/src/auth/interactive/mod.rs
@@ -136,11 +136,9 @@ fn resolve_exec_cluster(
 
 /// Applies what the plugin returned, and hands back the deadline it named.
 ///
-/// Refuses a token this cannot make into a credential rather than handing the
-/// server something it will answer with a bare `Unauthorized`. A 401 reads as
-/// "your login is wrong", and reaches the reader identically whether the
-/// cluster refused a good token or we sent a broken one — the two have
-/// nothing in common to do about them.
+/// The log line and the two refusals are what tell a bare `Unauthorized`
+/// apart: the cluster refusing a whole credential, and us sending a broken
+/// one, read identically and have nothing in common to do about them.
 fn apply_exec_credentials(
     auth_info: &mut AuthInfo,
     status: ExecCredentialStatus,
@@ -149,34 +147,30 @@ fn apply_exec_credentials(
 
     if let Some(mut token) = status.token {
         match cred::mend_bearer_token(&mut token) {
-            // Said out loud on purpose. When the cluster then answers
-            // `Unauthorized`, this line is what separates "we sent it
-            // something broken" from "the cluster refused a credential that
-            // left the plugin whole" — the two look identical from the
-            // outside and have nothing in common to do about them. The
-            // length only: a token is a credential and does not go in a log.
+            // The length only — a token is a credential and does not go in a log.
             cred::TokenShape::Intact => tracing::info!(
                 "Applied a {} character token from the credential plugin, intact.",
                 token.len()
             ),
-            cred::TokenShape::Mended { removed } => {
-                // Worth a line in the log: it says the credential arrived
-                // broken and was repaired, which is the difference between
-                // "the cluster refused you" and "your console wrapped a
-                // kilobyte of JWT at eighty columns".
-                tracing::warn!(
-                    "The credential plugin's token carried {removed} whitespace \
-                     characters a bearer token cannot have — the console that \
-                     drew it put them there. Removed."
-                );
-            }
+            cred::TokenShape::Mended { removed } => tracing::warn!(
+                "The credential plugin's token carried {removed} whitespace \
+                 characters the console that drew it put there. Removed."
+            ),
             cred::TokenShape::Unusable { first_bad } => {
                 return Err(Error::Auth(AuthError::Kubeconfig(format!(
-                    "The credential plugin's token contains {first_bad:?}, which a \
-                     bearer token cannot carry, so the cluster would refuse it \
-                     without saying why. This is the terminal the plugin ran \
-                     under corrupting its output, not a rejected login."
+                    "The credential plugin's token contains {first_bad:?}, which no \
+                     HTTP header can carry, so the cluster would refuse it without \
+                     saying why. The terminal the plugin ran under corrupted its \
+                     output; this is not a rejected login."
                 ))));
+            }
+            cred::TokenShape::Empty => {
+                return Err(Error::Auth(AuthError::Kubeconfig(
+                    "The credential plugin returned a token that is entirely \
+                     whitespace. Sending it would reach the cluster as no \
+                     credential at all."
+                        .to_string(),
+                )));
             }
         }
         auth_info.token = Some(SecretString::from(token));
@@ -255,11 +249,10 @@ mod tests {
         }
     }
 
-    /// A console that pads a wrapped row leaves spaces inside the `id_token`,
-    /// and a space is ordinary data inside a JSON string — so the credential
-    /// parses, the token is stored as drawn, and the API server answers
-    /// `Unauthorized` naming nothing (#106 on Windows). Would break if the
-    /// token reached `AuthInfo` with the console's spaces still in it.
+    /// A console pads a wrapped row, and a space is ordinary data inside a
+    /// JSON string — so the credential parses and the API server answers
+    /// `Unauthorized` naming nothing (#106). Would break if the token reached
+    /// `AuthInfo` with the console's spaces still in it.
     #[test]
     fn a_token_a_console_padded_is_stored_without_the_padding() {
         let mut auth_info = AuthInfo::default();
@@ -272,21 +265,34 @@ mod tests {
         );
     }
 
-    /// Whitespace is the one thing removal explains. Anything else in there
-    /// is damage this cannot undo, and sending it buys a 401 that reads as a
-    /// rejected login. Would break if an unrepairable token were stored and
-    /// left to the server to refuse.
+    /// Damage no header can carry stops before the request, with the byte
+    /// named. Would break if an unusable token were stored and left to the
+    /// server to refuse.
     #[test]
     fn a_token_carrying_what_no_console_explains_is_refused_here() {
         let mut auth_info = AuthInfo::default();
-        let err = apply_exec_credentials(&mut auth_info, token_status("header.pay<load>.sig"))
+        let err = apply_exec_credentials(&mut auth_info, token_status("header.pay\u{7f}load.sig"))
             .expect_err("a token that cannot be a bearer credential is not sent");
 
         assert!(auth_info.token.is_none(), "nothing half-applied");
-        let text = err.to_string();
         assert!(
-            text.contains('<'),
-            "the message names the character found: {text}"
+            err.to_string().contains("\\u{7f}"),
+            "the message names the character found: {err}"
+        );
+    }
+
+    /// `<` and `:` are bytes an HTTP header carries and real plugins emit —
+    /// Rancher's `<id>:<secret>` among them. Would break if the refusal
+    /// widened back to a charset narrower than the transport.
+    #[test]
+    fn a_token_with_punctuation_the_transport_accepts_is_applied() {
+        let mut auth_info = AuthInfo::default();
+        apply_exec_credentials(&mut auth_info, token_status("kubeconfig-u-abc:x9f7q2"))
+            .expect("a colon is not damage");
+
+        assert_eq!(
+            auth_info.token.as_ref().expect("the token").expose_secret(),
+            "kubeconfig-u-abc:x9f7q2"
         );
     }
 }

--- a/src-tauri/src/cli/paths.rs
+++ b/src-tauri/src/cli/paths.rs
@@ -31,6 +31,36 @@ impl PathResolver {
         }
     }
 
+    /// The file names one command can be installed under, in the order a
+    /// shell would try them.
+    ///
+    /// On Unix a command is its own file name. On Windows it is the name plus
+    /// an extension from `PATHEXT`, and the ones that matter here are not
+    /// `.exe`: Azure's CLI ships `az.cmd` and Google's `gcloud.cmd`. Joining
+    /// the bare name found neither, so the Diagnostics pane reported tools
+    /// absent that the reader can run in their own terminal, and an AKS
+    /// context whose exec command is `az` could not be started at all.
+    #[must_use]
+    pub fn binary_file_names(binary_name: &str) -> Vec<String> {
+        #[cfg(not(windows))]
+        {
+            vec![binary_name.to_string()]
+        }
+        #[cfg(windows)]
+        {
+            // The name alone stays first: a file with no extension is what an
+            // scoop shim or a hand-placed binary can be.
+            let mut names = vec![binary_name.to_string()];
+            let pathext = std::env::var("PATHEXT")
+                .unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string())
+                .to_lowercase();
+            for ext in pathext.split(';').filter(|e| e.starts_with('.')) {
+                names.push(format!("{binary_name}{ext}"));
+            }
+            names
+        }
+    }
+
     /// Build common search paths for a binary.
     ///
     /// Returns a list of paths where the binary might be installed,
@@ -86,24 +116,27 @@ impl PathResolver {
 
         #[cfg(windows)]
         {
-            // Windows common paths
+            // Every extension `PATHEXT` names, not just `.exe`: `az` and
+            // `gcloud` ship as `.cmd`.
+            let mut dirs_to_try: Vec<PathBuf> = Vec::new();
             if let Some(home) = dirs::home_dir() {
-                paths.push(
-                    home.join(".cargo\\bin")
-                        .join(format!("{}.exe", binary_name)),
-                );
-                paths.push(
-                    home.join("scoop\\shims")
-                        .join(format!("{}.exe", binary_name)),
-                );
+                dirs_to_try.push(home.join(".cargo\\bin"));
+                dirs_to_try.push(home.join("scoop\\shims"));
             }
             if let Ok(program_files) = std::env::var("ProgramFiles") {
-                paths.push(PathBuf::from(program_files).join(format!("{}.exe", binary_name)));
+                dirs_to_try.push(PathBuf::from(program_files));
+            }
+            for dir in dirs_to_try {
+                for file in Self::binary_file_names(binary_name) {
+                    paths.push(dir.join(file));
+                }
             }
         }
 
-        // Just binary name for PATH lookup (last resort)
-        paths.push(PathBuf::from(binary_name));
+        // Bare names for PATH lookup (last resort)
+        for file in Self::binary_file_names(binary_name) {
+            paths.push(PathBuf::from(file));
+        }
 
         paths
     }
@@ -235,6 +268,26 @@ impl PathResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The bare name leads, so a file installed without an extension still
+    /// wins over a `.cmd` shim beside it. Would break if the extensions were
+    /// put first.
+    #[test]
+    fn the_command_name_itself_is_tried_before_any_extension() {
+        let names = PathResolver::binary_file_names("az");
+
+        assert_eq!(names.first().map(String::as_str), Some("az"));
+        assert!(names.iter().all(|n| n.starts_with("az")));
+    }
+
+    /// A Unix command is its own file name; adding extensions there would
+    /// make every lookup miss on the first try. Would break if the Windows
+    /// branch leaked out of its `cfg`.
+    #[cfg(not(windows))]
+    #[test]
+    fn a_unix_command_has_exactly_one_file_name() {
+        assert_eq!(PathResolver::binary_file_names("gcloud"), vec!["gcloud"]);
+    }
 
     #[test]
     fn test_separator_is_os_specific() {

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -60,9 +60,12 @@ fn locate(name: &str, search_dirs: &[std::path::PathBuf]) -> Option<String> {
     if literal.components().count() > 1 {
         return is_runnable(&literal).then(|| literal.to_string_lossy().into_owned());
     }
+    let file_names = PathResolver::binary_file_names(name);
     search_dirs.iter().find_map(|dir| {
-        let candidate = dir.join(name);
-        is_runnable(&candidate).then(|| candidate.to_string_lossy().into_owned())
+        file_names.iter().find_map(|file| {
+            let candidate = dir.join(file);
+            is_runnable(&candidate).then(|| candidate.to_string_lossy().into_owned())
+        })
     })
 }
 

--- a/src-tauri/src/shell/command.rs
+++ b/src-tauri/src/shell/command.rs
@@ -11,6 +11,22 @@ use tokio::process::Command;
 
 use super::path::get_user_path;
 
+/// `CREATE_NO_WINDOW` — a console app spawned from a GUI gets no console of
+/// its own.
+///
+/// Windows gives a subsystem-windows process no console, so `CreateProcess`
+/// allocates one for every console child and it appears on screen. Nothing
+/// here is meant to be looked at: these are `--version` probes and `kubectl`
+/// calls whose pipes we read ourselves. Reported against 4.9.0 — opening
+/// Settings → Diagnostics fires six tool probes at once and six windows
+/// flash over whatever the reader was doing.
+///
+/// This is `run`'s business rather than each caller's: one spawn point, one
+/// place to decide. The auth PTY is deliberately not this — `ConPTY` has no
+/// window to begin with, and its child is one the reader can watch.
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 /// Errors that can occur during shell command execution.
 #[derive(Debug, Error)]
 pub enum ShellError {
@@ -135,6 +151,8 @@ impl ShellCommand {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
         cmd.stdin(Stdio::null());
+        #[cfg(windows)]
+        cmd.creation_flags(CREATE_NO_WINDOW);
 
         // Apply user PATH
         let user_path = get_user_path();


### PR DESCRIPTION
Both from the report on #106, against 4.9.0 on Windows.

## The credential still comes back `Unauthorized`

4.9.0 stopped the console's hard line breaks from breaking the JSON — which is
why the error moved from "Exec credentials missing status" to a bare
`Unauthorized`. The credential now parses and a token is sent; the API server
refuses it.

What `unwrap_console_breaks` cannot remove is the padding, because a space
inside a JSON string is ordinary data. Inside an `id_token` it is not: the
value travels in an HTTP header, and RFC 7235 `token68` has no room for
whitespace. Removing it therefore cannot damage a token that was ever valid,
and rescues one a terminal wrapped at eighty columns.

Anything left that a console does not explain now stops before the request,
with the character named, instead of reaching the API server to come back as a
denial that reads like a rejected login. And when the token arrives whole, the
log says so — that line is what tells the next reader which of the two
happened, since today they are the same 401.

## Windows opens a console window for every probe

A GUI process on Windows has no console of its own, so `CreateProcess`
allocates one for each console child and it appears on screen. Opening
Settings → Diagnostics fires six `--version` probes at once, and six windows
flash over whatever the reader was doing. `CREATE_NO_WINDOW` goes at the one
spawn point every non-PTY child passes through. The auth PTY keeps its own —
`ConPTY` has no window, and its child is one the reader can watch.

## What is not a bug

The empty search-path block in the attached report: the author says they
cleared those lines before attaching it.

## Verifying

512 Rust tests, clippy clean. Six new tests, each checked by breaking the code
under it. Only `build.yml` touches Windows and it builds without running tests,
so the flag is guarded by compilation and nothing more — which is what this PR
is here to get.