### PR TITLE
fix(web): a reveal that never arrives leaves the page readable (#112)

### DIFF
--- a/web/src/lib/use-in-view.ts
+++ b/web/src/lib/use-in-view.ts
@@ -1,8 +1,17 @@
+declare global {
+  interface Window {
+    __disarmReveal?: ReturnType<typeof setTimeout>;
+  }
+}
+
 import { useEffect, useRef } from "react";
 
 const observers = new Map<string, IntersectionObserver>();
 
 function observe(el: Element, margin: string) {
+  // The bundle is here, so the disarm timer in `__root.tsx` is not needed.
+  clearTimeout(window.__disarmReveal);
+
   if (!("IntersectionObserver" in window)) {
     el.setAttribute("data-in", "");
     return () => {};

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -8,6 +8,19 @@ import { NotFound } from "../components/not-found";
 import { JSON_LD, OG_IMAGE, SITE } from "../lib/site";
 import appCss from "../styles.css?url";
 
+/**
+ * Arm the scroll reveal, and disarm it if the bundle never turns up.
+ *
+ * `@media (scripting: enabled)` says JavaScript is allowed, not that it ran,
+ * so a bundle that 404s or is stripped by a proxy would leave every
+ * `[data-reveal]` at `opacity: 0` for good — the whole page below the hero.
+ * Arming here rather than at hydration is what keeps the reveal from
+ * flashing; `use-in-view` clears the timer as soon as it observes anything,
+ * so the timeout only ever fires on a page whose bundle did not arrive.
+ */
+const ARM_REVEAL = `document.documentElement.setAttribute('data-reveal-armed','');
+window.__disarmReveal=setTimeout(function(){document.documentElement.removeAttribute('data-reveal-armed')},5000)`;
+
 export const Route = createRootRoute({
   head: () => ({
     meta: [
@@ -36,7 +49,10 @@ export const Route = createRootRoute({
       { rel: "icon", type: "image/svg+xml", href: "/logo.svg" },
       { rel: "apple-touch-icon", href: "/apple-touch-icon.png" },
     ],
-    scripts: [{ type: "application/ld+json", children: JSON_LD }],
+    scripts: [
+      { type: "application/ld+json", children: JSON_LD },
+      { children: ARM_REVEAL },
+    ],
   }),
   component: RootComponent,
   notFoundComponent: NotFound,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -125,14 +125,19 @@ p {
     animation: rise 0.6s var(--ease-enter) var(--d, 0s) both;
   }
 
-  [data-reveal] {
+  /* Armed by the inline script in `__root.tsx`, and disarmed by it if the
+     bundle never turns up. `scripting: enabled` says JavaScript is allowed,
+     not that it ran: without this gate a bundle that 404s or is stripped by a
+     proxy leaves every one of these at `opacity: 0` for good, which is the
+     whole page below the hero. */
+  [data-reveal-armed] [data-reveal] {
     opacity: 0;
     transform: translateY(12px);
     transition:
       opacity 0.36s var(--ease-enter) var(--d, 0s),
       transform 0.36s var(--ease-enter) var(--d, 0s);
   }
-  [data-reveal="settle"] {
+  [data-reveal-armed] [data-reveal="settle"] {
     transform: translateY(12px) scale(0.985);
   }
   [data-reveal][data-in],


### PR DESCRIPTION
The last confirmed finding from the review of #112.

`@media (scripting: enabled)` distinguishes "JS off" from "JS on" — not the third state, "JS on but the bundle never arrived". In that state every `[data-reveal]` stayed at `opacity: 0` permanently: deleting every `*.js` from a build and serving it gives a black screen below the hero, 50 hidden elements over 15 000 px, with the prerendered HTML fully present underneath.

Hiding is gated on `data-reveal-armed` now, set by an inline head script rather than at hydration so nothing flashes, plus a timer that takes it back off. `use-in-view` clears the timer as soon as it observes anything, so the timeout only fires on a page whose bundle did not arrive.

Verified against a real build in all three states — bundle removed, bundle present (armed, still armed after 8s, scroll still reveals), and JavaScript off.