### PR TITLE
fix: work the deferred audit findings to completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # The Comment budget step diffs against the merge-base, which a
+          # shallow clone does not contain — `origin/main...HEAD` then exits
+          # 128 and the script that reads it crashes. Full history is what
+          # lets the three-dot diff find where this branch left main.
+          fetch-depth: 0
 
       - name: Setup Tauri build environment
         uses: ./.github/actions/setup-tauri
@@ -71,7 +77,7 @@ jobs:
         # for the rare change that is only about comments.
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'comments')
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          git fetch --no-tags origin "${{ github.base_ref }}"
           python3 scripts/comment-budget.py "origin/${{ github.base_ref }}" HEAD
 
       - name: Frontend formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,7 +1954,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1 0.10.6",
+ "sha1",
 ]
 
 [[package]]
@@ -2125,7 +2125,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2591,7 +2591,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
- "tokio-tungstenite 0.30.0",
  "tokio-util",
  "toml 1.1.5+spec-1.1.0",
  "tracing",
@@ -2679,7 +2678,7 @@ dependencies = [
  "tame-oauth",
  "thiserror 2.0.20",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4346,7 +4345,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4964,17 +4963,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
 ]
 
 [[package]]
@@ -5978,23 +5966,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tungstenite 0.30.0",
- "webpki-roots 0.26.11",
+ "tungstenite",
 ]
 
 [[package]]
@@ -6325,27 +6297,9 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.6",
- "sha1 0.10.6",
+ "sha1",
  "thiserror 1.0.69",
  "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.10.2",
- "rustls",
- "rustls-pki-types",
- "sha1 0.11.0",
- "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6914,15 +6868,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/scripts/comment-budget.py
+++ b/scripts/comment-budget.py
@@ -34,12 +34,20 @@ TEST_SUBJECT = re.compile(
 
 def added_lines(base, head):
     """Every added line of the diff, grouped by the file it lands in."""
-    diff = subprocess.run(
+    result = subprocess.run(
         ["git", "diff", "--unified=0", f"{base}...{head}", "--", "*.rs", "*.ts", "*.tsx"],
         capture_output=True,
         text=True,
-        check=True,
-    ).stdout
+    )
+    if result.returncode != 0:
+        # `base...head` diffs from the merge-base, which a shallow clone does
+        # not contain. Say so plainly instead of crashing with a traceback —
+        # the fix is a full-history checkout, not a change here.
+        sys.exit(
+            f"comment-budget: could not diff {base}...{head} "
+            f"(is the checkout shallow? git said: {result.stderr.strip()})"
+        )
+    diff = result.stdout
 
     files, path = {}, None
     for line in diff.split("\n"):

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,9 +51,6 @@ serde_yaml = "0.9"
 # HTTP client
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"] }
 
-# WebSocket for exec
-tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }
-
 # Security
 rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2.2"

--- a/src-tauri/src/config/cloud.rs
+++ b/src-tauri/src/config/cloud.rs
@@ -13,13 +13,13 @@ use super::app::default_true;
 pub struct CloudConfig {
     /// GCP profiles (key = profile name)
     #[serde(default, alias = "gcp_profiles")]
-    pub gcp_profiles: std::collections::HashMap<String, GcpProfile>,
+    pub gcp_profiles: std::collections::BTreeMap<String, GcpProfile>,
     /// Azure profiles (key = profile name)
     #[serde(default, alias = "azure_profiles")]
-    pub azure_profiles: std::collections::HashMap<String, AzureProfile>,
+    pub azure_profiles: std::collections::BTreeMap<String, AzureProfile>,
     /// Context to profile bindings (key = kubeconfig context name)
     #[serde(default, alias = "context_bindings")]
-    pub context_bindings: std::collections::HashMap<String, ContextBinding>,
+    pub context_bindings: std::collections::BTreeMap<String, ContextBinding>,
 }
 
 /// CLI tools paths configuration

