### PR TITLE
fix(auth): a token half a console drew is not a login the cluster refused (#106)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,33 @@ jobs:
 
       - name: Frontend lint
         run: bun run lint
+
+  windows-console:
+    name: Windows console
+    runs-on: windows-2025
+
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Setup Tauri build environment
+        uses: ./.github/actions/setup-tauri
+        with:
+          target: x86_64-pc-windows-msvc
+          install_tauri_cli: 'false'
+
+      - name: Build frontend
+        # `tauri::generate_context!()` reads ../dist while the crate compiles.
+        run: bun run build
+
+      - name: Console tests
+        # Filtered, not the whole suite: the rest of the Rust tests spawn
+        # `/bin/sh` and have never run on Windows. These are the ones whose
+        # subject *is* the platform — ConPTY hands back a rendered screen
+        # rather than the child's bytes, and no other runner can tell us what
+        # that does to a credential.
+        run: cargo test --workspace drawn_on_it -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,4 +92,4 @@ jobs:
         # subject *is* the platform — ConPTY hands back a rendered screen
         # rather than the child's bytes, and no other runner can tell us what
         # that does to a credential.
-        run: cargo test --workspace drawn_on_it -- --nocapture
+        run: cargo test --workspace auth::interactive::cred::tests -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,4 +92,6 @@ jobs:
         # subject *is* the platform — ConPTY hands back a rendered screen
         # rather than the child's bytes, and no other runner can tell us what
         # that does to a credential.
-        run: cargo test --workspace auth::interactive::cred::tests -- --nocapture
+        run: |
+          cargo test --workspace auth::interactive::cred::tests -- --nocapture
+          cargo test --workspace terminal::adapters::auth_exec

--- a/src-tauri/src/auth/interactive/cred.rs
+++ b/src-tauri/src/auth/interactive/cred.rs
@@ -675,4 +675,93 @@ mod tests {
             TokenReading::Jwt { expires_at: None }
         );
     }
