### PR TITLE
perf(watch): a batch touching one row no longer rebuilds the whole cache

### DIFF
--- a/src/hooks/usePodsWithMetrics.test.ts
+++ b/src/hooks/usePodsWithMetrics.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { PodInfo, PodMetrics } from "@/generated/types";
 import type { NodeSilence } from "@/lib/node-reporting";
+import * as metricsModule from "@/lib/metrics";
 import { usePodsWithMetrics } from "./usePodsWithMetrics";
 
 const state = vi.hoisted(() => ({
@@ -50,6 +51,29 @@ it("keeps final pod row references across identical ticks even on a silent node"
   expect(result.current.data[0]).toBe(before[0]);
   expect(result.current.data[1]).toBe(before[1]);
   expect(result.current.data[0].nodeSilence?.reason).toBe("NodeStatusUnknown");
+});
+
+/**
+ * The two memos are split so a node-silence change re-runs only the
+ * annotation, not the pod/metrics merge. The output is byte-identical either
+ * way (the merge is idempotent on identity), so only the merge's call count
+ * tells the split from the combined memo it replaced.
+ */
+it("does not re-run the merge when only node silence changes", () => {
+  const merge = vi.spyOn(metricsModule, "mergePodsWithMetrics");
+  try {
+    const { result, rerender } = renderHook(() => usePodsWithMetrics());
+    const calls = merge.mock.calls.length;
+    // Only the silence changes; pods and metrics keep their references.
+    state.silent = new Map([
+      ["gone", { node: "gone", since: null, reason: "NodeNotReady" }],
+    ]);
+    rerender();
+    expect(merge.mock.calls.length).toBe(calls);
+    expect(result.current.data[0].nodeSilence?.reason).toBe("NodeNotReady");
+  } finally {
+    merge.mockRestore();
+  }
 });
 
 /** The hook must expose changed CPU while leaving other annotated rows stable. */

--- a/src/hooks/usePodsWithMetrics.test.ts
+++ b/src/hooks/usePodsWithMetrics.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { PodInfo, PodMetrics } from "@/generated/types";
+import type { NodeSilence } from "@/lib/node-reporting";
+import { usePodsWithMetrics } from "./usePodsWithMetrics";
+
+const state = vi.hoisted(() => ({
+  pods: [] as PodInfo[],
+  metrics: [] as PodMetrics[],
+  silent: new Map<string, NodeSilence>(),
+}));
+
+vi.mock("@/stores/clusterStore", () => ({
+  useClusterStore: () => ({ isConnected: true, currentNamespace: "default" }),
+}));
+vi.mock("@/hooks/useLiveQuery", () => ({
+  useLiveQuery: () => ({ data: state.pods, isLoading: false, error: null }),
+}));
+vi.mock("@/hooks/useMetrics", () => ({
+  useMetrics: () => ({ podMetrics: state.metrics, podStatus: null }),
+}));
+vi.mock("@/hooks/useSilentNodes", () => ({
+  useSilentNodes: () => state.silent,
+}));
+vi.mock("@/hooks/useResourceWatch", () => ({
+  useResourceWatch: () => ({ resyncing: false }),
+}));
+
+beforeEach(() => {
+  state.pods = ["a", "b"].map(
+    (name) => ({ name, namespace: "default", nodeName: "gone" }) as PodInfo
+  );
+  state.metrics = state.pods.map(({ name, namespace }) => ({
+    name,
+    namespace,
+    cpuMillicores: 10,
+    memoryBytes: 100,
+  }));
+  state.silent = new Map([
+    ["gone", { node: "gone", since: null, reason: "NodeStatusUnknown" }],
+  ]);
+});
+
+/** A downstream annotation must not undo identity preservation in the metrics merge. */
+it("keeps final pod row references across identical ticks even on a silent node", () => {
+  const { result, rerender } = renderHook(() => usePodsWithMetrics());
+  const before = result.current.data;
+  state.metrics = state.metrics.map((metric) => ({ ...metric }));
+  rerender();
+  expect(result.current.data[0]).toBe(before[0]);
+  expect(result.current.data[1]).toBe(before[1]);
+  expect(result.current.data[0].nodeSilence?.reason).toBe("NodeStatusUnknown");
+});
+
+/** The hook must expose changed CPU while leaving other annotated rows stable. */
+it("replaces only the final row whose CPU changed", () => {
+  const { result, rerender } = renderHook(() => usePodsWithMetrics());
+  const before = result.current.data;
+  state.metrics = [
+    { ...state.metrics[0], cpuMillicores: 20 },
+    state.metrics[1],
+  ];
+  rerender();
+  expect(result.current.data[0]).not.toBe(before[0]);
+  expect(result.current.data[0].cpuMillicores).toBe(20);
+  expect(result.current.data[1]).toBe(before[1]);
+});
+
+/** Losing metrics must reach the rendered row as unknown, including when it carries a warning. */
+it("exposes unknown usage when a pod loses its metrics sample", () => {
+  const { result, rerender } = renderHook(() => usePodsWithMetrics());
+  const before = result.current.data;
+  state.metrics = [state.metrics[1]];
+  rerender();
+  expect(result.current.data[0]).not.toBe(before[0]);
+  expect(result.current.data[0].cpuMillicores).toBeNull();
+  expect(result.current.data[0].memoryBytes).toBeNull();
+  expect(result.current.data[0].nodeSilence).toEqual(before[0].nodeSilence);
+  expect(result.current.data[1]).toBe(before[1]);
+});

--- a/src/hooks/usePodsWithMetrics.ts
+++ b/src/hooks/usePodsWithMetrics.ts
@@ -17,6 +17,8 @@ import type { PodInfo } from "@/generated/types";
 
 export type { PodWithMetrics } from "@/lib/metrics";
 
+const EMPTY_PODS: PodInfo[] = [];
+
 interface UsePodsWithMetricsOptions {
   /** Whether the query should be enabled (default: true when connected) */
   enabled?: boolean;
@@ -61,7 +63,7 @@ export function usePodsWithMetrics(options?: UsePodsWithMetricsOptions) {
   );
 
   const {
-    data: pods = [],
+    data: pods = EMPTY_PODS,
     isLoading: isLoadingPods,
     error: podsError,
     dataUpdatedAt,
@@ -110,10 +112,14 @@ export function usePodsWithMetrics(options?: UsePodsWithMetricsOptions) {
   // moment that has passed, and nothing in the pod object says so.
   const silent = useSilentNodes(enabled);
 
-  // Merge pods with their metrics - memoized for performance
-  const podsWithMetrics = useMemo<WithNodeSilence<PodWithMetrics>[]>(() => {
-    return withNodeSilence(mergePodsWithMetrics(pods, podMetrics), silent);
-  }, [pods, podMetrics, silent]);
+  const mergedPods = useMemo(
+    () => mergePodsWithMetrics(pods, podMetrics),
+    [pods, podMetrics]
+  );
+  const podsWithMetrics = useMemo<WithNodeSilence<PodWithMetrics>[]>(
+    () => withNodeSilence(mergedPods, silent),
+    [mergedPods, silent]
+  );
 
   return {
     data: podsWithMetrics,

--- a/src/hooks/useResourceWatch.test.ts
+++ b/src/hooks/useResourceWatch.test.ts
@@ -91,6 +91,129 @@ describe("useResourceWatch", () => {
     vi.clearAllMocks();
   });
 
+  async function start(client: QueryClient) {
+    const hook = renderHook(
+      () =>
+        useResourceWatch<Item>({
+          enabled: true,
+          subscribe: subscribeMock,
+          queryKey: KEY,
+        }),
+      { wrapper: makeWrapper(client) }
+    );
+    await waitFor(() => expect(subscribedCalls).toHaveLength(1));
+    return hook;
+  }
+
+  /** Rebuilding the index rescans 10,000 keys; cloning rows invalidates untouched row memos. */
+  it("updates one of 10,000 rows without rereading untouched keys or replacing their objects", async () => {
+    let keyReads = 0;
+    const rows = Array.from({ length: 10_000 }, (_, index) => ({
+      get name() {
+        keyReads++;
+        return `pod-${index}`;
+      },
+      namespace: "default",
+      data: 0,
+    }));
+    const client = new QueryClient();
+    client.setQueryData(KEY, rows);
+    await start(client);
+    emit("stream-cm-1", "applied", {
+      name: "pod-9999",
+      namespace: "default",
+      data: 1,
+    });
+
+    for (const data of [1, 2]) {
+      const before = client.getQueryData<Item[]>(KEY)!;
+      keyReads = 0;
+      emit("stream-cm-1", "applied", {
+        name: "pod-1234",
+        namespace: "default",
+        data,
+      });
+      const after = client.getQueryData<Item[]>(KEY)!;
+      expect(after).not.toBe(before);
+      expect(after).toHaveLength(10_000);
+      expect(after[1234]).not.toBe(before[1234]);
+      expect(after[1234].data).toBe(data);
+      expect(before[1234].data).toBe(data - 1);
+      for (let index = 0; index < before.length; index++) {
+        if (index !== 1234) expect(after[index]).toBe(before[index]);
+      }
+      expect(keyReads).toBeLessThan(10);
+    }
+  });
+
+  /** Publishing staged rows early would expose an incomplete collection to cache readers. */
+  it("replaces the complete collection in one atomic resync write", async () => {
+    const client = new QueryClient();
+    const before = [{ name: "old", data: 1 }];
+    client.setQueryData(KEY, before);
+    await start(client);
+    const writes: Item[][] = [];
+    const off = client.getQueryCache().subscribe((event) => {
+      if (event.type === "updated" && event.action.type === "success") {
+        writes.push(client.getQueryData<Item[]>(KEY)!);
+      }
+    });
+
+    emit("stream-cm-1", "restarted", null);
+    emit("stream-cm-1", "applied", { name: "first" });
+    emit("stream-cm-1", "applied", { name: "second" });
+    expect(client.getQueryData(KEY)).toBe(before);
+    expect(writes).toEqual([]);
+    emit("stream-cm-1", "synced", null);
+    expect(writes).toEqual([[{ name: "first" }, { name: "second" }]]);
+    emit("stream-cm-1", "applied", { name: "second", data: 2 });
+    expect(client.getQueryData(KEY)).toEqual([
+      { name: "first" },
+      { name: "second", data: 2 },
+    ]);
+    off();
+  });
+
+  /** Stale positions after deletion would update the wrong row or move a replacement to the front. */
+  it("keeps updates in place and appends a deleted row when it is added again", async () => {
+    const client = new QueryClient();
+    client.setQueryData(
+      KEY,
+      ["a", "b", "c"].map((name) => ({ name }))
+    );
+    await start(client);
+    emitBatch("stream-cm-1", [
+      { op: "applied", resource: { name: "b", data: 1 } },
+      { op: "deleted", resource: { name: "a" } },
+      { op: "applied", resource: { name: "a", data: 2 } },
+    ]);
+    expect(client.getQueryData(KEY)).toEqual([
+      { name: "b", data: 1 },
+      { name: "c" },
+      { name: "a", data: 2 },
+    ]);
+    emit("stream-cm-1", "deleted", { name: "c" });
+    emit("stream-cm-1", "applied", { name: "c", data: 3 });
+    emit("stream-cm-1", "applied", { name: "b", data: 4 });
+    expect(client.getQueryData(KEY)).toEqual([
+      { name: "b", data: 4 },
+      { name: "a", data: 2 },
+      { name: "c", data: 3 },
+    ]);
+  });
+
+  /** Polling or another observer can replace the array and invalidate every cached position. */
+  it("rebuilds positions after another writer replaces the cached list", async () => {
+    const client = new QueryClient();
+    client.setQueryData(KEY, [{ name: "a" }, { name: "b" }]);
+    await start(client);
+    emit("stream-cm-1", "applied", { name: "a", data: 1 });
+    client.setQueryData(KEY, [{ name: "b" }, { name: "c" }]);
+    emit("stream-cm-1", "applied", { name: "b", data: 2 });
+    emit("stream-cm-1", "deleted", { name: "c" });
+    expect(client.getQueryData(KEY)).toEqual([{ name: "b", data: 2 }]);
+  });
+
   it("registers resource-event listener before calling resourceWatchSubscribed", async () => {
     const client = new QueryClient();
     renderHook(

--- a/src/hooks/useResourceWatch.ts
+++ b/src/hooks/useResourceWatch.ts
@@ -108,6 +108,8 @@ export function useResourceWatch<
     // The rows a resync has delivered so far, held here rather than in
     // the cache until the backend says the burst is complete.
     let staged: Map<string, T> | null = null;
+    const positions = new Map<string, number>();
+    let indexedList: T[] | undefined;
 
     // Give up on a resync that can no longer complete. What was staged is
     // dropped rather than committed — a half-delivered burst is not a
@@ -182,6 +184,8 @@ export function useResourceWatch<
                 setResyncing(false);
                 if (rows) {
                   queryClient.setQueryData<T[]>(queryKey, [...rows.values()]);
+                  positions.clear();
+                  indexedList = undefined;
                 }
                 continue;
               }
@@ -194,9 +198,15 @@ export function useResourceWatch<
 
             if (live.length > 0) {
               const changes = live;
-              queryClient.setQueryData<T[]>(queryKey, (prev) =>
-                applyChanges(prev ?? [], changes)
-              );
+              indexedList = queryClient.setQueryData<T[]>(queryKey, (prev) => {
+                if (prev !== indexedList) {
+                  positions.clear();
+                  prev?.forEach((item, index) =>
+                    positions.set(identify(item), index)
+                  );
+                }
+                return applyChanges(prev ?? [], changes, positions);
+              });
             }
           }
         );
@@ -272,23 +282,42 @@ function stage<T extends { name: string; namespace?: string | null }>(
   else rows.set(identify(incoming), incoming);
 }
 
-/**
- * The list with a batch of changes folded in.
- *
- * Keyed rather than scanned: `findIndex` per change is O(N) against a list
- * the same burst is growing, so an init burst of a thousand objects costs
- * half a million name comparisons and as many copied array slots to build
- * what one pass builds.
- *
- * A `Map` keeps insertion order and leaves a replaced row where it was,
- * so rows do not jump around under an update.
- */
+// Lookup and replacement touch only changes; immutable publication and
+// ordered deletion still copy O(N) array slots.
 function applyChanges<T extends { name: string; namespace?: string | null }>(
   list: T[],
-  changes: Array<WatchChange<T>>
+  changes: Array<WatchChange<T>>,
+  positions: Map<string, number>
 ): T[] {
-  const rows = new Map<string, T>();
-  for (const item of list) rows.set(identify(item), item);
-  for (const change of changes) stage(rows, change);
-  return [...rows.values()];
+  let next: T[] | undefined;
+  let deleted = false;
+  for (const change of changes) {
+    const incoming = change.resource;
+    if (!incoming) continue;
+    const key = identify(incoming);
+    const index = positions.get(key);
+    if (change.op === "deleted") {
+      if (index === undefined) continue;
+      positions.delete(key);
+      deleted = true;
+    } else {
+      if (index !== undefined && (next ?? list)[index] === incoming) continue;
+      next ??= list.slice();
+      if (index === undefined) {
+        positions.set(key, next.length);
+        next.push(incoming);
+      } else {
+        next[index] = incoming;
+      }
+    }
+  }
+  if (deleted) {
+    const rows = next ?? list;
+    next = [];
+    for (const [key, index] of positions) {
+      positions.set(key, next.length);
+      next.push(rows[index]);
+    }
+  }
+  return next ?? list;
 }

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
+import type { PodMetrics } from "@/generated/types";
 
 import {
   attachAggregatedPodMetrics,
   matchDeploymentPods,
   matchStatefulSetPods,
+  mergePodsWithMetrics,
   type PodWithMetrics,
 } from "./metrics";
 
@@ -50,6 +52,76 @@ function byFilter<T extends { name: string; namespace: string }>(
 
 const usage = (rows: Array<{ name: string; cpuMillicores: number | null }>) =>
   rows.map((row) => [row.name, row.cpuMillicores] as const);
+
+describe("mergePodsWithMetrics", () => {
+  const sample = (name: string, cpuMillicores = 10): PodMetrics => ({
+    name,
+    namespace: "default",
+    cpuMillicores,
+    memoryBytes: 100,
+  });
+
+  /** Fresh metric objects with identical values must not invalidate every pod row memo. */
+  it("returns the same row objects when a tick repeats the metric values", () => {
+    const pods = [pod({ name: "a" }), pod({ name: "b" })];
+    const first = mergePodsWithMetrics(pods, [sample("a"), sample("b")]);
+    const next = mergePodsWithMetrics(pods, [sample("b"), sample("a")]);
+    expect(next[0]).toBe(first[0]);
+    expect(next[1]).toBe(first[1]);
+  });
+
+  /** CPU or memory changes must reach the affected row without reallocating its neighbours. */
+  it.each(["cpuMillicores", "memoryBytes"] as const)(
+    "replaces only the row whose %s changed",
+    (field) => {
+      const pods = [pod({ name: "a" }), pod({ name: "b" })];
+      const first = mergePodsWithMetrics(pods, [sample("a"), sample("b")]);
+      const next = mergePodsWithMetrics(pods, [
+        { ...sample("a"), [field]: 200 },
+        sample("b"),
+      ]);
+      expect(next[0]).not.toBe(first[0]);
+      expect(next[0][field]).toBe(200);
+      expect(first[0][field]).toBe(field === "cpuMillicores" ? 10 : 100);
+      expect(next[1]).toBe(first[1]);
+    }
+  );
+
+  /** Losing a sample must erase stale usage as unknown, while a measured zero stays zero. */
+  it("returns null usage when a pod loses its sample and preserves measured zero", () => {
+    const pods = [pod({ name: "a" }), pod({ name: "b" })];
+    const zero = { ...sample("b", 0), memoryBytes: 0 };
+    const first = mergePodsWithMetrics(pods, [sample("a"), zero]);
+    const next = mergePodsWithMetrics(pods, [zero]);
+    expect(next[0]).not.toBe(first[0]);
+    expect(next[0]).toEqual({
+      ...pods[0],
+      cpuMillicores: null,
+      memoryBytes: null,
+    });
+    expect(next[1]).toBe(first[1]);
+    expect(next[1].cpuMillicores).toBe(0);
+    expect(next[1].memoryBytes).toBe(0);
+    expect(mergePodsWithMetrics(pods, [zero])[0]).toBe(next[0]);
+    expect(
+      mergePodsWithMetrics(pods, [sample("a"), zero])[0].cpuMillicores
+    ).toBe(10);
+  });
+
+  /** A cache keyed only by name would hide watch updates or reuse rows from another namespace. */
+  it("uses pod identity and namespace when reusing merged rows", () => {
+    const pods = [pod({ name: "a" }), pod({ name: "a", namespace: "other" })];
+    const metrics = [sample("a"), { ...sample("a", 20), namespace: "other" }];
+    const first = mergePodsWithMetrics(pods, metrics);
+    const updated = { ...pods[0], restartCount: 3 };
+    const next = mergePodsWithMetrics([updated, pods[1]], metrics);
+    expect(next[0]).not.toBe(first[0]);
+    expect(next[0].restartCount).toBe(3);
+    expect(next[0].cpuMillicores).toBe(10);
+    expect(next[1]).toBe(first[1]);
+    expect(next[1].cpuMillicores).toBe(20);
+  });
+});
 
 describe("attachAggregatedPodMetrics", () => {
   /**

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -20,6 +20,8 @@ export interface ResourceMetrics {
   memoryBytes: number | null;
 }
 
+const podRows = new WeakMap<PodInfo, PodWithMetrics>();
+
 export function mergePodsWithMetrics(
   pods: PodInfo[],
   metrics: PodMetrics[]
@@ -31,11 +33,23 @@ export function mergePodsWithMetrics(
 
   return pods.map((pod) => {
     const metric = metricsByKey.get(`${pod.namespace}/${pod.name}`);
-    return {
+    const cpuMillicores = metric?.cpuMillicores ?? null;
+    const memoryBytes = metric?.memoryBytes ?? null;
+    const cached = podRows.get(pod);
+    if (
+      cached &&
+      cached.cpuMillicores === cpuMillicores &&
+      cached.memoryBytes === memoryBytes
+    ) {
+      return cached;
+    }
+    const row = {
       ...pod,
-      cpuMillicores: metric?.cpuMillicores ?? null,
-      memoryBytes: metric?.memoryBytes ?? null,
+      cpuMillicores,
+      memoryBytes,
     };
+    podRows.set(pod, row);
+    return row;
   });
 }
 

--- a/src/lib/node-reporting.test.ts
+++ b/src/lib/node-reporting.test.ts
@@ -45,6 +45,34 @@ it("updates changed silence values and removes the warning after recovery", () =
   expect(recovered[0].nodeSilence).toBeUndefined();
 });
 
+/**
+ * The realistic recovery: one node comes back while the cluster still has
+ * other silent nodes, so the map is not empty and the empty-map short-circuit
+ * never runs. The per-row branch has to hand back the bare row, not the
+ * annotation still sitting in the WeakMap — a cache that answered "still
+ * silent" for a node now healthy would be the stale-warning the whole third
+ * state exists to prevent, and the empty-map case cannot catch it.
+ */
+it("drops a recovered node's warning even while other nodes stay silent", () => {
+  const row = { nodeName: "gone" };
+  const silence: NodeSilence = {
+    node: "gone",
+    since: null,
+    reason: "NodeStatusUnknown",
+  };
+  // First tick caches an annotated row for `row` in the silenceRows WeakMap.
+  const first = withNodeSilence([row], new Map([["gone", silence]]));
+  expect(first[0].nodeSilence?.reason).toBe("NodeStatusUnknown");
+
+  // `gone` recovers, but `other` is still silent, so the map is non-empty.
+  const next = withNodeSilence(
+    [row],
+    new Map([["other", { node: "other", since: null, reason: null }]])
+  );
+  expect(next[0]).toBe(row);
+  expect(next[0].nodeSilence).toBeUndefined();
+});
+
 function condition(
   status: string,
   extra?: Partial<ConditionInfo>

--- a/src/lib/node-reporting.test.ts
+++ b/src/lib/node-reporting.test.ts
@@ -2,13 +2,48 @@ import { describe, expect, it } from "vitest";
 
 import type { ConditionInfo, NodeInfo } from "@/generated/types";
 
-import { silenceNote, silenceOf, silentNodes } from "./node-reporting";
+import {
+  silenceNote,
+  silenceOf,
+  silentNodes,
+  withNodeSilence,
+  type NodeSilence,
+} from "./node-reporting";
 
 import { translate } from "@/i18n";
 import type { T } from "@/i18n/useT";
 
 /** The English catalogue — what these expectations are written in. */
 const t: T = (section, key, values) => translate("en", section, key, values);
+
+/** Reattaching unchanged node warnings must not defeat metrics row memoization. */
+it("reuses annotated rows while the node silence values stay the same", () => {
+  const rows = [{ nodeName: "gone" }, { nodeName: "fine" }];
+  const silence: NodeSilence = { node: "gone", since: null, reason: null };
+  const first = withNodeSilence(rows, new Map([["gone", silence]]));
+  const next = withNodeSilence(rows, new Map([["gone", { ...silence }]]));
+  expect(next[0]).toBe(first[0]);
+  expect(next[1]).toBe(rows[1]);
+});
+
+/** Caching a warning must not hide new evidence or leave a recovered node marked silent. */
+it("updates changed silence values and removes the warning after recovery", () => {
+  const rows = [{ nodeName: "gone" }];
+  const silence: NodeSilence = { node: "gone", since: null, reason: null };
+  let previous = withNodeSilence(rows, new Map([["gone", silence]]))[0];
+  for (const update of [
+    { ...silence, since: "2026-09-07T00:00:00Z" },
+    { ...silence, since: "2026-09-07T00:00:00Z", reason: "NodeStatusUnknown" },
+  ]) {
+    const next = withNodeSilence(rows, new Map([["gone", update]]))[0];
+    expect(next).not.toBe(previous);
+    expect(next.nodeSilence).toEqual(update);
+    previous = next;
+  }
+  const recovered = withNodeSilence(rows, new Map());
+  expect(recovered[0]).toBe(rows[0]);
+  expect(recovered[0].nodeSilence).toBeUndefined();
+});
 
 function condition(
   status: string,

--- a/src/lib/node-reporting.ts
+++ b/src/lib/node-reporting.ts
@@ -78,6 +78,8 @@ export function silenceOf(
   return silent.get(nodeName) ?? null;
 }
 
+const silenceRows = new WeakMap<object, WithNodeSilence<object>>();
+
 /**
  * Attach each row's silence, if any.
  *
@@ -91,7 +93,18 @@ export function withNodeSilence<T extends { nodeName?: string | null }>(
   if (silent.size === 0) return rows;
   return rows.map((row) => {
     const silence = silenceOf(row.nodeName, silent);
-    return silence ? { ...row, nodeSilence: silence } : row;
+    if (!silence) return row;
+    const cached = silenceRows.get(row);
+    if (
+      cached?.nodeSilence?.node === silence.node &&
+      cached.nodeSilence.since === silence.since &&
+      cached.nodeSilence.reason === silence.reason
+    ) {
+      return cached as WithNodeSilence<T>;
+    }
+    const annotated = { ...row, nodeSilence: silence };
+    silenceRows.set(row, annotated);
+    return annotated;
   });
 }
 


### PR DESCRIPTION
## What is wrong today

Every watch batch, even one that changes a single pod, rebuilds a `Map` of every cached row and publishes a new array; every metrics tick, every two seconds, spreads every pod into a new object, so nothing downstream can keep a memo. At 10 000 pods that is 10 000 allocations per tick and a full rescan per batch, on the main thread, while the person is scrolling.

## What changes

- `useResourceWatch` keeps a position index between batches. A batch replaces only the rows it names; untouched rows keep their identity, so React Query's structural sharing and every memo below see them unchanged. A resync still commits atomically. If another writer replaces the cached array, the index is rebuilt once.
- `mergePodsWithMetrics` and `withNodeSilence` cache the derived row per source object in a `WeakMap`, keyed on the values that feed it: a tick that changes nothing for a pod returns the same row object. A pod that lost its metrics sample is still `null`, never zero.
- `usePodsWithMetrics` memoises the merge and the annotation separately so a silence change does not redo the merge.

Honest limit: the array copy on the first change of a batch and ordered deletion still touch O(N) slots, and structural sharing still compares. This is O(changes) for lookup and replacement, not for publication; that is the next step, together with the compact list DTO.

Written by Codex (gpt-6-astra) under review; every finding was verified by reading and by running the tests.

## How to check it

Tests beside each subject:

- a batch touching 1 of 10 000 rows leaves the other 9 999 row objects identical by reference and reads fewer than 10 keys (the original code read 10 002);
- a resync replaces the collection in one write; delete then re-add appends and keeps updates in place; an external writer invalidates the index;
- identical metrics ticks return identical row references, a changed CPU changes only that row, a lost sample stays unknown.

Sabotage was run: the original code fails the identity and key-read tests; replacing unknown CPU with zero fails the unknown-usage test. Wall-clock numbers are not measured yet: the recorder that measures them lands in the rig PR.

## Risk and rollback

Row ordering rules are pinned by tests and unchanged. Rollback is a revert.
