### PR TITLE
fix(web): the site has to build in its own image (#112)

### DIFF
--- a/web/src/components/download-buttons.tsx
+++ b/web/src/components/download-buttons.tsx
@@ -30,13 +30,13 @@ export function DownloadButtons() {
   return (
     <div className="flex flex-wrap items-center gap-3">
       {first ? (
-        <ButtonLink href="#install">
+        <ButtonLink href="/#install">
           <first.Icon aria-hidden className="size-4" />
           {first.label}
         </ButtonLink>
       ) : null}
       {rest.map((d) => (
-        <ButtonLink key={d.os} href="#install" variant="ghost">
+        <ButtonLink key={d.os} href="/#install" variant="ghost">
           <d.Icon aria-hidden className="size-4" />
           {d.label.replace("Download for ", "")}
         </ButtonLink>

--- a/web/src/components/peek.tsx
+++ b/web/src/components/peek.tsx
@@ -126,7 +126,7 @@ function RefRow({
     <button
       type="button"
       onClick={() => onOpen(key)}
-      className="group -mx-2 flex min-h-9 flex-wrap items-center gap-x-2 rounded-md px-2 text-left font-mono text-[13px] transition-colors hover:bg-neutral-800/70 focus-visible:bg-neutral-800/70 focus-visible:outline-none"
+      className="group -mx-2 flex min-h-9 flex-wrap items-center gap-x-2 rounded-md px-2 text-left font-mono text-[13px] transition-colors hover:bg-neutral-800/70 focus-visible:bg-neutral-800/70 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
     >
       {body}
       <span

--- a/web/src/routes/certificates.tsx
+++ b/web/src/routes/certificates.tsx
@@ -16,6 +16,11 @@ export const Route = createFileRoute("/certificates")({
       { property: "og:description", content: description },
       { property: "og:url", content: url },
       { property: "og:image", content: `${SITE.url}/og/certificates.png` },
+      {
+        property: "og:image:alt",
+        content:
+          "The certificates card: what issued each certificate, when it expires, and what renews it",
+      },
       { name: "twitter:title", content: title },
       { name: "twitter:description", content: description },
       { name: "twitter:image", content: `${SITE.url}/og/certificates.png` },

--- a/web/src/routes/delivery.tsx
+++ b/web/src/routes/delivery.tsx
@@ -16,6 +16,11 @@ export const Route = createFileRoute("/delivery")({
       { property: "og:description", content: description },
       { property: "og:url", content: url },
       { property: "og:image", content: `${SITE.url}/og/delivery.png` },
+      {
+        property: "og:image:alt",
+        content:
+          "The Argo CD and Flux delivery card: what applied each object, and whether an edit made by hand survives",
+      },
       { name: "twitter:title", content: title },
       { name: "twitter:description", content: description },
       { name: "twitter:image", content: `${SITE.url}/og/delivery.png` },

--- a/web/src/sections/nav.tsx
+++ b/web/src/sections/nav.tsx
@@ -41,7 +41,7 @@ export function Nav() {
             <FaGithub aria-hidden className="size-4" />
             GitHub
           </a>
-          <ButtonLink href="#install">Download</ButtonLink>
+          <ButtonLink href="/#install">Download</ButtonLink>
         </nav>
       </div>
     </header>

--- a/web/src/sections/quiz-cases.ts
+++ b/web/src/sections/quiz-cases.ts
@@ -1,0 +1,139 @@
+/**
+ * The six pod fragments the quiz asks about, and the status inspection leaves
+ * standing for each.
+ *
+ * Copied once from `shared/pod-status-conformance.json`, which is the contract
+ * between the two evaluators of pod status — Rust for a live pod, TypeScript
+ * for a pasted manifest. It is deliberately not imported: that file lives at
+ * the repository root, outside this site's Docker build context, and reading it
+ * from here would also make a case added for the Rust conformance test change
+ * what the marketing site asks visitors.
+ */
+
+export type QuizContainer = {
+  ready?: boolean;
+  state: {
+    waiting?: { reason?: string };
+    terminated?: { reason?: string; exitCode?: number; signal?: number };
+    running?: object;
+  };
+};
+
+export type QuizCase = {
+  name: string;
+  expect: string;
+  status: { phase: string; containerStatuses: QuizContainer[] };
+};
+
+export const QUIZ_CASES: QuizCase[] = [
+  {
+    name: "a container waiting for a reason names the pod",
+    expect: "CrashLoopBackOff",
+    status: {
+      phase: "Running",
+      containerStatuses: [
+        {
+          ready: false,
+          state: {
+            waiting: {
+              reason: "CrashLoopBackOff",
+            },
+          },
+        },
+      ],
+    },
+  },
+  {
+    name: "the first container's verdict is the one that stands",
+    expect: "ImagePullBackOff",
+    status: {
+      phase: "Running",
+      containerStatuses: [
+        {
+          ready: false,
+          state: {
+            waiting: {
+              reason: "ImagePullBackOff",
+            },
+          },
+        },
+        {
+          ready: false,
+          state: {
+            waiting: {
+              reason: "CrashLoopBackOff",
+            },
+          },
+        },
+      ],
+    },
+  },
+  {
+    name: "a running container leaves the phase standing",
+    expect: "Running",
+    status: {
+      phase: "Running",
+      containerStatuses: [
+        {
+          ready: true,
+          state: {
+            running: {},
+          },
+        },
+      ],
+    },
+  },
+  {
+    name: "a terminated container names its reason",
+    expect: "OOMKilled",
+    status: {
+      phase: "Failed",
+      containerStatuses: [
+        {
+          ready: false,
+          state: {
+            terminated: {
+              exitCode: 137,
+              reason: "OOMKilled",
+            },
+          },
+        },
+      ],
+    },
+  },
+  {
+    name: "a terminated container with no reason names its exit code",
+    expect: "ExitCode:2",
+    status: {
+      phase: "Failed",
+      containerStatuses: [
+        {
+          ready: false,
+          state: {
+            terminated: {
+              exitCode: 2,
+            },
+          },
+        },
+      ],
+    },
+  },
+  {
+    name: "a container killed by a signal names the signal",
+    expect: "Signal:9",
+    status: {
+      phase: "Failed",
+      containerStatuses: [
+        {
+          ready: false,
+          state: {
+            terminated: {
+              exitCode: 0,
+              signal: 9,
+            },
+          },
+        },
+      ],
+    },
+  },
+];

--- a/web/src/sections/quiz.tsx
+++ b/web/src/sections/quiz.tsx
@@ -1,25 +1,14 @@
 import { useRef, useState } from "react";
-import corpus from "../../../shared/pod-status-conformance.json";
+import { QUIZ_CASES, type QuizContainer } from "./quiz-cases";
 import { Reveal } from "../components/motion/reveal";
 import { Section } from "../components/section";
 import { useHydrated } from "../lib/use-hydrated";
 
-type Container = {
-  ready?: boolean;
-  state: {
-    waiting?: { reason?: string };
-    terminated?: { reason?: string; exitCode?: number; signal?: number };
-    running?: object;
-  };
-};
-
-const VERDICTS = [
-  ...new Set([...corpus.cases.map((c) => c.expect), "Running"]),
-];
+const VERDICTS = [...new Set([...QUIZ_CASES.map((c) => c.expect), "Running"])];
 const FOCUS =
   "focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent";
 
-function evidence(containers: Container[]) {
+function evidence(containers: QuizContainer[]) {
   for (const [index, container] of containers.entries()) {
     const { waiting, terminated } = container.state;
     if (waiting?.reason) {
@@ -54,12 +43,12 @@ export function Quiz() {
   const [index, setIndex] = useState(0);
   const [choice, setChoice] = useState<string | null>(null);
   const firstVerdict = useRef<HTMLButtonElement>(null);
-  const current = corpus.cases[index]!;
+  const current = QUIZ_CASES[index]!;
   const inspected = !interactive || choice !== null;
   const decisive = evidence(current.status.containerStatuses);
 
   function nextCase() {
-    setIndex((previous) => (previous + 1) % corpus.cases.length);
+    setIndex((previous) => (previous + 1) % QUIZ_CASES.length);
     setChoice(null);
     firstVerdict.current?.focus();
   }
@@ -85,7 +74,7 @@ export function Quiz() {
             aria-atomic="true"
             className="font-mono text-sm tabular-nums text-neutral-400"
           >
-            {index + 1} of {corpus.cases.length}
+            {index + 1} of {QUIZ_CASES.length}
           </p>
         </div>
         <div className="p-6">
@@ -104,7 +93,7 @@ export function Quiz() {
           </div>
           <div className="mt-6 space-y-4">
             {current.status.containerStatuses.map((raw, containerIndex) => {
-              const container: Container = raw;
+              const container: QuizContainer = raw;
               const state = container.state;
               const fields = [
                 [


### PR DESCRIPTION
Four findings from a review of #112, one of them stopping the deploy. Targets
`feat/landing-motion` so they land inside that PR.

## The site no longer builds in its image

`web/src/sections/quiz.tsx` imports `shared/pod-status-conformance.json` from
the repository root. The Docker context is `web/`, so that file is not in the
image and `RUN bun run build` stops at `UNRESOLVED_IMPORT`. `docker build .`
fails on the branch and succeeds on main.

Nothing catches it earlier — no workflow builds `web/`, and `bun run build`,
`tsc --noEmit` and `eslint` are all green in a checkout, because there the
file really is two directories up. That is why the branch looked fine.

The six cases are copied into `quiz-cases.ts` rather than widening the build
context. That corpus is the contract between the two evaluators of pod status
and is read today by exactly two things, both tests. Importing it here would
mean a case added for the Rust conformance test silently changes what the
marketing site asks visitors — which is the defect class `CLAUDE.md` is built
around.

## Three more

- **Focus ring.** The peek rows carried `focus-visible:outline-none` with a
  background tint as the only replacement, measuring **1.12:1** against the
  card where WCAG asks 3:1. A keyboard reader could not tell which of seven
  rows was focused. Back to the outline every other interactive surface in
  this branch already uses.
- **Dead Download button.** The header pointed at `#install`, a section that
  exists only on the landing, so it did nothing on the five other pages `Nav`
  renders on. Now `/#install`.
- **`og:image:alt`.** `/delivery` and `/certificates` set their own
  `og:image` and inherited the root's alt, which describes the landing card.

## Verified

`docker build` completes; the container serves `/`, `/delivery/` and
`/lies/running/`; `lies.yaml` comes back as `text/yaml`; an unknown path
answers a real 404 rather than a soft one. `bun run build` prerenders 11
pages, `bun run check` and `bun run lint` are clean.