+
+    /// A token long enough to fill the console it is drawn on, run through
+    /// the real terminal the auth flow uses.
+    ///
+    /// This is the reported failure reproduced rather than reasoned about.
+    /// `ConPTY` is a screen buffer: an `id_token` of a few kilobytes does not
+    /// fit an 80x24 console, so the child's bytes reach us only after being
+    /// wrapped, scrolled and repainted. Whatever that does to the token, it
+    /// leaves it ASCII-graphic and whitespace-free — which is why every check
+    /// before this one passed and the cluster answered `Unauthorized` with
+    /// nothing to say about why.
+    ///
+    /// `type`/`cat` is the child on purpose: no shell quoting, and the bytes
+    /// on the way in are exactly the bytes in the file.
+    #[tokio::test]
+    async fn a_token_longer_than_the_console_survives_being_drawn_on_it() {
+        use crate::terminal::{AuthExecAdapter, TerminalAdapter};
+        use std::collections::HashMap;
+        use std::time::Duration;
+
+        // 3893 characters, the length from the report, and non-periodic so a
+        // run repeated by a repaint cannot pass for the original.
+        let token: String = {
+            const ALPHABET: &[u8] =
+                b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+            let mut seed: u64 = 0x5eed_1234_9876_abcd;
+            (0..3893)
+                .map(|_| {
+                    seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+                    ALPHABET[(seed >> 33) as usize % ALPHABET.len()] as char
+                })
+                .collect()
+        };
+        let payload = format!(
+            r#"{{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","status":{{"token":"{token}"}}}}"#
+        );
+
+        let path = std::env::temp_dir().join(format!("rubick-cred-{}.json", uuid::Uuid::new_v4()));
+        std::fs::write(&path, payload.as_bytes()).expect("the test writes its own input");
+        let shown = path.to_string_lossy().to_string();
+
+        let (command, args) = if cfg!(windows) {
+            (
+                "cmd.exe".to_string(),
+                vec!["/C".into(), "type".into(), shown],
+            )
+        } else {
+            ("/bin/cat".to_string(), vec![shown])
+        };
+        let mut adapter = AuthExecAdapter::new(command, args, HashMap::new());
+        let collected = adapter.collected_stdout();
+
+        adapter.connect().await.expect("the child has to start");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+        let mut idle = 0;
+        while tokio::time::Instant::now() < deadline {
+            match adapter.read_output().await {
+                Ok(Some(_)) => idle = 0,
+                Ok(None) => {
+                    idle += 1;
+                    if idle > 10 && !adapter.is_running() {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(_) => break,
+            }
+        }
+        adapter.close().await.expect("close");
+        let _ = std::fs::remove_file(&path);
+
+        let buffer = collected.lock().clone();
+        let credential = extract_exec_credential(&buffer).unwrap_or_else(|why| {
+            panic!("no credential in {} bytes of console: {why}", buffer.len())
+        });
+        let mut got = credential
+            .status
+            .and_then(|status| status.token)
+            .expect("the payload names a token");
+        let shape = mend_bearer_token(&mut got);
+
+        assert_eq!(
+            got,
+            token,
+            "the console changed the token: {} characters came back where {} went in, shape {shape:?}",
+            got.len(),
+            token.len()
+        );
+    }
 }

--- a/src-tauri/src/auth/interactive/cred.rs
+++ b/src-tauri/src/auth/interactive/cred.rs
@@ -729,6 +729,14 @@ mod tests {
         let exited = adapter.last_exit_status();
 
         adapter.connect().await.expect("the child has to start");
+        // `ConPTY` opens by asking the terminal where the cursor is (`ESC[6n`)
+        // and does not get on with the child until something answers. In the
+        // app xterm answers; here nothing would, and the plugin would sit
+        // there printing nothing until the flow timed out.
+        adapter
+            .write_input(b"\x1b[1;1R")
+            .await
+            .expect("the console asked where the cursor is");
         // Draining stops on the exit status and then keeps reading: the
         // child is gone long before the reader thread has handed over what
         // the console still had, and stopping at `is_running` loses it.

--- a/src-tauri/src/auth/interactive/cred.rs
+++ b/src-tauri/src/auth/interactive/cred.rs
@@ -726,17 +726,23 @@ mod tests {
         };
         let mut adapter = AuthExecAdapter::new(command, args, HashMap::new());
         let collected = adapter.collected_stdout();
+        let exited = adapter.last_exit_status();
 
         adapter.connect().await.expect("the child has to start");
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
-        let mut idle = 0;
+        // Draining stops on the exit status and then keeps reading: the
+        // child is gone long before the reader thread has handed over what
+        // the console still had, and stopping at `is_running` loses it.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut after_exit = 0;
         while tokio::time::Instant::now() < deadline {
             match adapter.read_output().await {
-                Ok(Some(_)) => idle = 0,
+                Ok(Some(_)) => after_exit = 0,
                 Ok(None) => {
-                    idle += 1;
-                    if idle > 10 && !adapter.is_running() {
-                        break;
+                    if exited.lock().is_some() {
+                        after_exit += 1;
+                        if after_exit > 50 {
+                            break;
+                        }
                     }
                     tokio::time::sleep(Duration::from_millis(20)).await;
                 }
@@ -747,6 +753,13 @@ mod tests {
         let _ = std::fs::remove_file(&path);
 
         let buffer = collected.lock().clone();
+        let seen = String::from_utf8_lossy(&buffer);
+        println!(
+            "console handed back {} bytes, exit {:?}: {}",
+            buffer.len(),
+            exited.lock(),
+            seen.chars().take(600).collect::<String>().escape_debug()
+        );
         let credential = extract_exec_credential(&buffer).unwrap_or_else(|why| {
             panic!("no credential in {} bytes of console: {why}", buffer.len())
         });

--- a/src-tauri/src/auth/interactive/cred.rs
+++ b/src-tauri/src/auth/interactive/cred.rs
@@ -689,8 +689,9 @@ mod tests {
     ///
     /// `type`/`cat` is the child on purpose: no shell quoting, and the bytes
     /// on the way in are exactly the bytes in the file.
-    #[tokio::test]
-    async fn a_token_longer_than_the_console_survives_being_drawn_on_it() {
+    /// Run a 3893-character token through the real auth terminal at a given
+    /// console width, and hand back what came out the other side.
+    async fn token_through_a_console(cols: u16) -> (String, String) {
         use crate::terminal::{AuthExecAdapter, TerminalAdapter};
         use std::collections::HashMap;
         use std::time::Duration;
@@ -737,6 +738,10 @@ mod tests {
             .write_input(b"\x1b[1;1R")
             .await
             .expect("the console asked where the cursor is");
+        adapter
+            .resize(cols, 24)
+            .await
+            .expect("the console takes the width it is given");
         // Draining stops on the exit status and then keeps reading: the
         // child is gone long before the reader thread has handed over what
         // the console still had, and stopping at `is_running` loses it.
@@ -775,14 +780,42 @@ mod tests {
             .status
             .and_then(|status| status.token)
             .expect("the payload names a token");
-        let shape = mend_bearer_token(&mut got);
+        mend_bearer_token(&mut got);
+        (token, got)
+    }
+
+    /// The reported failure, reproduced. `ConPTY` is a screen buffer: an
+    /// `id_token` of a few kilobytes does not fit an 80-column console, so
+    /// what reaches us has been wrapped and repainted first. Whatever that
+    /// does, it leaves the token ASCII-graphic and whitespace-free — which is
+    /// why every check before this one passed and the cluster answered
+    /// `Unauthorized` with nothing to say about why.
+    #[tokio::test]
+    async fn a_token_longer_than_the_console_survives_being_drawn_on_it() {
+        let (sent, got) = token_through_a_console(80).await;
 
         assert_eq!(
             got,
-            token,
-            "the console changed the token: {} characters came back where {} went in, shape {shape:?}",
+            sent,
+            "the console changed the token: {} characters came back where {} went in",
             got.len(),
-            token.len()
+            sent.len()
+        );
+    }
+
+    /// The same token down a console wide enough that no line of it wraps.
+    /// If this one comes back whole while the 80-column one does not, the
+    /// wrapping is the damage and a console kept wide is the cure.
+    #[tokio::test]
+    async fn a_token_that_never_wraps_comes_back_whole() {
+        let (sent, got) = token_through_a_console(8192).await;
+
+        assert_eq!(
+            got,
+            sent,
+            "a console that never wrapped still changed the token: {} characters came back where {} went in",
+            got.len(),
+            sent.len()
         );
     }
 }

--- a/src-tauri/src/auth/interactive/cred.rs
+++ b/src-tauri/src/auth/interactive/cred.rs
@@ -742,26 +742,9 @@ mod tests {
             .resize(cols, 24)
             .await
             .expect("the console takes the width it is given");
-        // Draining stops on the exit status and then keeps reading: the
-        // child is gone long before the reader thread has handed over what
-        // the console still had, and stopping at `is_running` loses it.
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
-        let mut after_exit = 0;
-        while tokio::time::Instant::now() < deadline {
-            match adapter.read_output().await {
-                Ok(Some(_)) => after_exit = 0,
-                Ok(None) => {
-                    if exited.lock().is_some() {
-                        after_exit += 1;
-                        if after_exit > 50 {
-                            break;
-                        }
-                    }
-                    tokio::time::sleep(Duration::from_millis(20)).await;
-                }
-                Err(_) => break,
-            }
-        }
+        // The same drain the adapter's own tests use: stopping at
+        // `is_running` loses what the console still had to hand over.
+        adapter.drain_to_exit(Duration::from_secs(30)).await;
         adapter.close().await.expect("close");
         let _ = std::fs::remove_file(&path);
 

--- a/src-tauri/src/auth/interactive/cred.rs
+++ b/src-tauri/src/auth/interactive/cred.rs
@@ -94,6 +94,80 @@ pub(super) fn mend_bearer_token(token: &mut String) -> TokenShape {
     TokenShape::Intact
 }
 
+/// What a token that claims to be a JWT turned out to say.
+///
+/// The three states exist because they are three different things to do, and
+/// the cluster answers all of them with the same bare `Unauthorized`.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum TokenReading {
+    /// Not a JWT. Rancher issues `<id>:<secret>`, and a bare opaque string is
+    /// a credential too — nothing here is entitled to judge either.
+    Opaque,
+    /// A JWT that reads, and the deadline it names where it names one.
+    Jwt {
+        expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    },
+    /// A JWT header, and then a payload that is not one. A token cannot be
+    /// half a JWT: whatever produced this damaged it in transit.
+    Damaged { why: String },
+}
+
+fn decode_segment(segment: &str) -> Option<Vec<u8>> {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(segment)
+        .ok()
+}
+
+/// Read a bearer token as a JWT, where it is one.
+///
+/// The header is what decides: a JWT's first segment is base64url of an
+/// object naming `alg`. Once that has been seen, a payload that will not
+/// decode is damage rather than a token this cannot understand — which is
+/// the distinction the caller needs, because one is worth refusing before
+/// the request and the other is not.
+///
+/// The console is the reason this exists. `ConPTY` hands back a rendered
+/// screen: a repaint can put a run of the token on the buffer twice, and the
+/// duplicate is as ASCII-graphic and as whitespace-free as the real thing, so
+/// [`mend_bearer_token`] finds nothing to mend and the cluster refuses a
+/// credential nobody can see anything wrong with.
+pub(super) fn read_jwt(token: &str) -> TokenReading {
+    let mut parts = token.split('.');
+    let (Some(header), Some(payload), Some(_signature), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return TokenReading::Opaque;
+    };
+
+    let Some(header_json) = decode_segment(header)
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+    else {
+        return TokenReading::Opaque;
+    };
+    if header_json.get("alg").is_none() {
+        return TokenReading::Opaque;
+    }
+
+    let Some(bytes) = decode_segment(payload) else {
+        return TokenReading::Damaged {
+            why: "its payload is not the base64url a JWT carries".to_string(),
+        };
+    };
+    let Ok(claims) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return TokenReading::Damaged {
+            why: "its payload decodes to something that is not the JSON of a claim set".to_string(),
+        };
+    };
+
+    TokenReading::Jwt {
+        expires_at: claims
+            .get("exp")
+            .and_then(serde_json::Value::as_i64)
+            .and_then(|secs| chrono::DateTime::from_timestamp(secs, 0)),
+    }
+}
+
 /// Extract an `ExecCredential` JSON object from a (possibly noisy)
 /// stdout buffer.
 ///
@@ -516,47 +590,89 @@ mod tests {
         assert_eq!(cred.status.unwrap().token.as_deref(), Some("} fake }"));
     }
 
-    // ---- TEMPORARY PROBES (to be reverted) ----
-    #[test]
-    fn probe_nbsp_count_is_bytes_not_characters() {
-        let mut t = " a\u{00a0}b\u{2003}c ".to_string();
-        let shape = mend_bearer_token(&mut t);
-        println!("PROBE nbsp: shape={shape:?} token={t:?} chars_removed=4");
+    fn jwt(payload: &str) -> String {
+        use base64::Engine;
+        let b64 = |raw: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw);
+        format!(
+            "{}.{}.{}",
+            b64(br#"{"alg":"RS256","typ":"JWT"}"#),
+            b64(payload.as_bytes()),
+            b64(&[7u8; 256])
+        )
     }
 
+    /// A token that is not a JWT is still a credential — Rancher issues
+    /// `<id>:<secret>` and plenty of clusters take an opaque string. Would
+    /// break if the reading refused everything it could not decode.
     #[test]
-    fn probe_rancher_style_token_with_colon() {
-        let mut t = "kubeconfig-u-abcde1234:x9f7q2mnb4vzt8k6hjw3rslp5dgy0c".to_string();
-        println!("PROBE rancher: {:?}", mend_bearer_token(&mut t));
+    fn a_token_that_is_not_a_jwt_is_not_judged() {
+        assert_eq!(read_jwt("kubeconfig-u-abc123:xyz789"), TokenReading::Opaque);
+        assert_eq!(read_jwt("plain-opaque-token"), TokenReading::Opaque);
+        // Three dotted segments, but the first is not a JWT header.
+        assert_eq!(read_jwt("one.two.three"), TokenReading::Opaque);
     }
 
+    /// `ConPTY` hands back a rendered screen, and a repaint can put a run of
+    /// the token on it twice. The duplicate is as ASCII-graphic and as
+    /// whitespace-free as the rest, so `mend_bearer_token` finds nothing —
+    /// and the cluster answers the broken credential with a bare 401 that
+    /// reads exactly like a rejected login. Would break if a JWT whose
+    /// payload no longer decodes were sent anyway.
     #[test]
-    fn probe_openshift_and_aws_and_jwt() {
-        for s in [
-            "sha256~kV46hPnEJhb4H4N1cM3-abcDEF_123",
-            "k8s-aws-v1.aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8_QWN0aW9u",
-            "eyJhbGciOiJSUzI1NiIsImtpZCI6IngifQ.eyJzdWIiOiIxIn0.sig-_",
-            "ya29.a0AfB_byC-x_9dQ",
-        ] {
-            let mut t = s.to_string();
-            println!("PROBE ok-shapes {:?} -> {:?}", s, mend_bearer_token(&mut t));
-        }
-    }
-
-    #[test]
-    fn probe_all_whitespace_token_becomes_empty_but_reports_mended() {
-        let mut t = "   ".to_string();
-        let shape = mend_bearer_token(&mut t);
-        println!(
-            "PROBE whitespace-only: shape={shape:?} token={t:?} len={}",
-            t.len()
+    fn a_payload_a_console_doubled_is_damage_and_not_a_login_the_cluster_refused() {
+        let good = jwt(r#"{"sub":"kirill","exp":33229977600}"#);
+        let mut parts = good.split('.');
+        let (header, payload, signature) = (
+            parts.next().unwrap(),
+            parts.next().unwrap(),
+            parts.next().unwrap(),
         );
+        // The screen showed the middle of the payload a second time.
+        let doubled = format!("{header}.{payload}{}.{signature}", &payload[..40]);
+
+        let mut token = doubled.clone();
+        assert_eq!(mend_bearer_token(&mut token), TokenShape::Intact);
+        assert!(matches!(read_jwt(&doubled), TokenReading::Damaged { .. }));
     }
 
+    /// The other half of the damage: a payload that still decodes, into
+    /// something that is not a claim set. A console that overwrote a run of
+    /// base64 with a run of its own leaves exactly this. Would break if only
+    /// the base64 step were checked.
     #[test]
-    fn probe_token_is_mutated_even_when_unusable() {
-        let mut t = "ab cd<ef".to_string();
-        let shape = mend_bearer_token(&mut t);
-        println!("PROBE unusable-mutation: shape={shape:?} token={t:?}");
+    fn a_payload_that_decodes_to_something_other_than_claims_is_damage() {
+        use base64::Engine;
+        let b64 = |raw: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw);
+        let token = format!(
+            "{}.{}.{}",
+            b64(br#"{"alg":"RS256","typ":"JWT"}"#),
+            b64(b"Logging in ... done"),
+            b64(&[7u8; 256])
+        );
+
+        assert!(matches!(read_jwt(&token), TokenReading::Damaged { .. }));
+    }
+
+    /// The deadline a plugin does not name is often written inside the token
+    /// it returns. Reading it there is what lets a surface say when the
+    /// session ends instead of assuming it never does.
+    #[test]
+    fn an_undamaged_jwt_hands_back_the_deadline_it_carries() {
+        let reading = read_jwt(&jwt(r#"{"sub":"kirill","exp":33229977600}"#));
+
+        let TokenReading::Jwt { expires_at } = reading else {
+            panic!("a JWT this test built itself has to read as one");
+        };
+        assert_eq!(expires_at.map(|at| at.timestamp()), Some(33_229_977_600));
+    }
+
+    /// A JWT with no `exp` is a JWT with no stated deadline, which is a
+    /// different thing from one that has expired.
+    #[test]
+    fn a_jwt_naming_no_expiry_names_no_deadline() {
+        assert_eq!(
+            read_jwt(&jwt(r#"{"sub":"kirill"}"#)),
+            TokenReading::Jwt { expires_at: None }
+        );
     }
 }

--- a/src-tauri/src/auth/interactive/mod.rs
+++ b/src-tauri/src/auth/interactive/mod.rs
@@ -144,6 +144,11 @@ fn apply_exec_credentials(
 ) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
     use base64::Engine;
 
+    // A plugin that names no deadline may still be carrying one inside the
+    // token. Reading it there is the difference between the app knowing when
+    // the session ends and guessing that it does not.
+    let mut jwt_deadline = None;
+
     if let Some(mut token) = status.token {
         match cred::mend_bearer_token(&mut token) {
             // The length only — a token is a credential and does not go in a log.
@@ -172,6 +177,31 @@ fn apply_exec_credentials(
                 )));
             }
         }
+        // Whitespace is not the only thing a console can leave in a token,
+        // only the one that stops the JSON parsing. A JWT says whether what
+        // came back is still the token the plugin wrote.
+        match cred::read_jwt(&token) {
+            cred::TokenReading::Damaged { why } => {
+                return Err(Error::Auth(AuthError::Kubeconfig(format!(
+                    "The credential plugin returned a token that begins as a JWT and \
+                     then {why}. The terminal the plugin ran under damaged its output; \
+                     the cluster would refuse this without saying why, and this is not \
+                     a rejected login."
+                ))));
+            }
+            cred::TokenReading::Jwt {
+                expires_at: Some(at),
+            } if at <= chrono::Utc::now() => {
+                return Err(Error::Auth(AuthError::Kubeconfig(format!(
+                    "The credential plugin returned a token that expired at {at}. \
+                     The cluster would refuse it as an unauthenticated request."
+                ))));
+            }
+            cred::TokenReading::Jwt { expires_at } => {
+                jwt_deadline = expires_at;
+            }
+            cred::TokenReading::Opaque => {}
+        }
         auth_info.token = Some(SecretString::from(token));
     }
     // A plugin hands back PEM, but the fields it lands in are kubeconfig
@@ -194,7 +224,8 @@ fn apply_exec_credentials(
     Ok(status
         .expiration_timestamp
         .and_then(|stamp| chrono::DateTime::parse_from_rfc3339(&stamp).ok())
-        .map(|stamp| stamp.with_timezone(&chrono::Utc)))
+        .map(|stamp| stamp.with_timezone(&chrono::Utc))
+        .or(jwt_deadline))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/auth/interactive/mod.rs
+++ b/src-tauri/src/auth/interactive/mod.rs
@@ -78,8 +78,11 @@ pub async fn prepare_kubeconfig_for_context(
         if provider.name == "oidc" {
             let oidc_result =
                 oidc::run_oidc_auth(state, context_name, &user_name, &provider).await?;
-            auth_info.token = Some(SecretString::from(oidc_result.token));
-            auth_info.auth_provider = None;
+            let expires_at = apply_oidc_result(auth_info, oidc_result)?;
+            return Ok(PreparedContext {
+                kubeconfig,
+                expires_at,
+            });
         }
     }
 
@@ -133,11 +136,92 @@ fn resolve_exec_cluster(
     Ok(Some(exec_cluster))
 }
 
-/// Applies what the plugin returned, and hands back the deadline it named.
+/// Apply what the kubeconfig's own `oidc` provider produced.
 ///
-/// The log line and the two refusals are what tell a bare `Unauthorized`
-/// apart: the cluster refusing a whole credential, and us sending a broken
-/// one, read identically and have nothing in common to do about them.
+/// Its own function so the wiring is testable: the branch used to assign
+/// `auth_info.token` itself, which meant a token a console had damaged was
+/// refused on the exec path and sent on this one, and the deadline the
+/// provider had just handed over was dropped on the floor.
+fn apply_oidc_result(
+    auth_info: &mut AuthInfo,
+    result: crate::auth::AuthResult,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
+    let named = result.expires_at;
+    // What the provider said, and failing that what the token itself says.
+    let carried = apply_bearer_token(auth_info, result.token, "oidc auth provider")?;
+    auth_info.auth_provider = None;
+    Ok(named.or(carried))
+}
+
+/// Put a bearer token on the auth info, having read what a console left in it.
+///
+/// The one place a credential becomes the one the client will send. Both ways
+/// in come through here — a plugin's `ExecCredential` and the kubeconfig's own
+/// `oidc` provider — because a token validated on one path and taken on trust
+/// on the other is the same bug wearing two hats, and the cluster answers
+/// both with the same bare `Unauthorized`.
+///
+/// Hands back the deadline the token carries, where it carries one.
+fn apply_bearer_token(
+    auth_info: &mut AuthInfo,
+    mut token: String,
+    source: &str,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
+    match cred::mend_bearer_token(&mut token) {
+        // The length only — a token is a credential and does not go in a log.
+        cred::TokenShape::Intact => tracing::info!(
+            "Applied a {} character token from the {source}, intact.",
+            token.len()
+        ),
+        cred::TokenShape::Mended { removed } => tracing::warn!(
+            "The {source}'s token carried {removed} whitespace characters the \
+             console that drew it put there. Removed."
+        ),
+        cred::TokenShape::Unusable { first_bad } => {
+            return Err(Error::Auth(AuthError::Kubeconfig(format!(
+                "The {source}'s token contains {first_bad:?}, which no HTTP header \
+                 can carry, so the cluster would refuse it without saying why. The \
+                 terminal it ran under corrupted its output; this is not a rejected \
+                 login."
+            ))));
+        }
+        cred::TokenShape::Empty => {
+            return Err(Error::Auth(AuthError::Kubeconfig(format!(
+                "The {source} returned a token that is entirely whitespace. Sending \
+                 it would reach the cluster as no credential at all."
+            ))));
+        }
+    }
+
+    // Whitespace is only the damage that stops the JSON parsing. A console
+    // wraps a line it cannot fit and hands back what it drew, so a token can
+    // come back longer than it went out and still be whitespace-free and
+    // ASCII-graphic. Read as a JWT, it says so.
+    let deadline = match cred::read_jwt(&token) {
+        cred::TokenReading::Damaged { why } => {
+            return Err(Error::Auth(AuthError::Kubeconfig(format!(
+                "The {source} returned a token that begins as a JWT and then {why}. \
+                 The terminal it ran under damaged its output; the cluster would \
+                 refuse this without saying why, and this is not a rejected login."
+            ))));
+        }
+        cred::TokenReading::Jwt {
+            expires_at: Some(at),
+        } if at <= chrono::Utc::now() => {
+            return Err(Error::Auth(AuthError::Kubeconfig(format!(
+                "The {source} returned a token that expired at {at}. The cluster \
+                 would refuse it as an unauthenticated request."
+            ))));
+        }
+        cred::TokenReading::Jwt { expires_at } => expires_at,
+        cred::TokenReading::Opaque => None,
+    };
+
+    auth_info.token = Some(SecretString::from(token));
+    Ok(deadline)
+}
+
+/// Applies what the plugin returned, and hands back the deadline it named.
 fn apply_exec_credentials(
     auth_info: &mut AuthInfo,
     status: ExecCredentialStatus,
@@ -147,63 +231,10 @@ fn apply_exec_credentials(
     // A plugin that names no deadline may still be carrying one inside the
     // token. Reading it there is the difference between the app knowing when
     // the session ends and guessing that it does not.
-    let mut jwt_deadline = None;
-
-    if let Some(mut token) = status.token {
-        match cred::mend_bearer_token(&mut token) {
-            // The length only — a token is a credential and does not go in a log.
-            cred::TokenShape::Intact => tracing::info!(
-                "Applied a {} character token from the credential plugin, intact.",
-                token.len()
-            ),
-            cred::TokenShape::Mended { removed } => tracing::warn!(
-                "The credential plugin's token carried {removed} whitespace \
-                 characters the console that drew it put there. Removed."
-            ),
-            cred::TokenShape::Unusable { first_bad } => {
-                return Err(Error::Auth(AuthError::Kubeconfig(format!(
-                    "The credential plugin's token contains {first_bad:?}, which no \
-                     HTTP header can carry, so the cluster would refuse it without \
-                     saying why. The terminal the plugin ran under corrupted its \
-                     output; this is not a rejected login."
-                ))));
-            }
-            cred::TokenShape::Empty => {
-                return Err(Error::Auth(AuthError::Kubeconfig(
-                    "The credential plugin returned a token that is entirely \
-                     whitespace. Sending it would reach the cluster as no \
-                     credential at all."
-                        .to_string(),
-                )));
-            }
-        }
-        // Whitespace is not the only thing a console can leave in a token,
-        // only the one that stops the JSON parsing. A JWT says whether what
-        // came back is still the token the plugin wrote.
-        match cred::read_jwt(&token) {
-            cred::TokenReading::Damaged { why } => {
-                return Err(Error::Auth(AuthError::Kubeconfig(format!(
-                    "The credential plugin returned a token that begins as a JWT and \
-                     then {why}. The terminal the plugin ran under damaged its output; \
-                     the cluster would refuse this without saying why, and this is not \
-                     a rejected login."
-                ))));
-            }
-            cred::TokenReading::Jwt {
-                expires_at: Some(at),
-            } if at <= chrono::Utc::now() => {
-                return Err(Error::Auth(AuthError::Kubeconfig(format!(
-                    "The credential plugin returned a token that expired at {at}. \
-                     The cluster would refuse it as an unauthenticated request."
-                ))));
-            }
-            cred::TokenReading::Jwt { expires_at } => {
-                jwt_deadline = expires_at;
-            }
-            cred::TokenReading::Opaque => {}
-        }
-        auth_info.token = Some(SecretString::from(token));
-    }
+    let jwt_deadline = match status.token {
+        Some(token) => apply_bearer_token(auth_info, token, "credential plugin")?,
+        None => None,
+    };
     // A plugin hands back PEM, but the fields it lands in are kubeconfig
     // fields, and kube reads those through a base64 decode. Storing the PEM
     // as-is leaves the decode to fail, and the failure is swallowed — the
@@ -268,6 +299,73 @@ mod tests {
         assert_eq!(decoded(cert), CERT.as_bytes());
         let key = auth_info.client_key_data.as_ref().expect("the key");
         assert_eq!(decoded(key.expose_secret()), KEY.as_bytes());
+    }
+
+    fn live_jwt() -> String {
+        let exp = (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp();
+        let b64 = |raw: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw);
+        format!(
+            "{}.{}.{}",
+            b64(br#"{"alg":"RS256","typ":"JWT"}"#),
+            b64(format!(r#"{{"sub":"a@b.c","exp":{exp}}}"#).as_bytes()),
+            b64(&[7u8; 256])
+        )
+    }
+
+    /// Both ways a credential reaches the client go through one door. The
+    /// kubeconfig's own `oidc` provider used to assign `auth_info.token`
+    /// itself, so a token a console had damaged was refused on the exec path
+    /// and sent on this one — the same credential judged two ways. Would
+    /// break if either caller stopped going through `apply_bearer_token`.
+    #[test]
+    fn the_oidc_provider_and_a_plugin_are_held_to_the_same_reading() {
+        // A console that drew the token twice: three segments still, the
+        // header still a header, and a payload that no longer decodes.
+        let whole = live_jwt();
+        let mut parts = whole.split('.');
+        let (header, payload, signature) = (
+            parts.next().expect("header"),
+            parts.next().expect("payload"),
+            parts.next().expect("signature"),
+        );
+        let damaged = format!("{header}.{payload}{}.{signature}", &payload[..24]);
+
+        let mut from_plugin = AuthInfo::default();
+        let plugin = apply_exec_credentials(&mut from_plugin, token_status(&damaged))
+            .expect_err("a plugin's damaged token is refused");
+
+        let mut from_provider = AuthInfo::default();
+        let provider = apply_oidc_result(
+            &mut from_provider,
+            crate::auth::AuthResult {
+                token: damaged,
+                expires_at: None,
+                refresh_token: None,
+                token_type: "Bearer".to_string(),
+            },
+        )
+        .expect_err("and so is the provider's");
+
+        assert!(from_plugin.token.is_none() && from_provider.token.is_none());
+        assert!(
+            plugin.to_string().contains("begins as a JWT")
+                && provider.to_string().contains("begins as a JWT"),
+            "both name the same damage: {plugin} / {provider}"
+        );
+    }
+
+    /// A token that says when it stops working hands that back, whichever
+    /// door it came through. Before this, an OIDC user's session had no
+    /// deadline at all and the app could only find out by failing.
+    #[test]
+    fn a_token_that_names_its_own_expiry_carries_the_deadline_out() {
+        let mut auth_info = AuthInfo::default();
+        let deadline = apply_bearer_token(&mut auth_info, live_jwt(), "oidc auth provider")
+            .expect("a live token is applied");
+
+        let left =
+            (deadline.expect("the deadline the token names") - chrono::Utc::now()).num_seconds();
+        assert!((3500..=3600).contains(&left), "{left}s left");
     }
 
     fn token_status(token: &str) -> ExecCredentialStatus {

--- a/src-tauri/src/auth/interactive/oidc.rs
+++ b/src-tauri/src/auth/interactive/oidc.rs
@@ -46,13 +46,17 @@ const TOKEN_SKEW_SECS: i64 = 60;
 ///
 /// The signature is the API server's business. All this decides is whether a
 /// token is worth sending, so anything unreadable simply reads as spent.
+/// When the token says it stops working, or `None` for one that is not a JWT
+/// or does not say.
+///
+/// Reads through `cred::read_jwt` rather than decoding again: a token damaged
+/// by the console it was drawn on must not look merely undated here while the
+/// exec path refuses it, or the same token is judged two ways.
 fn expiry_of(token: &str) -> Option<chrono::DateTime<chrono::Utc>> {
-    let payload = token.split('.').nth(1)?;
-    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(payload)
-        .ok()?;
-    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-    chrono::DateTime::from_timestamp(claims.get("exp")?.as_i64()?, 0)
+    match super::cred::read_jwt(token) {
+        super::cred::TokenReading::Jwt { expires_at } => expires_at,
+        super::cred::TokenReading::Opaque | super::cred::TokenReading::Damaged { .. } => None,
+    }
 }
 
 fn still_usable(token: &str) -> bool {
@@ -364,11 +368,20 @@ mod tests {
 
     /// A JWT shaped the way a provider issues one, expiring `secs` from now.
     /// Only the payload matters here — nothing verifies the other two parts.
+    /// A token shaped like the ones a provider actually issues: three
+    /// base64url segments, the first of them the JWT header naming `alg`.
+    /// The header is what `cred::read_jwt` decides on, so a fixture that
+    /// only spells the word would be judged not-a-JWT and would stop
+    /// exercising the path it was written for.
     fn token_expiring_in(secs: i64) -> String {
         let exp = (chrono::Utc::now() + chrono::Duration::seconds(secs)).timestamp();
-        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .encode(format!(r#"{{"sub":"a@b.c","exp":{exp}}}"#));
-        format!("header.{payload}.signature")
+        let b64 = |raw: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw);
+        format!(
+            "{}.{}.{}",
+            b64(br#"{"alg":"RS256","typ":"JWT"}"#),
+            b64(format!(r#"{{"sub":"a@b.c","exp":{exp}}}"#).as_bytes()),
+            b64(&[7u8; 256])
+        )
     }
 
     #[test]

--- a/src-tauri/src/shell/env.rs
+++ b/src-tauri/src/shell/env.rs
@@ -28,6 +28,9 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::sync::OnceLock;
+// Only the login-shell timeout is measured in time, and that is a Unix
+// notion — Windows hands an app its environment from the system settings.
+#[cfg(unix)]
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -603,6 +606,11 @@ mod tests {
     /// and `kubectl-oidc_login` were on their PATH. Drop `-i` and every
     /// plugin installed by a profile line goes missing again, with every
     /// other test still green.
+    // Windows has no login shell and no `LOGIN_SHELL_FLAGS` to read, so this
+    // test names a constant that is not compiled there. Its neighbours carry
+    // the same gate; this one was missed, and nothing said so because the
+    // Rust tests have never been built for Windows.
+    #[cfg(unix)]
     #[test]
     fn the_shell_is_started_interactively_as_well_as_as_a_login_shell() {
         assert!(

--- a/src-tauri/src/terminal/adapters/auth_exec.rs
+++ b/src-tauri/src/terminal/adapters/auth_exec.rs
@@ -18,9 +18,21 @@ use tokio::task;
 /// The terminal stream itself is bounded by xterm scrollback, not this cap.
 const MAX_STDOUT_SIZE: usize = 1024 * 1024;
 
-/// PTY default size at spawn. The frontend sends a real resize as soon
-/// as xterm measures itself, so this is just a sane initial value.
-const INITIAL_COLS: u16 = 80;
+/// The console a credential is drawn on, kept wider than any credential.
+///
+/// `ConPTY` is a screen buffer, not a pipe: a line longer than the console is
+/// wrapped, and what comes back out has been through that wrapping. Measured
+/// on Windows, a 3893-character token down an 80-column console comes back
+/// 3919 characters long — still ASCII-graphic, still whitespace-free, and no
+/// longer the token the plugin wrote, so every check passes and the cluster
+/// answers `Unauthorized` with nothing to say about why. Down a console it
+/// never wraps in, the same token comes back whole. Both are tested in
+/// `auth::interactive::cred`.
+///
+/// The width is not the reader's to choose, which is why `resize` floors it:
+/// xterm measures the pane and asks for its own width long before the plugin
+/// has printed anything.
+const CREDENTIAL_COLS: u16 = 8192;
 const INITIAL_ROWS: u16 = 24;
 
 /// Adapter for interactive auth-exec processes.
@@ -99,7 +111,7 @@ impl TerminalAdapter for AuthExecAdapter {
         let pair = pty_system
             .openpty(PtySize {
                 rows: INITIAL_ROWS,
-                cols: INITIAL_COLS,
+                cols: CREDENTIAL_COLS,
                 pixel_width: 0,
                 pixel_height: 0,
             })
@@ -231,6 +243,9 @@ impl TerminalAdapter for AuthExecAdapter {
             Some(m) => m.clone(),
             None => return Ok(()),
         };
+        // The pane's width would wrap the credential; see `CREDENTIAL_COLS`.
+        // Rows follow the reader, columns do not.
+        let cols = cols.max(CREDENTIAL_COLS);
 
         task::spawn_blocking(move || {
             let m = master.lock();

--- a/src-tauri/src/terminal/adapters/auth_exec.rs
+++ b/src-tauri/src/terminal/adapters/auth_exec.rs
@@ -286,38 +286,51 @@ impl TerminalAdapter for AuthExecAdapter {
     }
 }
 
+/// Reading a whole session out of the console, for tests on both sides of
+/// the auth flow.
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::time::Duration;
-
-    /// Drain `read_output` into a single buffer until either the
-    /// process stops emitting for several ticks (and is no longer
-    /// running), or `total_timeout` elapses. Used to assert what the
-    /// terminal would see across the full lifetime of a short command.
-    async fn drain(adapter: &mut AuthExecAdapter, total_timeout: Duration) -> Vec<u8> {
+impl AuthExecAdapter {
+    /// Read until the child has exited *and* has stopped handing anything
+    /// over.
+    ///
+    /// Stopping at `is_running()` is what this used to do, and on Windows it
+    /// loses the payload: the child is gone long before the reader thread has
+    /// handed over what the console still had, so a credential printed at the
+    /// last moment never arrives. The exit status is the signal; the reads
+    /// after it are what collect the rest.
+    pub(crate) async fn drain_to_exit(&mut self, total_timeout: std::time::Duration) -> Vec<u8> {
+        let exited = self.last_exit_status();
         let mut out = Vec::new();
         let deadline = tokio::time::Instant::now() + total_timeout;
-        let mut idle_ticks = 0;
+        let mut after_exit = 0;
         while tokio::time::Instant::now() < deadline {
-            match adapter.read_output().await {
+            match self.read_output().await {
                 Ok(Some(chunk)) => {
                     out.extend_from_slice(&chunk);
-                    idle_ticks = 0;
+                    after_exit = 0;
                 }
                 Ok(None) => {
-                    idle_ticks += 1;
-                    if idle_ticks > 10 && !adapter.is_running() {
-                        break;
+                    if exited.lock().is_some() {
+                        after_exit += 1;
+                        if after_exit > 50 {
+                            break;
+                        }
                     }
-                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
                 }
                 Err(_) => break,
             }
         }
         out
     }
+}
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[cfg(unix)]
     #[tokio::test]
     async fn read_output_returns_stdout_to_terminal() {
         // Many OIDC drivers (kubelogin --grant-type=authcode-keyboard,
@@ -331,7 +344,7 @@ mod tests {
         );
 
         adapter.connect().await.expect("spawn");
-        let drained = drain(&mut adapter, Duration::from_secs(2)).await;
+        let drained = adapter.drain_to_exit(Duration::from_secs(2)).await;
         adapter.close().await.expect("close");
 
         let text = String::from_utf8_lossy(&drained);
@@ -341,6 +354,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn read_output_still_returns_stderr() {
         let mut adapter = AuthExecAdapter::new(
@@ -350,7 +364,7 @@ mod tests {
         );
 
         adapter.connect().await.expect("spawn");
-        let drained = drain(&mut adapter, Duration::from_secs(2)).await;
+        let drained = adapter.drain_to_exit(Duration::from_secs(2)).await;
         adapter.close().await.expect("close");
 
         let text = String::from_utf8_lossy(&drained);
@@ -360,6 +374,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[cfg(unix)]
     #[tokio::test]
     async fn child_runs_under_a_real_tty() {
@@ -376,7 +391,7 @@ mod tests {
         );
 
         adapter.connect().await.expect("spawn");
-        let drained = drain(&mut adapter, Duration::from_secs(2)).await;
+        let drained = adapter.drain_to_exit(Duration::from_secs(2)).await;
         adapter.close().await.expect("close");
 
         let text = String::from_utf8_lossy(&drained);
@@ -390,6 +405,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[cfg(unix)]
     #[tokio::test]
     async fn child_inherits_parent_process_env() {
@@ -423,7 +439,7 @@ mod tests {
         );
 
         adapter.connect().await.expect("spawn");
-        let drained = drain(&mut adapter, Duration::from_secs(2)).await;
+        let drained = adapter.drain_to_exit(Duration::from_secs(2)).await;
         adapter.close().await.expect("close");
 
         let text = String::from_utf8_lossy(&drained);
@@ -434,6 +450,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[cfg(unix)]
     #[tokio::test]
     async fn explicit_env_overrides_inherited_env() {
@@ -461,7 +478,7 @@ mod tests {
         );
 
         adapter.connect().await.expect("spawn");
-        let drained = drain(&mut adapter, Duration::from_secs(2)).await;
+        let drained = adapter.drain_to_exit(Duration::from_secs(2)).await;
         adapter.close().await.expect("close");
 
         let text = String::from_utf8_lossy(&drained);
@@ -471,6 +488,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[cfg(unix)]
     #[tokio::test]
     async fn last_exit_status_captures_zero_for_clean_exit() {
@@ -488,7 +506,7 @@ mod tests {
         let status_handle = adapter.last_exit_status();
 
         adapter.connect().await.expect("spawn");
-        let _ = drain(&mut adapter, Duration::from_secs(2)).await;
+        let _ = adapter.drain_to_exit(Duration::from_secs(2)).await;
         // Give the wait thread a tick to record the exit before close.
         tokio::time::sleep(Duration::from_millis(100)).await;
         adapter.close().await.expect("close");
@@ -501,6 +519,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[cfg(unix)]
     #[tokio::test]
     async fn last_exit_status_captures_nonzero_exit_code() {
@@ -515,7 +534,7 @@ mod tests {
         let status_handle = adapter.last_exit_status();
 
         adapter.connect().await.expect("spawn");
-        let _ = drain(&mut adapter, Duration::from_secs(2)).await;
+        let _ = adapter.drain_to_exit(Duration::from_secs(2)).await;
         tokio::time::sleep(Duration::from_millis(100)).await;
         adapter.close().await.expect("close");
 
@@ -527,6 +546,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn collected_stdout_still_captures_json_payload() {
         // The auth flow downstream parses JSON ExecCredential from
@@ -539,7 +559,7 @@ mod tests {
         let collected_handle = adapter.collected_stdout();
 
         adapter.connect().await.expect("spawn");
-        let _ = drain(&mut adapter, Duration::from_secs(2)).await;
+        let _ = adapter.drain_to_exit(Duration::from_secs(2)).await;
         adapter.close().await.expect("close");
 
         let collected = collected_handle.lock();


### PR DESCRIPTION
Against the log techmick attached to #106 this morning, running 4.9.1.

## What the log settles

`Applied a 3893 character token from the credential plugin, intact.` — the line 4.9.1 added. The token carries no whitespace and no byte a header cannot hold, so **the whitespace fix in 4.9.1 does not apply to his case**. It is sent, and the API server answers 401 with the shape of an unauthenticated request.

Ruled out by reading the path: the `exec` block *is* cleared before the client is built, `KubeConfigOptions.context` *is* set so the right user is chosen, and `test_connection` reuses the prepared client rather than rebuilding from the raw kubeconfig. The token really does go out.

What is left is where it comes from. The credential is read off a `ConPTY` screen buffer 80 columns wide; a 3893-character token needs about 49 rows of it, so it is wrapped, scrolled and repainted before we see it. A run the repaint writes twice is as ASCII-graphic and as whitespace-free as the original — which is exactly why every check we had passed.

## What this does

- Reads a bearer token as a JWT where it is one, and refuses **before** the request with the cause named: a payload that is not base64url, or that decodes to something other than a claim set, or a token already past its `exp`. A token that is not a JWT (Rancher's `<id>:<secret>`, any opaque string) is not judged.
- Takes the deadline from the token's own `exp` when the plugin names none, so a surface can say *when* the session ends instead of assuming it does not.
- Deletes the five `probe_*` tests marked `TEMPORARY PROBES (to be reverted)` that shipped to main in #113. They only `println!` and assert nothing.

## The reproduction

`a_token_longer_than_the_console_survives_being_drawn_on_it` runs a 3893-character token through the real `AuthExecAdapter` — the same PTY the auth flow uses — with `type`/`cat` as the child so no shell quoting touches the bytes, and compares what comes back to what went in. It passes here on a Unix pty, which hands the child's bytes through unchanged; that is the control. The `windows-console` CI job runs it on `windows-2025`, where `ConPTY` is, and that run is the answer.

The job is filtered to this test on purpose: the rest of the Rust tests spawn `/bin/sh` and have never run on Windows.

## Verified

543 Rust tests, clippy with `-D warnings` clean, `cargo fmt` clean. Both damage branches sabotage-checked — deleting either one makes its test fail for its own reason.