### PR TITLE
feat: a read the cluster refused ends in the rule to ask for, not in a sentence

### DIFF
--- a/src/components/resources/ConnectionsPanel.test.tsx
+++ b/src/components/resources/ConnectionsPanel.test.tsx
@@ -178,6 +178,6 @@ describe("ConnectionsPanel", () => {
         query={query({ error: new Error("connection refused") })}
       />
     );
-    expect(screen.getByText("connection refused")).toBeInTheDocument();
+    expect(screen.getByText(/connection refused/)).toBeInTheDocument();
   });
 });

--- a/src/components/resources/ConnectionsPanel.tsx
+++ b/src/components/resources/ConnectionsPanel.tsx
@@ -14,6 +14,7 @@ import { Link } from "react-router-dom";
 import { ExternalLink } from "lucide-react";
 
 import { Section } from "@/components/ui/section";
+import { Unknown } from "@/components/ui/unknown";
 import { shortRevision } from "@/integrations";
 import { cn } from "@/lib/utils";
 import {
@@ -189,12 +190,11 @@ export function ConnectionsPanel({
   if (error || !data) {
     return (
       <Section>
-        <p className="text-xs text-err">
-          {t("empty", "couldNotReadWhatConnects")}
-        </p>
-        <p className="text-[11px] text-fg-fnt">
-          {error?.message ?? t("empty", "clusterDidNotAnswer")}
-        </p>
+        <Unknown
+          question={t("empty", "couldNotReadWhatConnects")}
+          error={error ?? t("empty", "clusterDidNotAnswer")}
+          onRetry={() => void query.refetch()}
+        />
       </Section>
     );
   }

--- a/src/components/resources/ResourceDetailLayout.test.tsx
+++ b/src/components/resources/ResourceDetailLayout.test.tsx
@@ -9,7 +9,7 @@ import { Info } from "lucide-react";
 import { SectionHeader } from "@/components/ui/section";
 import { useClusterStore } from "@/stores/clusterStore";
 import { useScopeTabStore } from "@/stores/scopeTabStore";
-import { ResourceDetailLayout } from "./ResourceDetailLayout";
+import { DetailError, ResourceDetailLayout } from "./ResourceDetailLayout";
 
 /**
  * A client, because the frame now asks a capability where this object came
@@ -738,5 +738,31 @@ describe("the breadcrumb's namespace segment", () => {
     );
     expect(screen.getByText("k8s-gui-test")).toBeInTheDocument();
     expect(screen.queryByTitle(/k8s-gui-test/)).toBeNull();
+  });
+});
+
+describe("DetailError does not stack the same sentence twice", () => {
+  /**
+   * The red heading already says "could not read this kind"; #128 wired an
+   * Unknown box below it. Passing the heading's own key as the box's question
+   * printed the sentence twice. The box asks the question the read was instead.
+   */
+  it("says 'could not read' once, and asks a distinct question", () => {
+    wrap(
+      <DetailError
+        error={
+          new Error(
+            'deployments.apps "api" is forbidden: User "system:serviceaccount:team:x" cannot get resource "deployments" in API group "apps" in the namespace "team"'
+          )
+        }
+        resourceKind="Deployment"
+        onBack={() => {}}
+      />
+    );
+
+    expect(screen.getAllByText(/could not read this deployment/i)).toHaveLength(
+      1
+    );
+    expect(screen.getByText(/what is this deployment/i)).toBeInTheDocument();
   });
 });

--- a/src/components/resources/ResourceDetailLayout.tsx
+++ b/src/components/resources/ResourceDetailLayout.tsx
@@ -73,7 +73,9 @@ export function DetailError({
         </p>
       ) : (
         <Unknown
-          question={t("empty", "kindCouldNotRead", { kind })}
+          // The heading already says "could not read this kind"; the box asks
+          // the question the read was, so the same sentence is not stacked twice.
+          question={t("empty", "whatIsThisKind", { kind })}
           error={error ?? t("empty", "clusterDidNotAnswer")}
         />
       )}

--- a/src/components/resources/ResourceDetailLayout.tsx
+++ b/src/components/resources/ResourceDetailLayout.tsx
@@ -19,6 +19,7 @@ import { AlertCircle, ArrowLeft, RefreshCw } from "lucide-react";
 
 import { DetailSkeleton } from "@/components/ui/skeleton";
 import { CaptionScope, Section } from "@/components/ui/section";
+import { Unknown } from "@/components/ui/unknown";
 import { isResourceNotFoundError } from "@/hooks/useResourceDetail";
 import { cn } from "@/lib/utils";
 import { ResourceDetailHeader } from "./ResourceDetailHeader";
@@ -66,13 +67,16 @@ export function DetailError({
             : t("empty", "kindCouldNotRead", { kind })}
         </h2>
       </div>
-      <p className="text-xs text-fg-mut">
-        {isNotFound
-          ? t("empty", "kindMayBeGone", { kind })
-          : typeof error === "string"
-            ? error
-            : (error?.message ?? t("empty", "clusterDidNotAnswer"))}
-      </p>
+      {isNotFound ? (
+        <p className="text-xs text-fg-mut">
+          {t("empty", "kindMayBeGone", { kind })}
+        </p>
+      ) : (
+        <Unknown
+          question={t("empty", "kindCouldNotRead", { kind })}
+          error={error ?? t("empty", "clusterDidNotAnswer")}
+        />
+      )}
       {additionalMessage && (
         <p className="text-xs text-fg-mut">{additionalMessage}</p>
       )}

--- a/src/components/resources/TrafficChain.test.tsx
+++ b/src/components/resources/TrafficChain.test.tsx
@@ -561,4 +561,30 @@ describe("TrafficChain", () => {
       vi.doUnmock("@/hooks/useServiceEdge");
     });
   });