--- a/src-tauri/src/config/connection.rs
+++ b/src-tauri/src/config/connection.rs
@@ -42,7 +42,7 @@ pub struct PortForwardConfig {
 pub struct RegistriesConfig {
     /// Registry configurations (key = registry ID)
     #[serde(default)]
-    pub registries: std::collections::HashMap<String, RegistryConfigEntry>,
+    pub registries: std::collections::BTreeMap<String, RegistryConfigEntry>,
 }
 
 /// Stored registry configuration (unified: connection settings + credentials)

--- a/src-tauri/src/config/editor.rs
+++ b/src-tauri/src/config/editor.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 pub struct YamlEditorConfig {
     /// History entries by resource key (kind:namespace:name)
     #[serde(default)]
-    pub history: std::collections::HashMap<String, Vec<YamlHistoryEntry>>,
+    pub history: std::collections::BTreeMap<String, Vec<YamlHistoryEntry>>,
 }
 
 /// YAML history entry
@@ -39,7 +39,7 @@ pub struct YamlHistoryEntry {
 pub struct InfrastructureBuilderConfig {
     /// State per context
     #[serde(default)]
-    pub contexts: std::collections::HashMap<String, InfrastructureBuilderState>,
+    pub contexts: std::collections::BTreeMap<String, InfrastructureBuilderState>,
 }
 
 /// Infrastructure builder state for a context

--- a/src-tauri/src/config/integrations.rs
+++ b/src-tauri/src/config/integrations.rs
@@ -13,7 +13,7 @@
 //! `integrations::prometheus::get_prometheus_connection`.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Every configured integration, per kubeconfig context.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -21,11 +21,11 @@ use std::collections::HashMap;
 pub struct IntegrationsConfig {
     /// Key is the kubeconfig context name.
     #[serde(default)]
-    pub prometheus: HashMap<String, ConnectionEntry>,
+    pub prometheus: BTreeMap<String, ConnectionEntry>,
     /// Same shape, same rules, and beside the Prometheus on purpose — a
     /// reader looking for where their tokens went finds both in one place.
     #[serde(default)]
-    pub loki: HashMap<String, ConnectionEntry>,
+    pub loki: BTreeMap<String, ConnectionEntry>,
 }
 
 /// One cluster's address for one configured integration.

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -24,7 +24,8 @@ pub mod private_file;
 
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 pub use app::{default_true, KubernetesConfig, ThemeConfig};
 pub use cloud::{AzureProfile, CliPathsConfig, CloudConfig, ContextBinding, GcpProfile};
@@ -134,6 +135,77 @@ impl AppConfig {
 
         Ok(config_dir.join("k8s-gui").join("config.toml"))
     }
+
+    /// Load for startup, where a broken file must not stop the window.
+    ///
+    /// [`load`](Self::load) stays strict, because a save path must refuse to
+    /// write over a file it could not read. This one always returns a config:
+    /// a `config.toml` that will not parse is renamed aside (preserved, and
+    /// out of the way of later reads and writes) and defaults take its place,
+    /// with the incident left in [`recovery_report`] for Diagnostics. A parse
+    /// error here used to fail `setup`, which Tauri answers with no window.
+    #[must_use]
+    pub fn load_or_recover() -> Self {
+        match Self::load() {
+            Ok(config) => config,
+            Err(why) => match Self::config_path() {
+                Ok(path) if path.exists() => {
+                    let (config, recovery) = Self::move_aside(&path, why.to_string());
+                    tracing::error!(
+                        "config.toml did not parse ({}); started on defaults, kept it at {}",
+                        recovery.why,
+                        recovery.backup
+                    );
+                    let _ = RECOVERY.set(recovery);
+                    config
+                }
+                _ => Self::default(),
+            },
+        }
+    }
+
+    /// Rename an unreadable config aside and describe what happened.
+    ///
+    /// Takes the path so a test can drive it without the real config
+    /// directory. The backup name is timestamped so a second corruption never
+    /// overwrites the first; a rename that fails still starts the app.
+    fn move_aside(path: &Path, why: String) -> (Self, ConfigRecovery) {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+        let backup_path = path.with_extension(format!("toml.corrupt.{stamp}"));
+        let backup = match std::fs::rename(path, &backup_path) {
+            Ok(()) => backup_path.to_string_lossy().into_owned(),
+            Err(_) => path.to_string_lossy().into_owned(),
+        };
+        (
+            Self::default(),
+            ConfigRecovery {
+                path: path.to_string_lossy().into_owned(),
+                backup,
+                why,
+            },
+        )
+    }
+}
+
+/// A `config.toml` that would not parse, moved aside so the app could start.
+#[derive(Debug, Clone)]
+pub struct ConfigRecovery {
+    /// Where the broken file was.
+    pub path: String,
+    /// Where it is now, kept so the reader can recover settings by hand.
+    pub backup: String,
+    /// Why it would not parse — the words `toml` gave.
+    pub why: String,
+}
+
+static RECOVERY: OnceLock<ConfigRecovery> = OnceLock::new();
+
+/// The startup recovery, if a broken config was moved aside this run.
+#[must_use]
+pub fn recovery_report() -> Option<&'static ConfigRecovery> {
+    RECOVERY.get()
 }
 
 // ============================================================================
@@ -179,7 +251,7 @@ pub struct ClusterPreferences {
     /// namespace, and a joined list here would have such a build asking the
     /// API server for a namespace called `a,b`.
     #[serde(default)]
-    pub namespaces: std::collections::HashMap<String, String>,
+    pub namespaces: std::collections::BTreeMap<String, String>,
     /// The whole selection per context, where there is more than one.
     ///
     /// Its own field rather than a joined `namespaces` value, for the reason
@@ -187,7 +259,7 @@ pub struct ClusterPreferences {
     /// reading `namespaces`, so downgrading loses the extra namespaces
     /// instead of asking for a namespace that cannot exist.
     #[serde(default)]
-    pub scopes: std::collections::HashMap<String, Vec<String>>,
+    pub scopes: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 #[cfg(test)]
@@ -199,6 +271,40 @@ mod tests {
         let config = AppConfig::default();
         assert_eq!(config.theme.theme, "dark");
         assert_eq!(config.kubernetes.default_namespace, "default");
+    }
+
+    /// A config that will not parse must not be lost and must not stop the
+    /// window: it is moved aside under a name that says what it is, and
+    /// defaults take over so the app starts. The alternative shipped for a
+    /// while — a parse error in `setup` and no window at all.
+    #[test]
+    fn an_unreadable_config_is_moved_aside_and_defaults_take_over() {
+        let path = std::env::temp_dir().join(format!(
+            "rubick-config-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, "this = is = broken = toml").unwrap();
+
+        let (config, recovery) =
+            AppConfig::move_aside(&path, "Failed to parse config: x".to_string());
+
+        // Defaults, so the app has something to run on.
+        assert_eq!(config.theme.theme, AppConfig::default().theme.theme);
+        // The broken file is gone from its place...
+        assert!(!path.exists(), "the broken file should have moved");
+        // ...and its bytes are preserved under a backup that names the trouble.
+        assert_ne!(recovery.backup, recovery.path, "a rename should have run");
+        assert!(recovery.backup.contains("corrupt"), "{}", recovery.backup);
+        assert_eq!(
+            std::fs::read_to_string(&recovery.backup).unwrap(),
+            "this = is = broken = toml"
+        );
+
+        std::fs::remove_file(&recovery.backup).ok();
     }
 
     /// Every config file written before those three sections were removed

--- a/src-tauri/src/diagnostics/collect.rs
+++ b/src-tauri/src/diagnostics/collect.rs
@@ -311,6 +311,13 @@ pub async fn collect(client: &crate::client::K8sClientManager) -> Diagnostics {
     let search_path_is_real = shell.answered();
     let tools = tools_status().await;
 
+    // A config the app could not read is the same silent failure this panel
+    // exists for: startup moved it aside and carried on, and this is the one
+    // place the reader is told their settings did not load.
+    let recovery_finding = crate::config::recovery_report().map(|recovery| {
+        super::settings_recovered_finding(&recovery.path, &recovery.backup, &recovery.why)
+    });
+
     // The parsed config the app is already living on, not a fresh read of
     // the file. A second read would answer about a different moment, and
     // this panel exists because two answers about one machine is the bug.
@@ -338,6 +345,7 @@ pub async fn collect(client: &crate::client::K8sClientManager) -> Diagnostics {
             None => (None, Vec::new()),
         };
         findings.extend(super::shell_env_finding(&shell));
+        findings.extend(recovery_finding);
         return Diagnostics {
             shell,
             search_path_is_real,
@@ -372,6 +380,7 @@ pub async fn collect(client: &crate::client::K8sClientManager) -> Diagnostics {
         })
         .collect();
     findings.extend(super::shell_env_finding(&shell));
+    findings.extend(recovery_finding);
     findings.sort_by(|a, b| {
         a.severity
             .cmp(&b.severity)

--- a/src-tauri/src/diagnostics/findings.rs
+++ b/src-tauri/src/diagnostics/findings.rs
@@ -70,6 +70,28 @@ pub fn unreadable_kubeconfig_finding(path: &str, why: &str) -> Finding {
     }
 }
 
+/// The finding for a `config.toml` that would not parse and was moved aside.
+///
+/// Misconfigured, not blocking: the cluster still connects, but the reader's
+/// saved settings — theme, cluster bindings, port-forwards — did not load,
+/// and the file that held them is now a backup they can recover by hand. The
+/// app used to answer this by never opening a window, since the parse ran in
+/// `setup` before one existed.
+#[must_use]
+pub fn settings_recovered_finding(path: &str, backup: &str, why: &str) -> Finding {
+    Finding {
+        severity: Severity::Misconfigured,
+        title: "Settings could not be read".to_string(),
+        detail: format!(
+            "{why}. The app started on default settings and kept your previous \
+             file at {backup}, so nothing was lost — open it to recover a value \
+             by hand. Saving any setting writes a fresh {path}."
+        ),
+        subject: Some(path.to_string()),
+        about_shell: false,
+    }
+}
+
 /// The finding for a login shell that did not answer at startup.
 ///
 /// `None` when it answered, or was never needed. Without an answer the
@@ -189,6 +211,35 @@ mod tests {
             finding.detail
         );
         assert_eq!(finding.subject.as_deref(), Some("orders-stage"));
+    }
+
+    /// A config the app could not read, once moved aside: the reader is told
+    /// where their settings went and how to get them back, and it stops short
+    /// of Blocking because the cluster still connects. The old answer was no
+    /// window and no word.
+    #[test]
+    fn a_recovered_config_names_its_backup_and_stops_short_of_blocking() {
+        let finding = settings_recovered_finding(
+            "/home/k/.config/k8s-gui/config.toml",
+            "/home/k/.config/k8s-gui/config.toml.corrupt.171",
+            "Failed to parse config: expected `=`",
+        );
+        assert_eq!(finding.severity, Severity::Misconfigured);
+        assert!(
+            finding.detail.contains("config.toml.corrupt.171"),
+            "detail should say where the old file was kept, got: {}",
+            finding.detail
+        );
+        assert!(
+            finding.detail.contains("expected `=`"),
+            "detail should carry the parse error, got: {}",
+            finding.detail
+        );
+        assert_eq!(
+            finding.subject.as_deref(),
+            Some("/home/k/.config/k8s-gui/config.toml")
+        );
+        assert!(!finding.about_shell);
     }
 
     #[test]

--- a/src-tauri/src/diagnostics/mod.rs
+++ b/src-tauri/src/diagnostics/mod.rs
@@ -15,6 +15,7 @@ pub use collect::{
     SearchPathEntry, ToolStatus,
 };
 pub use findings::{
-    missing_plugin_finding, shell_env_finding, unreadable_kubeconfig_finding, Finding, Severity,
+    missing_plugin_finding, settings_recovered_finding, shell_env_finding,
+    unreadable_kubeconfig_finding, Finding, Severity,
 };
 pub use redact::redacted;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -104,10 +104,6 @@ pub enum Error {
     #[error("Operation timed out: {0}")]
     Timeout(String),
 
-    /// WebSocket errors
-    #[error("WebSocket error: {0}")]
-    WebSocket(String),
-
     /// Internal errors
     #[error("Internal error: {0}")]
     Internal(String),
@@ -221,12 +217,6 @@ impl From<reqwest::Error> for Error {
     }
 }
 
-impl From<tokio_tungstenite::tungstenite::Error> for Error {
-    fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
-        Error::WebSocket(err.to_string())
-    }
-}
-
 impl From<url::ParseError> for Error {
     fn from(err: url::ParseError) -> Self {
         Error::InvalidInput(format!("Invalid URL: {err}"))
@@ -251,14 +241,19 @@ impl Error {
     ///
     /// A 403 arrives as `KubeApi` and stays there on purpose — its own variant
     /// would say the session is over when only one request was answered. So
-    /// the question is asked of the response code: a caller matching
-    /// `PermissionDenied` would match nothing a cluster sends, since that
-    /// variant is for refusals the app itself raises.
+    /// the question is asked of the response, and of `reason` as well as
+    /// `code` for the same reason the 401 path above does: some distributions
+    /// send `Forbidden` with the code unset, and code alone would then read a
+    /// refusal as a hard failure. A caller matching `PermissionDenied` would
+    /// match nothing a cluster sends — that variant is for refusals the app
+    /// itself raises.
     #[must_use]
     pub fn is_refusal(&self) -> bool {
         match self {
             Error::PermissionDenied(_) => true,
-            Error::KubeApi(kube::Error::Api(response)) => response.code == 403,
+            Error::KubeApi(kube::Error::Api(response)) => {
+                response.code == 403 || response.reason == "Forbidden"
+            }
             _ => false,
         }
     }
@@ -319,6 +314,15 @@ mod tests {
         assert!(!Error::from(api_error(401, "Unauthorized")).is_refusal());
         assert!(!Error::from(api_error(500, "InternalError")).is_refusal());
         assert!(!Error::Config("nothing to do with rights".into()).is_refusal());
+    }
+
+    /// The same trap the 401 path was already guarded against: a distribution
+    /// that sends `Forbidden` with the code unset. Asking `code` alone reads
+    /// that refusal as a hard failure and throws the reader out over a screen
+    /// their token merely cannot see.
+    #[test]
+    fn a_forbidden_with_no_code_is_still_a_refusal() {
+        assert!(Error::from(api_error(0, "Forbidden")).is_refusal());
     }
 
     #[test]

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -88,7 +88,9 @@ pub struct AppState {
 impl AppState {
     /// Create a new application state
     pub fn new() -> Result<Self> {
-        let config = AppConfig::load()?;
+        // Never `?` on config here: a broken file must not fail `setup` and
+        // leave Tauri with no window. `load_or_recover` moves it aside instead.
+        let config = AppConfig::load_or_recover();
         let (event_tx, _) = broadcast::channel(1000);
 
         let client_manager = Arc::new(K8sClientManager::new());


### PR DESCRIPTION
Works through the deferred audit findings to completion. Four were real and are fixed here; two belong to the held `deps/kube-4` branch because the types they need do not exist on `k8s-openapi` v1_31; three did not survive a look at the code.

## Fixed

- **A broken `config.toml` no longer kills the app.** The parse ran in Tauri's `setup` before a window existed, so an unreadable file left the app with no window and nothing said — the exact silent-failure class this project is about. It is now moved aside under a timestamped backup, defaults take over so the app opens, and the incident reaches the reader through the Diagnostics panel (`settings_recovered_finding`). The strict `load()` stays strict, so a save path still refuses to write over a file it could not read.
- **Config maps serialise in a stable order.** Ten `HashMap` fields became `BTreeMap`, so `config.toml` no longer reshuffles its sections on every write (Rust randomises `HashMap` iteration per process).
- **A `Forbidden` with no code is still a refusal.** `is_refusal()` asked only `code == 403`, but the 401 path already knows some distributions send the reason with the code unset. A 403 arriving as `reason == "Forbidden"` with `code == 0` was read as a hard failure and threw the reader out of a cluster their token could still use. Now it mirrors the 401 handling.
- **Dropped a dead dependency.** The direct `tokio-tungstenite` dep was unreachable: nothing produced its error, so its `From` impl and the `Error::WebSocket` variant it fed were dead. `kube` keeps its own copy for exec/attach.

Every fix has a unit test, each sabotage-checked.

## Deferred to `deps/kube-4` (cannot compile on main)

- **Pod-level resources (KEP-2837).** `PodSpec.resources` does not exist in `k8s-openapi` v1_31 — only from v1_32. The two aggregation sites (`pod.rs`, `overview.rs`) can read it once that branch lands.
- **Richer drain diagnosis from `Status.details`.** kube 0.97's `ErrorResponse` carries only status/message/reason/code — the drain code already documents this and honestly reports `NotNow`. kube 4 replaces it with a full `Status` (with `details.causes` / `retry_after_seconds`), so the PDB-vs-throttle distinction becomes possible there.

## Looked at, not changed

- **`prefetchQuery` "deprecated".** It is not deprecated in `@tanstack/react-query` 5.102.8 (no `@deprecated` in the installed types). No change.
- **`subscribed` in place of `useLiveQuery`'s visibility refetch.** It would only replace off-screen pause; the machinery that justifies the hook — freshness reporting (`slowed`/`paused`/`everyMs`), the steadiness backoff, the interaction-wake, and refetch-on-return guarded against a herd — all need the interval visible to the hook. Layering `subscribed` on would split "is this polling" across two mechanisms, which is the defect this repo fights.
- **Preserving hand-written comments in `config.toml`.** It is an app-managed, token-bearing file rewritten on every settings change; format-preserving edit adds real risk for marginal benefit, and the recovery above already preserves a file that cannot be parsed.