+
+  /**
+   * The chain reads the same `useConnections` query as the Connections tab, so
+   * a refusal must end in the rule to ask for and a retry here too — not the
+   * bare red dead-end it used to. Same fact, two readers.
+   */
+  it("offers the rule and a retry when the connections read is refused", () => {
+    const refetch = vi.fn();
+    const refused = {
+      data: undefined,
+      isPending: false,
+      error: new Error(
+        'services is forbidden: User "system:serviceaccount:team:x" cannot list resource "services" in API group "" at the cluster scope'
+      ),
+      refetch,
+    } as unknown as ConnectionsQuery;
+
+    wrap(<TrafficChain query={refused} />);
+
+    expect(
+      screen.getByRole("button", { name: /copy the rule to ask for/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /try the read again/i })
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/resources/TrafficChain.tsx
+++ b/src/components/resources/TrafficChain.tsx
@@ -16,6 +16,7 @@ import { joinSayings, sayWords } from "@/i18n/say";
 import { Link } from "react-router-dom";
 
 import { Section, SectionHeader } from "@/components/ui/section";
+import { Unknown } from "@/components/ui/unknown";
 import {
   CopyableAddress,
   CopyableAddresses,
@@ -533,12 +534,15 @@ export function TrafficChain({
     );
   }
   if (error || !data) {
+    // The same read the Connections tab escapes: this chain reads the one
+    // `useConnections` query too, so a refusal offers the rule here as well,
+    // not a bare red dead-end. See `ConnectionsPanel`.
     return (
-      <p className="text-xs text-err">
-        {t("empty", "couldNotReadConnections", {
-          reason: error?.message ?? t("empty", "noAnswer"),
-        })}
-      </p>
+      <Unknown
+        question={t("empty", "couldNotReadWhatConnects")}
+        error={error ?? t("empty", "clusterDidNotAnswer")}
+        onRetry={() => void query.refetch()}
+      />
     );
   }
 

--- a/src/components/ui/unknown.test.tsx
+++ b/src/components/ui/unknown.test.tsx
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { Unknown } from "./unknown";
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+Object.defineProperty(navigator, "clipboard", {
+  value: { writeText },
+  configurable: true,
+});
+
+const REFUSED =
+  'Tauri command \'getConnections\' failed: endpointslices.discovery.k8s.io is forbidden: User "kirya" cannot list resource "endpointslices" in API group "discovery.k8s.io" in the namespace "shop"';
+
+describe("Unknown", () => {
+  beforeEach(() => writeText.mockClear());
+
+  /** A refusal with no way out leaves the reader exactly where the sentence left them. */
+  it("turns a refusal into the rule to ask for", async () => {
+    render(
+      <Unknown
+        question="Who is behind this Service?"
+        error={new Error(REFUSED)}
+      />
+    );
+    expect(screen.getByText("Who is behind this Service?")).toBeInTheDocument();
+    expect(screen.getByText(/cluster refused/)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /rule/i }));
+    const yaml = writeText.mock.calls[0][0] as string;
+    expect(yaml).toContain("kind: Role");
+    expect(yaml).toContain("namespace: shop");
+    expect(yaml).toContain('resources: ["endpointslices"]');
+  });
+
+  /** A network fault names no subject; offering a rule for it would be a lie. */
+  it("offers a retry for a fault and no rule", async () => {
+    const retry = vi.fn();
+    render(
+      <Unknown
+        question="Usage history"
+        error={new Error("connection refused")}
+        onRetry={retry}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /rule/i })
+    ).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /again/i }));
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  /** Our own command wrapper's prefix is framing, not what the server said. */
+  it("shows the server's words without the command framing", () => {
+    render(<Unknown question="q" error={new Error(REFUSED)} />);
+    expect(screen.queryByText(/Tauri command/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/endpointslices\.discovery\.k8s\.io is forbidden/)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/unknown.tsx
+++ b/src/components/ui/unknown.tsx
@@ -55,8 +55,18 @@ export function Unknown({ question, error, onRetry, className }: UnknownProps) {
       </p>
       <div className="flex flex-wrap gap-1.5 pl-[22px] pt-0.5">
         {onRetry && (
-          <Button variant="outline" size="sm" onClick={onRetry}>
-            <RefreshCw className="mr-1.5 h-3 w-3" aria-hidden="true" />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRetry}
+            // A long label (Russian runs longer than English) must wrap inside
+            // the button rather than run past the box's edge.
+            className="h-auto min-h-6 items-start whitespace-normal py-0.5 text-left"
+          >
+            <RefreshCw
+              className="mr-1.5 mt-0.5 h-3 w-3 flex-none"
+              aria-hidden="true"
+            />
             {t("empty", "unknownRetry")}
           </Button>
         )}
@@ -67,8 +77,12 @@ export function Unknown({ question, error, onRetry, className }: UnknownProps) {
             onClick={() =>
               void copy(rbacRule(refusal), t("empty", "unknownRuleCopied"))
             }
+            className="h-auto min-h-6 items-start whitespace-normal py-0.5 text-left"
           >
-            <ClipboardCopy className="mr-1.5 h-3 w-3" aria-hidden="true" />
+            <ClipboardCopy
+              className="mr-1.5 mt-0.5 h-3 w-3 flex-none"
+              aria-hidden="true"
+            />
             {t("empty", "unknownCopyRule")}
           </Button>
         )}

--- a/src/components/ui/unknown.tsx
+++ b/src/components/ui/unknown.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react";
+import { ClipboardCopy, RefreshCw, TriangleAlert } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { errorToShow, isRefusal } from "@/lib/error-utils";
+import { parseRefusal, rbacRule } from "@/lib/refusal";
+import { cn } from "@/lib/utils";
+import { useT } from "@/i18n/useT";
+
+export interface UnknownProps {
+  /** What could not be answered, as a question the reader asked. */
+  question: ReactNode;
+  /** The failure, as the read returned it. */
+  error: unknown;
+  /** Ask the same read again. Offered whenever the caller can. */
+  onRetry?: () => void;
+  className?: string;
+}
+
+/**
+ * A read that did not happen, with a way out.
+ *
+ * Every "could not look" in the app renders this, so that none of them ends
+ * in a sentence: a refusal turns into the rule to ask an administrator for,
+ * a fault into a retry. The verdict around it does not move because a
+ * button was pressed; only a read that succeeds moves it.
+ */
+export function Unknown({ question, error, onRetry, className }: UnknownProps) {
+  const t = useT();
+  const copy = useCopyToClipboard();
+  const message = errorToShow(error);
+  const refused = isRefusal(error);
+  const refusal = parseRefusal(message);
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex flex-col gap-1.5 rounded-md border border-dashed border-hair px-3 py-2 text-xs",
+        className
+      )}
+    >
+      <p className="flex items-start gap-2 text-fg">
+        <TriangleAlert
+          className="mt-0.5 h-3.5 w-3.5 flex-none text-warn"
+          aria-hidden="true"
+        />
+        <span className="min-w-0">{question}</span>
+      </p>
+      <p className="pl-[22px] text-fg-mut">
+        {refused
+          ? t("empty", "unknownRefused", { message })
+          : t("empty", "unknownFault", { message })}
+      </p>
+      <div className="flex flex-wrap gap-1.5 pl-[22px] pt-0.5">
+        {onRetry && (
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            <RefreshCw className="mr-1.5 h-3 w-3" aria-hidden="true" />
+            {t("empty", "unknownRetry")}
+          </Button>
+        )}
+        {refusal && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              void copy(rbacRule(refusal), t("empty", "unknownRuleCopied"))
+            }
+          >
+            <ClipboardCopy className="mr-1.5 h-3 w-3" aria-hidden="true" />
+            {t("empty", "unknownCopyRule")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -2674,6 +2674,7 @@ export const en = {
     kindMayBeGone:
       "The {kind} may have been deleted or recreated under a new name.",
     kindCouldNotRead: "Could not read this {kind}",
+    whatIsThisKind: "What is this {kind}?",
     kindNotFound: "{kind} not found",
     pvcListDescription: "Requests for storage by pods in {scope}",
     expandRepeats: "Expand {count} repeats",

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -3505,6 +3505,12 @@ export const en = {
       "A slice carries a port by the Service port's name. These name none it declares, so nothing routes to them.",
     couldNotReadWhatConnects: "Could not read what connects to this.",
     clusterDidNotAnswer: "The cluster did not answer.",
+    unknownRefused: "The cluster refused: {message}",
+    unknownFault: "The read failed: {message}",
+    unknownRetry: "Try the read again",
+    unknownCopyRule: "Copy the rule to ask for",
+    unknownRuleCopied:
+      "A Role and a RoleBinding that would allow this read. Give it to whoever owns access.",
     inNamespaceWhere: "in {namespace}",
     inClusterWhere: "in the cluster",
     nothingStatesEdge: "Nothing {where} states an edge to this {kind}.",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -2854,6 +2854,7 @@ export const ru: Catalogue = {
     kindMayBeGone:
       "Объект ({kind}) мог быть удалён или пересоздан под новым именем.",
     kindCouldNotRead: "Не удалось прочитать этот объект ({kind})",
+    whatIsThisKind: "Что это за объект ({kind})?",
     kindNotFound: "{kind} не найден",
     pvcListDescription: "Запросы на хранилище от подов в {scope}",
     expandRepeats: "Развернуть повторы: {count}",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -3739,6 +3739,12 @@ export const ru: Catalogue = {
       "Срез несёт порт под именем порта Service. Эти не называют ни один из объявленных, поэтому к ним ничего не маршрутизируется.",
     couldNotReadWhatConnects: "Не удалось прочитать, что с этим связано.",
     clusterDidNotAnswer: "Кластер не ответил.",
+    unknownRefused: "Кластер отказал: {message}",
+    unknownFault: "Чтение не удалось: {message}",
+    unknownRetry: "Прочитать ещё раз",
+    unknownCopyRule: "Скопировать правило, которое попросить",
+    unknownRuleCopied:
+      "Role и RoleBinding, которые разрешили бы это чтение. Отдайте тому, кто выдаёт доступ.",
     inNamespaceWhere: "в пространстве имён {namespace}",
     inClusterWhere: "в кластере",
     nothingStatesEdge: "Ничто {where} не объявляет связь с этим {kind}.",

--- a/src/lib/refusal.test.ts
+++ b/src/lib/refusal.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRefusal, rbacRule } from "./refusal";
+
+describe("parseRefusal", () => {
+  /** A rule built from the wrong namespace or group would be asked for and still not help. */
+  it("reads user, verb, resource, group and namespace out of the server's sentence", () => {
+    expect(
+      parseRefusal(
+        'endpointslices.discovery.k8s.io is forbidden: User "kirya" cannot list resource "endpointslices" in API group "discovery.k8s.io" in the namespace "shop"'
+      )
+    ).toEqual({
+      user: "kirya",
+      verb: "list",
+      resource: "endpointslices",
+      group: "discovery.k8s.io",
+      namespace: "shop",
+    });
+  });
+
+  /** A cluster-scoped refusal has no namespace, and a Role in one would not help. */
+  it("keeps the cluster scope as no namespace and a subresource whole", () => {
+    expect(
+      parseRefusal(
+        'nodes is forbidden: User "dev" cannot list resource "nodes" in API group "" at the cluster scope'
+      )?.namespace
+    ).toBeNull();
+    expect(
+      parseRefusal(
+        'pods "x" is forbidden: User "dev" cannot get resource "pods/log" in API group "" in the namespace "shop"'
+      )?.resource
+    ).toBe("pods/log");
+  });
+
+  /** "permission denied" from elsewhere names nothing a rule could be built from. */
+  it("returns null for a refusal that names no subject", () => {
+    expect(parseRefusal("permission denied")).toBeNull();
+    expect(
+      parseRefusal("Tauri command 'listPods' failed: connection refused")
+    ).toBeNull();
+  });
+});
+
+describe("rbacRule", () => {
+  /** A list without get and watch is a screen that loads once and never updates. */
+  it("asks for all three read verbs in the namespace the refusal named", () => {
+    const rule = rbacRule({
+      user: "kirya",
+      verb: "list",
+      resource: "endpointslices",
+      group: "discovery.k8s.io",
+      namespace: "shop",
+    });
+    expect(rule).toContain("kind: Role\n");
+    expect(rule).toContain("  namespace: shop");
+    expect(rule).toContain('resources: ["endpointslices"]');
+    expect(rule).toContain('verbs: ["get", "list", "watch"]');
+    expect(rule).toContain("kind: User\n  name: kirya");
+    expect(rule).toContain("kind: RoleBinding");
+  });
+
+  /** A service account is bound by kind and namespace, not as a User string that no binding matches. */
+  it("binds a service account as a ServiceAccount at the cluster scope", () => {
+    const rule = rbacRule({
+      user: "system:serviceaccount:auth:dex",
+      verb: "delete",
+      resource: "nodes",
+      group: "",
+      namespace: null,
+    });
+    expect(rule).toContain("kind: ClusterRole\n");
+    expect(rule).not.toContain("namespace: null");
+    expect(rule).toContain('verbs: ["delete"]');
+    expect(rule).toContain(
+      "- kind: ServiceAccount\n  name: dex\n  namespace: auth"
+    );
+  });
+});

--- a/src/lib/refusal.ts
+++ b/src/lib/refusal.ts
@@ -1,0 +1,91 @@
+/**
+ * What a 403 from the API server says, read back out of its sentence.
+ *
+ * The server writes the whole refusal in one line: who, which verb, which
+ * resource, which group, which namespace. That is everything a Role needs,
+ * so the rule to ask an administrator for is the refusal turned around, not
+ * something guessed from the kubeconfig's user alias.
+ */
+
+export interface Refusal {
+  user: string;
+  verb: string;
+  /** `pods`, or `pods/log` for a subresource. */
+  resource: string;
+  group: string;
+  /** `null` at the cluster scope. */
+  namespace: string | null;
+}
+
+const SENTENCE =
+  /User "([^"]+)" cannot (\w+) resource "([^"]+)"(?: in API group "([^"]*)")?(?: in the namespace "([^"]+)"| at the cluster scope)?/;
+
+export function parseRefusal(message: string): Refusal | null {
+  const m = SENTENCE.exec(message);
+  if (!m) return null;
+  return {
+    user: m[1],
+    verb: m[2],
+    resource: m[3],
+    group: m[4] ?? "",
+    namespace: m[5] ?? null,
+  };
+}
+
+const READ_VERBS = ["get", "list", "watch"];
+
+function dnsLabel(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 63);
+}
+
+function subject(user: string): string {
+  const sa = /^system:serviceaccount:([^:]+):(.+)$/.exec(user);
+  if (sa) {
+    return `- kind: ServiceAccount\n  name: ${sa[2]}\n  namespace: ${sa[1]}`;
+  }
+  return `- kind: User\n  name: ${user}\n  apiGroup: rbac.authorization.k8s.io`;
+}
+
+/**
+ * A Role and RoleBinding (or their cluster-scoped pair) that would have let
+ * the refused read through. A read verb asks for all three read verbs, because
+ * a list without a watch is a screen that never updates.
+ */
+export function rbacRule(refusal: Refusal): string {
+  const verbs = READ_VERBS.includes(refusal.verb) ? READ_VERBS : [refusal.verb];
+  const scoped = refusal.namespace !== null;
+  const role = scoped ? "Role" : "ClusterRole";
+  const binding = scoped ? "RoleBinding" : "ClusterRoleBinding";
+  const name = dnsLabel(`rubick-${refusal.verb}-${refusal.resource}`);
+  const ns = scoped ? `\n  namespace: ${refusal.namespace}` : "";
+  const where = scoped
+    ? `in namespace ${refusal.namespace}`
+    : "at the cluster scope";
+  return [
+    `# Rubick was refused: ${refusal.user} cannot ${refusal.verb} ${refusal.resource} ${where}.`,
+    `apiVersion: rbac.authorization.k8s.io/v1`,
+    `kind: ${role}`,
+    `metadata:`,
+    `  name: ${name}${ns}`,
+    `rules:`,
+    `- apiGroups: ["${refusal.group}"]`,
+    `  resources: ["${refusal.resource}"]`,
+    `  verbs: [${verbs.map((v) => `"${v}"`).join(", ")}]`,
+    `---`,
+    `apiVersion: rbac.authorization.k8s.io/v1`,
+    `kind: ${binding}`,
+    `metadata:`,
+    `  name: ${name}${ns}`,
+    `roleRef:`,
+    `  apiGroup: rbac.authorization.k8s.io`,
+    `  kind: ${role}`,
+    `  name: ${name}`,
+    `subjects:`,
+    subject(refusal.user),
+    ``,
+  ].join("\n");
+}


### PR DESCRIPTION
## What is wrong today

When the cluster refuses a read, the app says so and stops: "Could not read what connects to this", the server's sentence under it, nothing to press. The honesty is right and the reader is stranded. The same sentence already names the user, the verb, the resource, the group and the namespace, which is everything a Role needs, so the way out was in the message all along.

## What changes

- `src/lib/refusal.ts` reads the API server's forbidden sentence back into its parts and turns it into a Role and RoleBinding (or the cluster-scoped pair) that would have allowed the read. A read verb asks for get, list and watch, because a list without a watch is a screen that never updates. A `system:serviceaccount:` user becomes a ServiceAccount subject, not a User string no binding would match.
- `Unknown` (`src/components/ui/unknown.tsx`) is the one component a could-not-look state renders: the question that went unanswered, the server's words without our command framing, and the exits: try the read again when the caller can, copy the rule when the failure was a refusal. A fault with no subject offers no rule. The verdict around it moves only when a read succeeds.
- Two sites use it first: the Connections tab's error branch, with the query's own `refetch` behind the retry, and the detail page's "could not read this kind" state. The other twenty-odd "could not read" sites in the catalogue follow one by one; most of them still carry only a boolean and need their error plumbed through before they can offer a rule.

Not in this PR: "mark the evidence unavailable" (needs the investigation model from the Team package) and reconnecting a Prometheus or Loki source from the panel (the forward's `reestablish` exists; the panel wiring is a separate change).

## How to check it

Tests: the sentence parses into user, verb, resource, group and namespace, keeps a subresource whole and the cluster scope as no namespace, and refuses text that names no subject; the rule asks for all three read verbs in the named namespace and binds a service account by kind; the component copies a Role for a refusal, offers a retry and no rule for a network fault, and never shows the `Tauri command … failed:` framing. `bun run test` 2 269 passed, `tsc` and `lint` clean.

## Risk and rollback

Additive; the two wired sites show the same error text with buttons beside it. Rollback is a revert.