### PR TITLE
feat: a cluster marked critical asks for its own name before any change

### DIFF
--- a/src/components/helm/HelmInstallDialog.test.tsx
+++ b/src/components/helm/HelmInstallDialog.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { HelmInstallDialog } from "./HelmInstallDialog";
+import type { HelmChartSearchResult } from "@/generated/types";
+import { useClusterIdentityStore } from "@/stores/clusterIdentityStore";
+import { useClusterStore } from "@/stores/clusterStore";
+
+const PROD = "prod-eu-1";
+
+const chart: HelmChartSearchResult = {
+  name: "nginx",
+  version: "1.0.0",
+  appVersion: "1.25",
+  description: "web server",
+};
+
+const dialog = () => (
+  <HelmInstallDialog
+    chart={chart}
+    onClose={() => {}}
+    namespaces={["default"]}
+    releaseName="web"
+    onReleaseNameChange={() => {}}
+    namespace="default"
+    onNamespaceChange={() => {}}
+    version=""
+    onVersionChange={() => {}}
+    values=""
+    onValuesChange={() => {}}
+    createNamespace={false}
+    onCreateNamespaceChange={() => {}}
+    wait={false}
+    onWaitChange={() => {}}
+    onInstall={() => {}}
+    isInstalling={false}
+  />
+);
+
+const installButton = () => screen.getByRole("button", { name: /^install$/i });
+
+beforeEach(() => {
+  useClusterIdentityStore.setState({ marks: {} });
+  useClusterStore.setState({ currentContext: PROD, isConnected: true });
+});
+
+afterEach(() => {
+  useClusterIdentityStore.setState({ marks: {} });
+  useClusterStore.setState({ currentContext: null, isConnected: false });
+});
+
+describe("installing a chart on critical infrastructure", () => {
+  /**
+   * Installing creates a whole release; on the marked cluster it took no
+   * confirmation at all while uninstall and rollback of the same release did,
+   * so the gate has to reach install too.
+   */
+  it("holds the install button until the cluster's name is typed", async () => {
+    useClusterIdentityStore.getState().setCritical(PROD, true);
+    render(dialog());
+
+    expect(screen.getByRole("alert")).toHaveTextContent(PROD);
+    expect(installButton()).toBeDisabled();
+
+    await userEvent.type(screen.getByPlaceholderText(PROD), PROD);
+    expect(installButton()).toBeEnabled();
+  });
+
+  it("asks nothing of a cluster nobody marked", () => {
+    render(dialog());
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(installButton()).toBeEnabled();
+  });
+});

--- a/src/components/helm/HelmInstallDialog.tsx
+++ b/src/components/helm/HelmInstallDialog.tsx
@@ -19,7 +19,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { HelmChartSearchResult } from "@/generated/types";
+import { useCriticalGate } from "@/hooks/useCriticalGate";
 import { useT } from "@/i18n/useT";
+import { useEffect } from "react";
 
 export interface HelmInstallDialogProps {
   /** Chart to install */
@@ -72,6 +74,13 @@ export function HelmInstallDialog({
   isInstalling,
 }: HelmInstallDialogProps) {
   const t = useT();
+  // Installing a chart creates a whole release on the cluster, so on a critical
+  // one it takes the typed-name gate — as uninstall and rollback already do.
+  const gate = useCriticalGate();
+  const gateReset = gate.reset;
+  useEffect(() => {
+    if (chart === null) gateReset();
+  }, [chart, gateReset]);
   return (
     <Dialog open={chart !== null} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="max-w-lg">
@@ -80,6 +89,7 @@ export function HelmInstallDialog({
           <DialogDescription>
             {t("action", "installChartHint", { name: chart?.name ?? "" })}
           </DialogDescription>
+          {gate.notice}
         </DialogHeader>
         <div className="space-y-4 py-4">
           <div className="space-y-2">
@@ -157,6 +167,7 @@ export function HelmInstallDialog({
               </Label>
             </div>
           </div>
+          {gate.input}
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={onClose}>
@@ -164,7 +175,9 @@ export function HelmInstallDialog({
           </Button>
           <Button
             onClick={onInstall}
-            disabled={!releaseName || !namespace || isInstalling}
+            disabled={
+              !releaseName || !namespace || isInstalling || gate.blocked
+            }
           >
             {isInstalling ? t("action", "installing") : t("action", "install")}
           </Button>

--- a/src/components/helm/HelmUpgradeDialog.tsx
+++ b/src/components/helm/HelmUpgradeDialog.tsx
@@ -13,7 +13,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { KeyValueRow } from "@/components/resources/detail-kv";
 import type { HelmRelease } from "@/generated/types";
+import { useCriticalGate } from "@/hooks/useCriticalGate";
 import { useT } from "@/i18n/useT";
+import { useEffect } from "react";
 
 export interface HelmUpgradeDialogProps {
   /** Release to upgrade */
@@ -48,6 +50,13 @@ export function HelmUpgradeDialog({
   isUpgrading,
 }: HelmUpgradeDialogProps) {
   const t = useT();
+  // Upgrading replaces a release on the cluster, so on a critical one it takes
+  // the typed-name gate — as uninstall and rollback already do.
+  const gate = useCriticalGate();
+  const gateReset = gate.reset;
+  useEffect(() => {
+    if (release === null) gateReset();
+  }, [release, gateReset]);
 
   return (
     <Dialog open={release !== null} onOpenChange={(open) => !open && onClose()}>
@@ -60,6 +69,7 @@ export function HelmUpgradeDialog({
               namespace: release?.namespace ?? "",
             })}
           </DialogDescription>
+          {gate.notice}
         </DialogHeader>
         <div className="space-y-4 py-4">
           <dl className="max-w-sm">
@@ -103,12 +113,13 @@ export function HelmUpgradeDialog({
               {t("action", "waitForReady")}
             </Label>
           </div>
+          {gate.input}
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={onClose}>
             {t("action", "cancel")}
           </Button>
-          <Button onClick={onUpgrade} disabled={isUpgrading}>
+          <Button onClick={onUpgrade} disabled={isUpgrading || gate.blocked}>
             {isUpgrading ? t("action", "upgrading") : t("action", "upgrade")}
           </Button>
         </DialogFooter>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { TriangleAlert } from "lucide-react";
 import { Outlet } from "react-router-dom";
 import { Sidebar } from "./Sidebar";
 import { CredentialsExpired } from "@/components/cluster/CredentialsExpired";
@@ -13,13 +14,17 @@ import { clusterColor } from "@/lib/cluster-identity";
 import { useScopeTabs } from "@/hooks/useScopeTabs";
 import { useClusterForwards } from "@/hooks/useClusterForwards";
 import { usePrefetchCoreLists } from "@/hooks/usePrefetchCoreLists";
+import { useCritical } from "@/hooks/useCritical";
+import { useT } from "@/i18n/useT";
 import { useClusterMark } from "@/stores/clusterIdentityStore";
 import { useClusterStore } from "@/stores/clusterStore";
 import { useScopeTabStore } from "@/stores/scopeTabStore";
 
 export function Layout() {
+  const t = useT();
   const currentContext = useClusterStore((s) => s.currentContext);
   const { hue } = useClusterMark(currentContext);
+  const { critical } = useCritical();
   const expired = useExpiredCredentials();
   const catchingUp = useScopeTabStore((s) => s.pendingHref !== null);
   useScopeTabs();
@@ -43,8 +48,20 @@ export function Layout() {
       }
     >
       {/* 2px along the top edge: unmissable in peripheral vision, zero
-          competition with the content below it. */}
-      <div className="h-0.5 flex-none bg-(--cluster)" />
+          competition with the content below it. Critical infrastructure
+          gets a band with words instead: the colour alone is what the
+          reader has stopped seeing by the time it matters. */}
+      {critical && currentContext ? (
+        <div
+          role="status"
+          className="flex h-5 flex-none items-center justify-center gap-2 bg-err px-3 font-mono text-[11px] font-semibold uppercase tracking-[0.08em] text-canvas"
+        >
+          <TriangleAlert className="h-3 w-3" aria-hidden="true" />
+          {t("cluster", "criticalStripe", { context: currentContext })}
+        </div>
+      ) : (
+        <div className="h-0.5 flex-none bg-(--cluster)" />
+      )}
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />
         <div className="flex flex-1 flex-col overflow-hidden">

--- a/src/components/resources/NodeList.tsx
+++ b/src/components/resources/NodeList.tsx
@@ -31,6 +31,8 @@ import { queryKeys } from "@/lib/query-keys";
 import { getResourceRowId } from "@/lib/table-utils";
 import { useResourceWatch } from "@/hooks/useResourceWatch";
 import { DrainDialog } from "@/components/resources/drain-dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { useCritical } from "@/hooks/useCritical";
 import { drainingNode, useNodeDrain } from "@/hooks/useNodeDrain";
 import { useT } from "@/i18n/useT";
 
@@ -256,6 +258,15 @@ export function NodeList() {
   });
 
   const [draining, setDraining] = useState<string | null>(null);
+  // Cordon/uncordon fire straight from a list row. On a critical cluster they
+  // are still a change to that cluster, so they route through the typed-name
+  // gate the ConfirmDialog carries; on an ordinary cluster they stay one-click.
+  const critical = useCritical();
+  const criticalActive = critical.critical && !!critical.context;
+  const [pendingSchedulable, setPendingSchedulable] = useState<{
+    action: "cordon" | "uncordon";
+    node: string;
+  } | null>(null);
 
   // A drain is not a mutation: it outlives its own command call and reports
   // as it goes. The hook owns that; the list only owns which node is open.
@@ -302,12 +313,18 @@ export function NodeList() {
       {
         icon: ShieldOff,
         label: t("action", "cordon"),
-        onClick: (item) => cordonMutation.mutate(item.name),
+        onClick: (item) =>
+          criticalActive
+            ? setPendingSchedulable({ action: "cordon", node: item.name })
+            : cordonMutation.mutate(item.name),
       },
       {
         icon: Shield,
         label: t("action", "uncordon"),
-        onClick: (item) => uncordonMutation.mutate(item.name),
+        onClick: (item) =>
+          criticalActive
+            ? setPendingSchedulable({ action: "uncordon", node: item.name })
+            : uncordonMutation.mutate(item.name),
       },
       {
         icon: AlertTriangle,
@@ -325,7 +342,16 @@ export function NodeList() {
         variant: "destructive",
       },
     ],
-    [t, navigate, cordonMutation, uncordonMutation, setDraining, drain]
+    [
+      t,
+      navigate,
+      cordonMutation,
+      uncordonMutation,
+      setDraining,
+      drain,
+      criticalActive,
+      setPendingSchedulable,
+    ]
   );
 
   return (
@@ -367,6 +393,33 @@ export function NodeList() {
           void drain.start(node, { ignoreDaemonsets: true, ...choices });
         }}
         onCancelDrain={drain.cancel}
+      />
+      <ConfirmDialog
+        open={pendingSchedulable !== null}
+        onOpenChange={(open) => !open && setPendingSchedulable(null)}
+        title={
+          pendingSchedulable
+            ? t(
+                "action",
+                pendingSchedulable.action === "cordon"
+                  ? "cordonNamed"
+                  : "uncordonNamed",
+                { name: pendingSchedulable.node }
+              )
+            : ""
+        }
+        confirmLabel={t(
+          "action",
+          pendingSchedulable?.action === "uncordon" ? "uncordon" : "cordon"
+        )}
+        confirmVariant="destructive"
+        onConfirm={() => {
+          if (!pendingSchedulable) return;
+          const { action, node } = pendingSchedulable;
+          setPendingSchedulable(null);
+          if (action === "cordon") cordonMutation.mutate(node);
+          else uncordonMutation.mutate(node);
+        }}
       />
     </>
   );

--- a/src/components/resources/PeekPanel.test.tsx
+++ b/src/components/resources/PeekPanel.test.tsx
@@ -1,6 +1,12 @@
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -83,6 +89,8 @@ status:
 import { commands } from "@/lib/commands";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { usePeek, type PeekTarget } from "@/hooks/usePeek";
+import { useClusterStore } from "@/stores/clusterStore";
+import { useClusterIdentityStore } from "@/stores/clusterIdentityStore";
 import {
   PEEK_WIDTH_DEFAULT,
   useDisplaySettingsStore,
@@ -1394,5 +1402,54 @@ describe("PeekPanel traffic chain", () => {
     wrap(POD_PEEK);
     await screen.findByText("CrashLoopBackOff");
     expect(screen.queryByText("Traffic path")).toBeNull();
+  });
+});
+
+describe("restarting a managed workload from the peek on critical infrastructure", () => {
+  const PROD = "prod-eu-1";
+
+  beforeEach(() => {
+    mockCluster();
+    useClusterIdentityStore.setState({ marks: {} });
+    useClusterStore.setState({ currentContext: PROD, isConnected: true });
+    useClusterIdentityStore.getState().setCritical(PROD, true);
+  });
+
+  afterEach(() => {
+    useClusterIdentityStore.setState({ marks: {} });
+    useClusterStore.setState({ currentContext: null, isConnected: false });
+  });
+
+  /**
+   * A managed restart is reversible and fires on one click everywhere else,
+   * which is exactly why it was the last change on the marked cluster that
+   * still had no gate. Here it takes the cluster's name like the rest.
+   */
+  it("holds the restart until the cluster's name is typed", async () => {
+    vi.mocked(commands.getPod).mockResolvedValue(RUNNING_POD);
+    wrap(RUNNING_PEEK);
+    await screen.findByText("Running");
+
+    await openMore();
+    await userEvent.click(screen.getByRole("menuitem", { name: /Restart/ }));
+
+    // Not fired on the click: the peek's one-click restart is what the gate closes.
+    expect(commands.restartPod).not.toHaveBeenCalled();
+
+    const confirm = await screen.findByRole("alertdialog");
+    expect(within(confirm).getByRole("alert")).toHaveTextContent(PROD);
+    const button = within(confirm).getByRole("button", { name: /^Restart$/ });
+    expect(button).toBeDisabled();
+
+    await userEvent.type(screen.getByPlaceholderText(PROD), PROD);
+    expect(button).toBeEnabled();
+
+    await userEvent.click(button);
+    await waitFor(() =>
+      expect(commands.restartPod).toHaveBeenCalledWith(
+        "log-demo-1",
+        "k8s-gui-test"
+      )
+    );
   });
 });

--- a/src/components/resources/ScaleDialog.test.tsx
+++ b/src/components/resources/ScaleDialog.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ScaleDialog } from "./ScaleDialog";
+import { useClusterIdentityStore } from "@/stores/clusterIdentityStore";
+import { useClusterStore } from "@/stores/clusterStore";
+
+const PROD = "prod-eu-1";
+
+const scaleButton = () => screen.getByRole("button", { name: /scale/i });
+
+const scale = (over: Partial<Parameters<typeof ScaleDialog>[0]> = {}) => (
+  <ScaleDialog
+    open
+    kind="Deployment"
+    current={3}
+    busy={false}
+    onOpenChange={() => {}}
+    onSubmit={() => {}}
+    {...over}
+  />
+);
+
+beforeEach(() => {
+  useClusterIdentityStore.setState({ marks: {} });
+  useClusterStore.setState({ currentContext: PROD, isConnected: true });
+});
+
+afterEach(() => {
+  useClusterIdentityStore.setState({ marks: {} });
+  useClusterStore.setState({ currentContext: null, isConnected: false });
+});
+
+describe("scaling on critical infrastructure", () => {
+  /**
+   * Scaling a workload to zero is the change the dialog's red band warns
+   * about; without the gate it was still one click, which is exactly what the
+   * mark on the cluster exists to stop.
+   */
+  it("holds the scale button until the cluster's name is typed", async () => {
+    useClusterIdentityStore.getState().setCritical(PROD, true);
+    const onSubmit = vi.fn();
+    render(scale({ onSubmit }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(PROD);
+    expect(scaleButton()).toBeDisabled();
+
+    await userEvent.type(screen.getByPlaceholderText(PROD), PROD);
+    expect(scaleButton()).toBeEnabled();
+
+    await userEvent.click(scaleButton());
+    expect(onSubmit).toHaveBeenCalledWith(3);
+  });
+
+  /**
+   * A production-looking name is a guess, never the answer: a guard armed by
+   * the name alone would sit on `prod-catalog-dev` until someone found the
+   * setting that turns it off.
+   */
+  it("asks nothing of a cluster nobody marked", () => {
+    render(scale());
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(scaleButton()).toBeEnabled();
+  });
+});

--- a/src/components/resources/ScaleDialog.test.tsx
+++ b/src/components/resources/ScaleDialog.test.tsx
@@ -54,6 +54,27 @@ describe("scaling on critical infrastructure", () => {
   });
 
   /**
+   * The Scale button is a plain button, not a Radix close, so the success path
+   * closes the dialog by the parent flipping `open` — which never fires
+   * onOpenChange. If the gate is reset only there, the typed name survives and
+   * the next scale on the same still-mounted surface fires on a stale match.
+   */
+  it("forgets the typed name once closed, so the next scale re-asks", async () => {
+    useClusterIdentityStore.getState().setCritical(PROD, true);
+    const { rerender } = render(scale());
+
+    await userEvent.type(screen.getByPlaceholderText(PROD), PROD);
+    expect(scaleButton()).toBeEnabled();
+
+    // The success path: the parent closes the dialog without onOpenChange.
+    rerender(scale({ open: false }));
+    rerender(scale({ open: true }));
+
+    expect(screen.getByPlaceholderText(PROD)).toHaveValue("");
+    expect(scaleButton()).toBeDisabled();
+  });
+
+  /**
    * A production-looking name is a guess, never the answer: a guard armed by
    * the name alone would sit on `prod-catalog-dev` until someone found the
    * setting that turns it off.

--- a/src/components/resources/ScaleDialog.tsx
+++ b/src/components/resources/ScaleDialog.tsx
@@ -1,7 +1,6 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
-import { CriticalNotice } from "@/components/ui/critical-notice";
 import {
   Dialog,
   DialogContent,
@@ -13,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { ActionWarning } from "@/lib/governance";
 import { ActionWarnings } from "./action-warnings";
-import { useCritical } from "@/hooks/useCritical";
+import { useCriticalGate } from "@/hooks/useCriticalGate";
 import { useT } from "@/i18n/useT";
 
 export interface ScaleDialogProps {
@@ -43,15 +42,22 @@ export function ScaleDialog({
   warnings = [],
 }: ScaleDialogProps) {
   const t = useT();
-  const critical = useCritical();
+  // Scaling a workload to zero on a cluster the person marked critical is a
+  // change to that cluster, so the same typed-name gate the confirm dialogs
+  // use guards the Scale button here too — notice and field cannot part ways.
+  const gate = useCriticalGate();
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) gate.reset();
+    onOpenChange(next);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{t("action", "scaleKind", { kind })}</DialogTitle>
-          {critical.critical && critical.context && (
-            <CriticalNotice context={critical.context} />
-          )}
+          {gate.notice}
         </DialogHeader>
         {/* Radix drops the content when closed, so the field seeds itself from
             the live count on every opening without an effect to sync it. */}
@@ -59,12 +65,14 @@ export function ScaleDialog({
         <ScaleForm
           current={current}
           busy={busy}
+          blocked={gate.blocked}
+          gateInput={gate.input}
           confirmLabel={
             warnings.length > 0
               ? t("action", "scaleAnyway")
               : t("action", "scale")
           }
-          onCancel={() => onOpenChange(false)}
+          onCancel={() => handleOpenChange(false)}
           onSubmit={onSubmit}
         />
       </DialogContent>
@@ -75,12 +83,18 @@ export function ScaleDialog({
 function ScaleForm({
   current,
   busy,
+  blocked,
+  gateInput,
   confirmLabel,
   onCancel,
   onSubmit,
 }: {
   current: number;
   busy: boolean;
+  /** True while the critical-cluster name has not been typed back. */
+  blocked: boolean;
+  /** The typed-name field, rendered next to the button it guards. */
+  gateInput: ReactNode;
   confirmLabel: string;
   onCancel: () => void;
   onSubmit: (replicas: number) => void;
@@ -102,11 +116,12 @@ function ScaleForm({
           }
         />
       </div>
+      {gateInput}
       <DialogFooter>
         <Button variant="outline" onClick={onCancel}>
           {t("action", "cancel")}
         </Button>
-        <Button onClick={() => onSubmit(replicas)} disabled={busy}>
+        <Button onClick={() => onSubmit(replicas)} disabled={busy || blocked}>
           {confirmLabel}
         </Button>
       </DialogFooter>

--- a/src/components/resources/ScaleDialog.tsx
+++ b/src/components/resources/ScaleDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -47,13 +47,17 @@ export function ScaleDialog({
   // use guards the Scale button here too — notice and field cannot part ways.
   const gate = useCriticalGate();
 
-  const handleOpenChange = (next: boolean) => {
-    if (!next) gate.reset();
-    onOpenChange(next);
-  };
+  // The Scale button is a plain button, not a Radix close, so the success path
+  // closes this by the parent flipping `open` — which never fires
+  // onOpenChange. Reset on every close regardless of who closed it, or the
+  // typed name survives a scale and the next one fires on a stale match.
+  const gateReset = gate.reset;
+  useEffect(() => {
+    if (!open) gateReset();
+  }, [open, gateReset]);
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{t("action", "scaleKind", { kind })}</DialogTitle>
@@ -72,7 +76,7 @@ export function ScaleDialog({
               ? t("action", "scaleAnyway")
               : t("action", "scale")
           }
-          onCancel={() => handleOpenChange(false)}
+          onCancel={() => onOpenChange(false)}
           onSubmit={onSubmit}
         />
       </DialogContent>

--- a/src/components/resources/ScaleDialog.tsx
+++ b/src/components/resources/ScaleDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { CriticalNotice } from "@/components/ui/critical-notice";
 import {
   Dialog,
   DialogContent,
@@ -12,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { ActionWarning } from "@/lib/governance";
 import { ActionWarnings } from "./action-warnings";
+import { useCritical } from "@/hooks/useCritical";
 import { useT } from "@/i18n/useT";
 
 export interface ScaleDialogProps {
@@ -41,11 +43,15 @@ export function ScaleDialog({
   warnings = [],
 }: ScaleDialogProps) {
   const t = useT();
+  const critical = useCritical();
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{t("action", "scaleKind", { kind })}</DialogTitle>
+          {critical.critical && critical.context && (
+            <CriticalNotice context={critical.context} />
+          )}
         </DialogHeader>
         {/* Radix drops the content when closed, so the field seeds itself from
             the live count on every opening without an effect to sync it. */}

--- a/src/components/resources/data-rows.test.tsx
+++ b/src/components/resources/data-rows.test.tsx
@@ -1,8 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { DataSection } from "./data-rows";
+import { useClusterIdentityStore } from "@/stores/clusterIdentityStore";
+import { useClusterStore } from "@/stores/clusterStore";
 
 const writeText = vi.fn().mockResolvedValue(undefined);
 Object.defineProperty(navigator, "clipboard", {
@@ -236,5 +238,49 @@ describe("editing one key", () => {
       />
     );
     expect(screen.queryByRole("button", { name: /Value of/ })).toBeNull();
+  });
+});
+
+describe("editing a key on critical infrastructure", () => {
+  const PROD = "prod-eu-1";
+
+  beforeEach(() => {
+    useClusterIdentityStore.setState({ marks: {} });
+    useClusterStore.setState({ currentContext: PROD, isConnected: true });
+    useClusterIdentityStore.getState().setCritical(PROD, true);
+  });
+
+  afterEach(() => {
+    useClusterIdentityStore.setState({ marks: {} });
+    useClusterStore.setState({ currentContext: null, isConnected: false });
+  });
+
+  /**
+   * Editing a key writes live config the cluster's workloads read; on the
+   * marked cluster the Save waits on the cluster's own name, the same gate the
+   * destructive dialogs use.
+   */
+  it("holds Save until the cluster's name is typed", async () => {
+    const onEditKey = vi.fn().mockResolvedValue(undefined);
+    render(
+      <DataSection data={{ "log.level": "debug" }} onEditKey={onEditKey} />
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Value of log.level" })
+    );
+    const box = screen.getByRole("textbox", { name: "Value of log.level" });
+    await userEvent.clear(box);
+    await userEvent.type(box, "info");
+
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(screen.getByRole("alert")).toHaveTextContent(PROD);
+    expect(save).toBeDisabled();
+
+    await userEvent.type(screen.getByPlaceholderText(PROD), PROD);
+    expect(save).toBeEnabled();
+
+    await userEvent.click(save);
+    expect(onEditKey).toHaveBeenCalledWith("log.level", "info");
   });
 });

--- a/src/components/resources/data-rows.tsx
+++ b/src/components/resources/data-rows.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Copy, Eye, EyeOff, Pencil } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -9,6 +9,7 @@ import { formatBytes } from "@/lib/k8s-quantity";
 import { cn } from "@/lib/utils";
 import { DetailAction } from "./detail-blocks";
 import type { BinaryValue } from "@/generated/types";
+import { useCriticalGate } from "@/hooks/useCriticalGate";
 import { useT } from "@/i18n/useT";
 import { T } from "@/i18n/T";
 
@@ -79,6 +80,14 @@ export function DataSection({
   const [editing, setEditing] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
+  // Editing a key writes live config the cluster's workloads read, so on a
+  // cluster marked critical the Save waits on the cluster's own name. Cleared
+  // whenever the edited key changes, so a match never carries to the next key.
+  const gate = useCriticalGate();
+  const gateReset = gate.reset;
+  useEffect(() => {
+    gateReset();
+  }, [editing, gateReset]);
   const copyToClipboard = useCopyToClipboard();
 
   const entries = useMemo(() => {
@@ -272,17 +281,19 @@ export function DataSection({
                 // the whole request: a JSON blob inside a YAML string is an
                 // indentation puzzle, and the puzzle is not the point.
                 <div className="mt-1 border-l border-hair pl-3">
+                  {gate.notice}
                   <Textarea
                     value={draft}
                     onChange={(event) => setDraft(event.target.value)}
                     rows={Math.min(20, draft.split("\n").length + 1)}
-                    className="font-mono text-xs"
+                    className="mt-2 font-mono text-xs"
                     aria-label={t("action", "editKeyLabel", { key })}
                   />
+                  {gate.input}
                   <div className="mt-2 flex items-center gap-2">
                     <Button
                       size="sm"
-                      disabled={saving || draft === value}
+                      disabled={saving || draft === value || gate.blocked}
                       onClick={async () => {
                         setSaving(true);
                         try {

--- a/src/components/resources/delivery-intercept.test.tsx
+++ b/src/components/resources/delivery-intercept.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RefreshCw } from "lucide-react";
+
+import { InterceptedAction } from "./delivery-intercept";
+import { useClusterIdentityStore } from "@/stores/clusterIdentityStore";
+import { useClusterStore } from "@/stores/clusterStore";
+
+const PROD = "prod-eu-1";
+
+const trigger = () => screen.getByRole("button", { name: /restart/i });
+
+const action = (onClick: () => void) => (
+  <InterceptedAction
+    intercept={null}
+    icon={RefreshCw}
+    label="Restart"
+    onClick={onClick}
+  />
+);
+
+afterEach(() => {
+  useClusterIdentityStore.setState({ marks: {} });
+  useClusterStore.setState({ currentContext: null, isConnected: false });
+});
+
+describe("an intercepted action with nothing to intercept", () => {
+  /**
+   * On an ordinary cluster with no delivery controller the control is the
+   * plain one it always was — a single click, no dialog interposed.
+   */
+  it("fires straight through on an ordinary cluster", async () => {
+    useClusterStore.setState({ currentContext: "dev", isConnected: true });
+    const onClick = vi.fn();
+    render(action(onClick));
+
+    await userEvent.click(trigger());
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});
+
+describe("an intercepted action on critical infrastructure", () => {
+  beforeEach(() => {
+    useClusterStore.setState({ currentContext: PROD, isConnected: true });
+    useClusterIdentityStore.getState().setCritical(PROD, true);
+  });
+
+  /**
+   * A restart with no delivery controller to warn about was the last change
+   * that still fired on one click; the gate has to reach it too, or "before
+   * any change" has a hole exactly where the reader would not look for one.
+   */
+  it("interposes the gate even with nothing to warn about", async () => {
+    const onClick = vi.fn();
+    render(action(onClick));
+
+    await userEvent.click(trigger());
+    expect(onClick).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByRole("alert")).toHaveTextContent(PROD);
+    const confirm = within(dialog).getByRole("button", { name: /restart/i });
+    expect(confirm).toBeDisabled();
+
+    await userEvent.type(screen.getByPlaceholderText(PROD), PROD);
+    expect(confirm).toBeEnabled();
+
+    await userEvent.click(confirm);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/resources/delivery-intercept.tsx
+++ b/src/components/resources/delivery-intercept.tsx
@@ -26,6 +26,8 @@ import {
 } from "@/components/ui/dialog";
 import type { DeliveryIntercept } from "@/lib/delivery";
 import { deliveryWarning } from "@/lib/governance";
+import { useCritical } from "@/hooks/useCritical";
+import { useCriticalGate } from "@/hooks/useCriticalGate";
 import { ActionWarnings } from "./action-warnings";
 import { DetailAction, type DetailActionProps } from "./detail-blocks";
 import { useT } from "@/i18n/useT";
@@ -34,9 +36,11 @@ import { useT } from "@/i18n/useT";
  * A {@link DetailAction} that asks first, and only when there is something to
  * ask about.
  *
- * With `intercept` null this is the control exactly as it was — same click,
- * same handler, no dialog — which is what every object on a cluster with no
- * delivery controller gets.
+ * With `intercept` null this was the control exactly as it was — same click,
+ * same handler, no dialog. It still is on an ordinary cluster; on one the
+ * person marked critical it grows the typed-name gate every other destructive
+ * control here has, because "before any change" has to mean this control too —
+ * a restart that fired on one click was the last way past the gate.
  */
 export function InterceptedAction({
   intercept,
@@ -45,16 +49,22 @@ export function InterceptedAction({
   ...props
 }: DetailActionProps & { intercept: DeliveryIntercept | null }) {
   const [open, setOpen] = useState(false);
+  const critical = useCritical();
+  // A dialog is owed when a delivery controller would undo this, or when the
+  // cluster is critical and so the gate must be typed first.
+  const guarded =
+    intercept !== null || (critical.critical && !!critical.context);
 
   return (
     <>
       <DetailAction
         {...props}
         label={label}
-        onClick={() => (intercept ? setOpen(true) : onClick())}
+        onClick={() => (guarded ? setOpen(true) : onClick())}
       />
       <DeliveryInterceptDialog
         intercept={intercept}
+        label={label}
         open={open}
         onOpenChange={setOpen}
         onConfirm={onClick}
@@ -65,36 +75,52 @@ export function InterceptedAction({
 
 export function DeliveryInterceptDialog({
   intercept,
+  label,
   open,
   onOpenChange,
   onConfirm,
 }: {
   intercept: DeliveryIntercept | null;
+  /** The action verb, used to title the dialog when there is no intercept of
+   *  its own to name it — the critical-cluster gate case. */
+  label?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
 }) {
   const t = useT();
-  if (!intercept) return null;
+  const gate = useCriticalGate();
+  // Nothing to ask when neither a delivery controller owns this nor the cluster
+  // is critical — the caller fires straight through in that case.
+  if (!intercept && !gate.active) return null;
+
+  const close = (next: boolean) => {
+    if (!next) gate.reset();
+    onOpenChange(next);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={close}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{intercept.title}</DialogTitle>
+          <DialogTitle>{intercept?.title ?? label}</DialogTitle>
+          {gate.notice}
         </DialogHeader>
-        <DeliveryInterceptBody intercept={intercept} />
+        {intercept && <DeliveryInterceptBody intercept={intercept} />}
+        {gate.input}
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button variant="outline" onClick={() => close(false)}>
             {t("action", "cancel")}
           </Button>
           <Button
             variant="destructive"
+            disabled={gate.blocked}
             onClick={() => {
-              onOpenChange(false);
+              close(false);
               onConfirm();
             }}
           >
-            {intercept.confirmLabel}
+            {intercept?.confirmLabel ?? label}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/resources/drain-dialog.test.tsx
+++ b/src/components/resources/drain-dialog.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -7,6 +7,8 @@ import { MemoryRouter } from "react-router-dom";
 
 import { DrainDialog } from "./drain-dialog";
 import type { DrainReport, DrainState, RefusedPod } from "@/hooks/useNodeDrain";
+import { useClusterIdentityStore } from "@/stores/clusterIdentityStore";
+import { useClusterStore } from "@/stores/clusterStore";
 
 const wrap = (ui: ReactNode) =>
   render(
@@ -352,5 +354,44 @@ describe("reading how a drain ended", () => {
     expect(
       screen.queryByRole("button", { name: /stop draining/i })
     ).not.toBeInTheDocument();
+  });
+});
+
+const PROD = "prod-eu-1";
+
+describe("draining a node on critical infrastructure", () => {
+  beforeEach(() => {
+    useClusterIdentityStore.setState({ marks: {} });
+    useClusterStore.setState({ currentContext: PROD, isConnected: true });
+    useClusterIdentityStore.getState().setCritical(PROD, true);
+  });
+
+  afterEach(() => {
+    useClusterIdentityStore.setState({ marks: {} });
+    useClusterStore.setState({ currentContext: null, isConnected: false });
+  });
+
+  /**
+   * A drain ends pods the cluster will not bring back, so on the marked
+   * cluster it takes the same typed-name gate the confirmations do; without
+   * it the drain was a single click on the one screen that reads like a
+   * report rather than a decision.
+   */
+  it("holds the drain until the cluster's name is typed", async () => {
+    const onConfirm = vi.fn();
+    wrap(dialog({ phase: "idle" }, { onConfirm }));
+
+    const drain = screen.getByRole("button", { name: /drain/i });
+    expect(screen.getByRole("alert")).toHaveTextContent(PROD);
+    expect(drain).toBeDisabled();
+
+    await userEvent.type(screen.getByPlaceholderText(PROD), PROD);
+    expect(drain).toBeEnabled();
+
+    await userEvent.click(drain);
+    expect(onConfirm).toHaveBeenCalledWith("node-7", {
+      evictUnmanagedPods: false,
+      evictPodsWithEmptydir: false,
+    });
   });
 });

--- a/src/components/resources/drain-dialog.tsx
+++ b/src/components/resources/drain-dialog.tsx
@@ -38,6 +38,7 @@ import type {
   RefusedPod,
 } from "@/hooks/useNodeDrain";
 import { useConnections } from "@/hooks/useConnections";
+import { useCriticalGate } from "@/hooks/useCriticalGate";
 import { budgetRule, drainBlockers } from "@/lib/governance";
 import { ResourceType } from "@/lib/resource-registry";
 import type { en } from "@/i18n/catalogue";
@@ -145,6 +146,10 @@ function DrainConfirm({
     evictUnmanagedPods: false,
     evictPodsWithEmptydir: false,
   });
+  // Draining a node on a cluster the person marked critical is a change to
+  // that cluster, so the drain waits on the cluster's own name — the same gate
+  // Scale, Apply and every confirmation use, notice and field inseparable.
+  const gate = useCriticalGate();
 
   // Asked for only while the dialog is open: a node's neighbourhood is every
   // pod on it in every namespace, which is not a read to make from a list row.
@@ -158,6 +163,7 @@ function DrainConfirm({
 
   return (
     <>
+      {gate.notice}
       <div className="flex flex-col gap-1.5">
         <p className="text-xs text-fg-mut">{t("empty", "drainExplained")}</p>
         {query.isPending && node && (
@@ -219,12 +225,14 @@ function DrainConfirm({
           </Link>
         )}
       </div>
+      {gate.input}
       <DialogFooter>
         <Button variant="outline" onClick={onCancel}>
           {t("action", "cancel")}
         </Button>
         <Button
           variant="destructive"
+          disabled={gate.blocked}
           onClick={() => node && onConfirm(node, choices)}
         >
           {blockers.length > 0

--- a/src/components/resources/useObjectActions.tsx
+++ b/src/components/resources/useObjectActions.tsx
@@ -25,10 +25,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { DebugNodeDialog, DebugPodDialog } from "@/components/debug";
 import { PortForwardDialog } from "@/components/port-forward/PortForwardDialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { DangerousConfirmDialog } from "@/components/ui/dangerous-confirm-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { useClusterInfo } from "@/hooks";
 import { useConnections } from "@/hooks/useConnections";
+import { useCritical } from "@/hooks/useCritical";
 import { useDeliveryIntercept } from "@/hooks/useDelivery";
 import { commands } from "@/lib/commands";
 import { lifetimeContainers, podPorts } from "@/lib/container-sequence";
@@ -110,6 +112,8 @@ export function useObjectActions({
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const { data: clusterInfo } = useClusterInfo();
+  const critical = useCritical();
+  const criticalActive = critical.critical && !!critical.context;
 
   const kind = toKind(rawKind) ?? rawKind;
   const pod = kind === "Pod" ? (detail as PodInfo | undefined) : undefined;
@@ -137,9 +141,9 @@ export function useObjectActions({
   const [dialog, setDialog] = useState<
     "debug" | "portForward" | "scale" | null
   >(null);
-  const [confirming, setConfirming] = useState<"delete" | "restart" | null>(
-    null
-  );
+  const [confirming, setConfirming] = useState<
+    "delete" | "restart" | "managedRestart" | null
+  >(null);
 
   // Asked for only once the dialog is open — a neighbourhood read on every row
   // somebody arrows past would be six lists per keystroke, and the query key
@@ -264,8 +268,13 @@ export function useObjectActions({
       case "restart":
         // A bare pod has no controller to put it back, so its "restart" is a
         // one-way door and gets the same gate as a delete.
-        return kind === "Pod" && !pod?.ownerReferences?.length
-          ? setConfirming("restart")
+        if (kind === "Pod" && !pod?.ownerReferences?.length)
+          return setConfirming("restart");
+        // A managed restart is reversible and normally fires straight through,
+        // but on a critical cluster it is still a change, so it takes the gate
+        // — the peek's one-click restart was the last way past it.
+        return criticalActive
+          ? setConfirming("managedRestart")
           : restart.mutate();
       case "delete":
         return setConfirming("delete");
@@ -348,6 +357,23 @@ export function useObjectActions({
         confirmationText={name}
         confirmLabel={t("action", "restart")}
         isLoading={restart.isPending}
+        onConfirm={() => restart.mutate()}
+      />
+
+      {/* A reversible restart has no object-name gate of its own, so this only
+          ever opens on a critical cluster, where the ConfirmDialog grows the
+          typed-name gate itself. Warned like the others where a controller
+          would also undo it. */}
+      <ConfirmDialog
+        open={confirming === "managedRestart"}
+        onOpenChange={(open) => setConfirming(open ? "managedRestart" : null)}
+        title={t("action", "restartSubjectTitle", {
+          subject: `${kind.toLowerCase()} ${namespace ? `${namespace}/${name}` : name}`,
+        })}
+        description={warned("", intercept("Restart")).trim() || undefined}
+        confirmLabel={t("action", "restart")}
+        confirmVariant="destructive"
+        confirmDisabled={restart.isPending}
         onConfirm={() => restart.mutate()}
       />
     </>

--- a/src/components/settings/clusters/ContextRow.test.tsx
+++ b/src/components/settings/clusters/ContextRow.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ContextRow } from "./ContextRow";
+import type { ContextInfo } from "@/generated/types";
+import { useClusterIdentityStore } from "@/stores/clusterIdentityStore";
+
+const PROD = "prod-eu-1";
+
+const ctx = (name: string): ContextInfo => ({
+  name,
+  cluster: name,
+  user: "u",
+  namespace: null,
+  is_current: false,
+  server: null,
+  exec_command: null,
+  auth: { kind: "token", source: null },
+});
+
+const row = (name: string) =>
+  render(
+    <ContextRow
+      context={ctx(name)}
+      binding={undefined}
+      binaries={new Map()}
+      connected={false}
+      onBind={() => {}}
+    />
+  );
+
+const criticalBox = () => screen.getByRole("checkbox");
+
+beforeEach(() => {
+  useClusterIdentityStore.setState({ marks: {} });
+});
+
+afterEach(() => {
+  useClusterIdentityStore.setState({ marks: {} });
+});
+
+describe("the critical checkbox on a context row", () => {
+  /**
+   * Unticking has to return the cluster to undecided, not write an explicit
+   * `false`: that residue reads as "the person said no", which then suppresses
+   * the guessed hint on a `prod`-looking name they only ever glanced at. The
+   * mark that no longer says anything is the mark that is gone.
+   */
+  it("clears the mark on untick rather than leaving a false behind", async () => {
+    row(PROD);
+
+    await userEvent.click(criticalBox());
+    expect(useClusterIdentityStore.getState().marks[PROD]?.critical).toBe(true);
+
+    await userEvent.click(criticalBox());
+    expect(useClusterIdentityStore.getState().marks[PROD]).toBeUndefined();
+  });
+});

--- a/src/components/settings/clusters/ContextRow.tsx
+++ b/src/components/settings/clusters/ContextRow.tsx
@@ -158,7 +158,10 @@ export function ContextRow({
           <Checkbox
             checked={criticality.critical}
             onCheckedChange={(checked) =>
-              setCritical(context.name, checked === true)
+              // Unticking clears the mark back to undecided rather than storing
+              // an explicit `false` — that residue would suppress the guessed
+              // hint on a prod-looking name the reader never meant to overrule.
+              setCritical(context.name, checked === true ? true : null)
             }
             className="mt-px"
           />

--- a/src/components/settings/clusters/ContextRow.tsx
+++ b/src/components/settings/clusters/ContextRow.tsx
@@ -1,7 +1,12 @@
 import type { ContextBindingInfo, ContextInfo } from "@/generated/types";
+import { Checkbox } from "@/components/ui/checkbox";
 import { clusterColor, clusterNameParts } from "@/lib/cluster-identity";
+import { criticalityOf } from "@/lib/critical";
 import { cn } from "@/lib/utils";
-import { useClusterMark } from "@/stores/clusterIdentityStore";
+import {
+  useClusterIdentityStore,
+  useClusterMark,
+} from "@/stores/clusterIdentityStore";
 import { useSettingSearchMatch } from "../settings-search";
 import { VENDOR_LABEL, binaryLabel, readContext } from "./context-reading";
 import { useT } from "@/i18n/useT";
@@ -52,6 +57,8 @@ export function ContextRow({
   const reading = readContext(context, { binaries, binding, connected }, t);
   const visible = useSettingSearchMatch(reading.searchText);
   const mark = useClusterMark(context.name);
+  const setCritical = useClusterIdentityStore((s) => s.setCritical);
+  const criticality = criticalityOf(context.name, mark);
   const colour = clusterColor(context.name, mark.hue);
   const { prefix, label } = clusterNameParts(context.name);
 
@@ -147,6 +154,26 @@ export function ContextRow({
             </button>
           </div>
         )}
+        <label className="mt-1.5 flex cursor-pointer items-start gap-2 text-[11px]">
+          <Checkbox
+            checked={criticality.critical}
+            onCheckedChange={(checked) =>
+              setCritical(context.name, checked === true)
+            }
+            className="mt-px"
+          />
+          <span className="min-w-0">
+            <span className={criticality.critical ? "text-err" : "text-fg-mut"}>
+              {t("settings", "criticalLabel")}
+            </span>
+            {criticality.guessed && (
+              <span className="ml-1.5 text-warn">
+                {t("settings", "criticalGuessed")}
+              </span>
+            )}
+          </span>
+        </label>
+
         {unbound === "aws" && (
           <div className="mt-1 text-[11px] text-fg-fnt">
             {t("settings", "awsNoProfilesPrefix")}{" "}

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { ReactNode } from "react";
 import {
   AlertDialog,
@@ -10,6 +11,10 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { buttonVariants } from "@/components/ui/button";
+import { CriticalNotice } from "@/components/ui/critical-notice";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useCritical } from "@/hooks/useCritical";
 import { useT } from "@/i18n/useT";
 
 interface ConfirmDialogProps {
@@ -45,16 +50,47 @@ export function ConfirmDialog({
   onConfirm,
 }: ConfirmDialogProps) {
   const t = useT();
+  const critical = useCritical();
+  const [typed, setTyped] = useState("");
+  // On critical infrastructure the reader also types the cluster's name:
+  // what this guards against is not the object but the window it is in.
+  const gate = critical.critical ? critical.context : null;
+  const gated = gate !== null && typed !== gate;
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setTyped("");
+    onOpenChange(next);
+  };
+
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
+          {gate && <CriticalNotice context={gate} />}
           {description && (
             <AlertDialogDescription>{description}</AlertDialogDescription>
           )}
         </AlertDialogHeader>
         {children}
+        {gate && (
+          <div className="space-y-2">
+            <Label htmlFor="critical-context-input" className="text-sm">
+              {t("action", "typeWord")}{" "}
+              <code className="rounded bg-err/16 px-1.5 py-0.5 font-mono text-xs text-err">
+                {gate}
+              </code>{" "}
+              {t("action", "toConfirm")}
+            </Label>
+            <Input
+              id="critical-context-input"
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              placeholder={gate}
+              autoComplete="off"
+            />
+          </div>
+        )}
         <AlertDialogFooter>
           <AlertDialogCancel>
             {cancelLabel ?? t("action", "cancel")}
@@ -62,7 +98,7 @@ export function ConfirmDialog({
           <AlertDialogAction
             className={buttonVariants({ variant: confirmVariant })}
             onClick={onConfirm}
-            disabled={confirmDisabled}
+            disabled={confirmDisabled || gated}
           >
             {confirmLabel ?? t("action", "confirm")}
           </AlertDialogAction>

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import type { ReactNode } from "react";
 import {
   AlertDialog,
@@ -11,10 +10,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { buttonVariants } from "@/components/ui/button";
-import { CriticalNotice } from "@/components/ui/critical-notice";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { useCritical } from "@/hooks/useCritical";
+import { useCriticalGate } from "@/hooks/useCriticalGate";
 import { useT } from "@/i18n/useT";
 
 interface ConfirmDialogProps {
@@ -50,15 +46,12 @@ export function ConfirmDialog({
   onConfirm,
 }: ConfirmDialogProps) {
   const t = useT();
-  const critical = useCritical();
-  const [typed, setTyped] = useState("");
   // On critical infrastructure the reader also types the cluster's name:
   // what this guards against is not the object but the window it is in.
-  const gate = critical.critical ? critical.context : null;
-  const gated = gate !== null && typed !== gate;
+  const gate = useCriticalGate();
 
   const handleOpenChange = (next: boolean) => {
-    if (!next) setTyped("");
+    if (!next) gate.reset();
     onOpenChange(next);
   };
 
@@ -67,30 +60,13 @@ export function ConfirmDialog({
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
-          {gate && <CriticalNotice context={gate} />}
+          {gate.notice}
           {description && (
             <AlertDialogDescription>{description}</AlertDialogDescription>
           )}
         </AlertDialogHeader>
         {children}
-        {gate && (
-          <div className="space-y-2">
-            <Label htmlFor="critical-context-input" className="text-sm">
-              {t("action", "typeWord")}{" "}
-              <code className="rounded bg-err/16 px-1.5 py-0.5 font-mono text-xs text-err">
-                {gate}
-              </code>{" "}
-              {t("action", "toConfirm")}
-            </Label>
-            <Input
-              id="critical-context-input"
-              value={typed}
-              onChange={(e) => setTyped(e.target.value)}
-              placeholder={gate}
-              autoComplete="off"
-            />
-          </div>
-        )}
+        {gate.input}
         <AlertDialogFooter>
           <AlertDialogCancel>
             {cancelLabel ?? t("action", "cancel")}
@@ -98,7 +74,7 @@ export function ConfirmDialog({
           <AlertDialogAction
             className={buttonVariants({ variant: confirmVariant })}
             onClick={onConfirm}
-            disabled={confirmDisabled || gated}
+            disabled={confirmDisabled || gate.blocked}
           >
             {confirmLabel ?? t("action", "confirm")}
           </AlertDialogAction>

--- a/src/components/ui/critical-dialogs.test.tsx
+++ b/src/components/ui/critical-dialogs.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { DangerousConfirmDialog } from "@/components/ui/dangerous-confirm-dialog";
+import { useClusterIdentityStore } from "@/stores/clusterIdentityStore";
+import { useClusterStore } from "@/stores/clusterStore";
+
+const PROD = "prod-eu-1";
+
+beforeEach(() => {
+  useClusterIdentityStore.setState({ marks: {} });
+  useClusterStore.setState({ currentContext: PROD, isConnected: true });
+});
+
+const confirmButton = () => screen.getByRole("button", { name: "Delete" });
+
+describe("a plain confirmation on critical infrastructure", () => {
+  /** Without the gate a deletion on the marked cluster is one click, exactly what the mark exists to stop. */
+  it("holds the button until the cluster's name is typed", () => {
+    useClusterIdentityStore.getState().setCritical(PROD, true);
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        title="Delete payments?"
+        confirmLabel="Delete"
+        onOpenChange={() => {}}
+        onConfirm={onConfirm}
+      />
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(PROD);
+    expect(confirmButton()).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText(PROD), {
+      target: { value: "prod-eu-2" },
+    });
+    expect(confirmButton()).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText(PROD), {
+      target: { value: PROD },
+    });
+    expect(confirmButton()).toBeEnabled();
+    fireEvent.click(confirmButton());
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  /** A guard armed by the name alone would fire on `product-catalog-dev` until someone found the setting. */
+  it("asks nothing of a cluster that merely looks like production", () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Delete payments?"
+        confirmLabel="Delete"
+        onOpenChange={() => {}}
+        onConfirm={() => {}}
+      />
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(confirmButton()).toBeEnabled();
+  });
+});
+
+describe("a typed confirmation on critical infrastructure", () => {
+  /** Typing the pod's name proves nothing about which cluster the pod is on. */
+  it("asks for the cluster's name instead of the object's", () => {
+    useClusterIdentityStore.getState().setCritical(PROD, true);
+    const onConfirm = vi.fn();
+    render(
+      <DangerousConfirmDialog
+        open
+        title="Delete payments?"
+        confirmationText="payments"
+        confirmLabel="Delete"
+        onOpenChange={() => {}}
+        onConfirm={onConfirm}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(PROD);
+    fireEvent.change(input, { target: { value: "payments" } });
+    expect(confirmButton()).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: PROD } });
+    expect(confirmButton()).toBeEnabled();
+  });
+
+  it("asks for the object's name everywhere else", () => {
+    render(
+      <DangerousConfirmDialog
+        open
+        title="Delete payments?"
+        confirmationText="payments"
+        confirmLabel="Delete"
+        onOpenChange={() => {}}
+        onConfirm={() => {}}
+      />
+    );
+    fireEvent.change(screen.getByPlaceholderText("payments"), {
+      target: { value: "payments" },
+    });
+    expect(confirmButton()).toBeEnabled();
+  });
+});

--- a/src/components/ui/critical-notice.tsx
+++ b/src/components/ui/critical-notice.tsx
@@ -1,0 +1,24 @@
+import { TriangleAlert } from "lucide-react";
+
+import { useT } from "@/i18n/useT";
+
+/**
+ * The block every confirmation on a critical cluster opens with. Loud on
+ * purpose: the point is to notice which cluster this is before reading
+ * what the button does.
+ */
+export function CriticalNotice({ context }: { context: string }) {
+  const t = useT();
+  return (
+    <div
+      role="alert"
+      className="rounded-md border border-err/50 bg-err/10 px-3 py-2 text-xs text-fg"
+    >
+      <p className="flex items-center gap-2 font-semibold uppercase tracking-[0.05em] text-err">
+        <TriangleAlert className="h-3.5 w-3.5" aria-hidden="true" />
+        {t("cluster", "criticalNoticeTitle")}
+      </p>
+      <p className="mt-1">{t("cluster", "criticalNoticeBody", { context })}</p>
+    </div>
+  );
+}

--- a/src/components/ui/dangerous-confirm-dialog.tsx
+++ b/src/components/ui/dangerous-confirm-dialog.tsx
@@ -9,9 +9,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { CriticalNotice } from "@/components/ui/critical-notice";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { buttonVariants } from "@/components/ui/button";
+import { useCritical } from "@/hooks/useCritical";
 import { useT } from "@/i18n/useT";
 
 interface DangerousConfirmDialogProps {
@@ -43,8 +45,14 @@ export function DangerousConfirmDialog({
 }: DangerousConfirmDialogProps) {
   const t = useT();
   const [inputValue, setInputValue] = useState("");
+  // On critical infrastructure the word to type is the cluster's, not the
+  // object's: the mistake this guards against is the cluster, and typing a
+  // pod's name proves nothing about which cluster the pod is on.
+  const critical = useCritical();
+  const expected =
+    critical.critical && critical.context ? critical.context : confirmationText;
 
-  const isConfirmEnabled = inputValue === confirmationText && !isLoading;
+  const isConfirmEnabled = inputValue === expected && !isLoading;
 
   const handleOpenChange = (newOpen: boolean) => {
     if (!newOpen) {
@@ -61,11 +69,12 @@ export function DangerousConfirmDialog({
 
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
-      <AlertDialogContent
-        aria-describedby={description ? undefined : undefined}
-      >
+      <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
+          {critical.critical && critical.context && (
+            <CriticalNotice context={critical.context} />
+          )}
           <AlertDialogDescription className={description ? "" : "sr-only"}>
             {description || t("action", "confirmByTyping")}
           </AlertDialogDescription>
@@ -75,7 +84,7 @@ export function DangerousConfirmDialog({
           <Label htmlFor="confirmation-input" className="text-sm">
             {t("action", "typeWord")}{" "}
             <code className="rounded bg-err/16 px-1.5 py-0.5 font-mono text-xs text-err">
-              {confirmationText}
+              {expected}
             </code>{" "}
             {t("action", "toConfirm")}
           </Label>
@@ -83,7 +92,7 @@ export function DangerousConfirmDialog({
             id="confirmation-input"
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
-            placeholder={confirmationPlaceholder ?? confirmationText}
+            placeholder={confirmationPlaceholder ?? expected}
             autoComplete="off"
             autoFocus
           />

--- a/src/components/yaml/YamlEditorDialog.test.tsx
+++ b/src/components/yaml/YamlEditorDialog.test.tsx
@@ -12,7 +12,7 @@
  * `useDelivery` would pass with the interception wired to nothing.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -21,6 +21,7 @@ import { MemoryRouter } from "react-router-dom";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 import { useYamlEditorStore } from "@/stores/yamlEditorStore";
+import { useClusterIdentityStore } from "@/stores/clusterIdentityStore";
 
 const detectInClusterExtensions = vi.fn();
 const listCustomResources = vi.fn();
@@ -203,5 +204,41 @@ describe("applying an edited manifest", () => {
     expect(
       screen.queryByRole("button", { name: /Apply anyway/ })
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("applying on critical infrastructure", () => {
+  beforeEach(() => {
+    useClusterIdentityStore.setState({ marks: {} });
+    useClusterIdentityStore.getState().setCritical("test", true);
+  });
+
+  afterEach(() => {
+    useClusterIdentityStore.setState({ marks: {} });
+  });
+
+  /**
+   * Applying a manifest replaces the whole object — the most powerful write
+   * here — so on the marked cluster it takes the same typed-name gate the
+   * confirmations do. Without it the apply's own confirmation, which delivery
+   * had already taught the reader to click through, was the way past.
+   */
+  it("holds Apply until the cluster's name is typed", async () => {
+    const user = await openWith(PLAIN);
+
+    await user.click(screen.getByRole("button", { name: /^Apply$/ }));
+    expect(await screen.findByText("Apply Changes?")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("test");
+
+    const confirm = screen
+      .getAllByRole("button", { name: /^Apply$/ })
+      .at(-1) as HTMLElement;
+    expect(confirm).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText("test"), "test");
+    expect(confirm).toBeEnabled();
+
+    await user.click(confirm);
+    await waitFor(() => expect(applyManifest).toHaveBeenCalledTimes(1));
   });
 });

--- a/src/components/yaml/YamlEditorDialog.tsx
+++ b/src/components/yaml/YamlEditorDialog.tsx
@@ -50,8 +50,7 @@ import { YamlEditor } from "./YamlEditor";
 import { YamlEditorToolbar } from "./YamlEditorToolbar";
 import { YamlDiffViewer } from "./YamlDiffViewer";
 import { YamlResultDisplay } from "./YamlResultDisplay";
-import { CriticalNotice } from "@/components/ui/critical-notice";
-import { useCritical } from "@/hooks/useCritical";
+import { useCriticalGate } from "@/hooks/useCriticalGate";
 import { useT } from "@/i18n/useT";
 
 interface YamlEditorActionProps {
@@ -108,7 +107,13 @@ export function YamlEditorAction(props: YamlEditorActionProps) {
 // Main Dialog Component
 export function YamlEditorDialog() {
   const t = useT();
-  const critical = useCritical();
+  // Applying an edited manifest replaces the whole object — the most powerful
+  // write here — so on a critical cluster it takes the same typed-name gate,
+  // and the field is bound to the notice so neither can appear without the other.
+  const gate = useCriticalGate();
+  // Stable (memoised in the hook), so the apply callback can depend on it
+  // without being rebuilt every render.
+  const gateReset = gate.reset;
   const { toast } = useToast();
   const currentNamespace = useClusterStore((state) => state.currentNamespace);
 
@@ -221,6 +226,7 @@ export function YamlEditorDialog() {
 
   const handleApply = useCallback(async () => {
     setShowApplyConfirm(false);
+    gateReset();
     setIsApplying(true);
     setApplyResult(null);
 
@@ -269,6 +275,7 @@ export function YamlEditorDialog() {
     setIsApplying,
     setApplyResult,
     addHistoryEntry,
+    gateReset,
     toast,
     t,
   ]);
@@ -413,15 +420,19 @@ export function YamlEditorDialog() {
       </Dialog>
 
       {/* Apply Confirmation Dialog */}
-      <Dialog open={showApplyConfirm} onOpenChange={setShowApplyConfirm}>
+      <Dialog
+        open={showApplyConfirm}
+        onOpenChange={(next) => {
+          if (!next) gate.reset();
+          setShowApplyConfirm(next);
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
               {intercept?.title ?? t("action", "applyChangesQuestion")}
             </DialogTitle>
-            {critical.critical && critical.context && (
-              <CriticalNotice context={critical.context} />
-            )}
+            {gate.notice}
             <DialogDescription>
               {t("action", "applyManifestConfirm")}
             </DialogDescription>
@@ -454,14 +465,19 @@ export function YamlEditorDialog() {
             </div>
           )}
 
+          {gate.input}
+
           <DialogFooter>
             <Button
               variant="outline"
-              onClick={() => setShowApplyConfirm(false)}
+              onClick={() => {
+                gate.reset();
+                setShowApplyConfirm(false);
+              }}
             >
               {t("action", "cancel")}
             </Button>
-            <Button onClick={handleApply}>
+            <Button onClick={handleApply} disabled={gate.blocked}>
               <Play className="mr-2 h-4 w-4" />
               {/* The intercept decides its own word where it has one — a
                   disowned label confirms with a plain "Apply", because there

--- a/src/components/yaml/YamlEditorDialog.tsx
+++ b/src/components/yaml/YamlEditorDialog.tsx
@@ -50,6 +50,8 @@ import { YamlEditor } from "./YamlEditor";
 import { YamlEditorToolbar } from "./YamlEditorToolbar";
 import { YamlDiffViewer } from "./YamlDiffViewer";
 import { YamlResultDisplay } from "./YamlResultDisplay";
+import { CriticalNotice } from "@/components/ui/critical-notice";
+import { useCritical } from "@/hooks/useCritical";
 import { useT } from "@/i18n/useT";
 
 interface YamlEditorActionProps {
@@ -106,6 +108,7 @@ export function YamlEditorAction(props: YamlEditorActionProps) {
 // Main Dialog Component
 export function YamlEditorDialog() {
   const t = useT();
+  const critical = useCritical();
   const { toast } = useToast();
   const currentNamespace = useClusterStore((state) => state.currentNamespace);
 
@@ -416,6 +419,9 @@ export function YamlEditorDialog() {
             <DialogTitle>
               {intercept?.title ?? t("action", "applyChangesQuestion")}
             </DialogTitle>
+            {critical.critical && critical.context && (
+              <CriticalNotice context={critical.context} />
+            )}
             <DialogDescription>
               {t("action", "applyManifestConfirm")}
             </DialogDescription>

--- a/src/hooks/useCritical.ts
+++ b/src/hooks/useCritical.ts
@@ -1,0 +1,11 @@
+import { criticalityOf } from "@/lib/critical";
+import type { Criticality } from "@/lib/critical";
+import { useClusterMark } from "@/stores/clusterIdentityStore";
+import { useClusterStore } from "@/stores/clusterStore";
+
+/** The current cluster's criticality, with its name for the dialogs that ask for it. */
+export function useCritical(): Criticality & { context: string | null } {
+  const context = useClusterStore((s) => s.currentContext);
+  const mark = useClusterMark(context);
+  return { context, ...criticalityOf(context, mark) };
+}

--- a/src/hooks/useCriticalGate.tsx
+++ b/src/hooks/useCriticalGate.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useId, useState, type ReactNode } from "react";
+
+import { CriticalNotice } from "@/components/ui/critical-notice";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useCritical } from "@/hooks/useCritical";
+import { useT } from "@/i18n/useT";
+
+/**
+ * The one place the critical-cluster typed-name gate lives.
+ *
+ * Every destructive dialog on a cluster the person marked critical asks for
+ * the cluster's own name before it fires. The check is one line, but it was
+ * copied into two dialogs and forgotten in the rest — so scale-to-zero, a
+ * YAML apply and a node drain showed the red "type the name" notice and then
+ * went ahead on one click. This hook is that notice AND the field it promises,
+ * together, so a dialog cannot render the one without the other:
+ *
+ *   const gate = useCriticalGate();
+ *   ... {gate.notice} ... {gate.input} ...
+ *   <Button disabled={busy || gate.blocked} />
+ *   // and gate.reset() when the dialog closes.
+ */
+export function useCriticalGate(): {
+  /** The cluster is marked critical, so the gate applies at all. A caller that
+   *  otherwise fires with no dialog (an InterceptedAction with no delivery to
+   *  warn about) uses this to decide it must interpose one after all. */
+  active: boolean;
+  /** True while the action must stay disabled: marked critical and the typed
+   *  name does not match yet. False on a cluster that is not critical. */
+  blocked: boolean;
+  /** The red band, or null when the cluster is not critical. */
+  notice: ReactNode;
+  /** The label + typed-name field, or null when not critical. */
+  input: ReactNode;
+  /** Clear the typed name — call when the dialog closes. */
+  reset: () => void;
+} {
+  const t = useT();
+  const critical = useCritical();
+  const [typed, setTyped] = useState("");
+  const id = useId();
+  const gate = critical.critical ? critical.context : null;
+  const blocked = gate !== null && typed !== gate;
+  // Stable so a callback that clears the gate on close (a useCallback apply
+  // handler, say) does not churn its identity every render.
+  const reset = useCallback(() => setTyped(""), []);
+
+  return {
+    active: gate !== null,
+    blocked,
+    notice: gate ? <CriticalNotice context={gate} /> : null,
+    input: gate ? (
+      <div className="space-y-2">
+        <Label htmlFor={id} className="text-sm">
+          {t("action", "typeWord")}{" "}
+          <code className="rounded bg-err/16 px-1.5 py-0.5 font-mono text-xs text-err">
+            {gate}
+          </code>{" "}
+          {t("action", "toConfirm")}
+        </Label>
+        <Input
+          id={id}
+          value={typed}
+          onChange={(e) => setTyped(e.target.value)}
+          placeholder={gate}
+          autoComplete="off"
+        />
+      </div>
+    ) : null,
+    reset,
+  };
+}

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -2213,6 +2213,10 @@ export const en = {
     refusalOther: "Refused",
     nameMissingParens: "{name} (missing)",
     noClusterSelected: "No cluster selected",
+    criticalNoticeTitle: "Critical infrastructure",
+    criticalNoticeBody:
+      "This is {context}. Whatever this does, it does there. Type the cluster's name to go on.",
+    criticalStripe: "Critical: {context}",
     metricsNotInstalled: "Metrics server not installed",
     metricsNotInstalledBody:
       "Install metrics-server to see CPU and memory usage.",
@@ -2369,6 +2373,10 @@ export const en = {
     contextReady: "ready",
     contextCannotConnect: "cannot connect",
     contextCannotTell: "cannot tell",
+    criticalLabel:
+      "Critical infrastructure: every change asks for the cluster's name",
+    criticalGuessed: "The name suggests it. Tick to make it so.",
+
     searchMissingWords: "not found missing path",
     searchContextWords: "context kubeconfig authentication",
     searchKubeconfigWords:

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -625,6 +625,8 @@ export const en = {
     noLimit: "No limit",
     latestN: "Latest {n}",
     drainNamed: "Drain {name}",
+    cordonNamed: "Cordon {name}?",
+    uncordonNamed: "Uncordon {name}?",
     drainAnyway: "Drain anyway",
     stopDraining: "Stop draining",
     drainEnded: "The drain of {name} ended",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -596,6 +596,8 @@ export const ru: Catalogue = {
     noLimit: "Без ограничения",
     latestN: "Последние {n}",
     drainNamed: "Освободить узел {name}",
+    cordonNamed: "Запретить планирование на {name}?",
+    uncordonNamed: "Разрешить планирование на {name}?",
     drainAnyway: "Всё равно освободить",
     stopDraining: "Остановить",
     drainEnded: "Освобождение {name} закончилось",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -2364,6 +2364,10 @@ export const ru: Catalogue = {
     refusalOther: "Отказано",
     nameMissingParens: "{name} (отсутствует)",
     noClusterSelected: "Кластер не выбран",
+    criticalNoticeTitle: "Критическая инфраструктура",
+    criticalNoticeBody:
+      "Это {context}. Что бы здесь ни делалось, делается там. Введите имя кластера, чтобы продолжить.",
+    criticalStripe: "Критический: {context}",
     metricsNotInstalled: "metrics-server не установлен",
     metricsNotInstalledBody:
       "Установите metrics-server, чтобы видеть загрузку CPU и памяти.",
@@ -2536,6 +2540,10 @@ export const ru: Catalogue = {
     contextReady: "готов",
     contextCannotConnect: "подключиться нельзя",
     contextCannotTell: "определить нельзя",
+    criticalLabel:
+      "Критическая инфраструктура: каждое изменение спросит имя кластера",
+    criticalGuessed: "Судя по имени, да. Отметьте, чтобы так и было.",
+
     searchMissingWords: "not found missing path не найден отсутствует путь",
     searchContextWords:
       "context kubeconfig authentication контекст аутентификация",

--- a/src/lib/critical.test.ts
+++ b/src/lib/critical.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { criticalityOf } from "./critical";
+
+describe("criticalityOf", () => {
+  /** A guard armed by a name alone fires on `product-catalog-dev` and is switched off for good. */
+  it("guesses from the name but never arms the guard on a guess", () => {
+    expect(criticalityOf("prod-eu-1", undefined)).toEqual({
+      critical: false,
+      guessed: true,
+    });
+    expect(criticalityOf("staging", undefined)).toEqual({
+      critical: false,
+      guessed: false,
+    });
+  });
+
+  /** Once the person has said, the name stops mattering either way. */
+  it("takes the person's word over the name", () => {
+    expect(criticalityOf("prod-eu-1", { critical: false })).toEqual({
+      critical: false,
+      guessed: false,
+    });
+    expect(criticalityOf("sandbox", { critical: true })).toEqual({
+      critical: true,
+      guessed: false,
+    });
+    expect(criticalityOf(null, { critical: true }).critical).toBe(false);
+  });
+});

--- a/src/lib/critical.ts
+++ b/src/lib/critical.ts
@@ -1,0 +1,29 @@
+import { isProductionContext } from "@/lib/cluster-identity";
+import type { ClusterMark } from "@/stores/clusterIdentityStore";
+
+/**
+ * Whether a cluster is critical infrastructure, and whether that is the
+ * person's word or only what its name suggests.
+ *
+ * Only the person's word arms the guard: a guess from the name paints the
+ * row and asks, and nothing else. Acting on the wrong cluster is the
+ * expensive mistake; so is a guard that fires on a cluster called
+ * `product-catalog-dev` until someone finds the setting that turns it off.
+ */
+export interface Criticality {
+  /** Every change asks for the context name. */
+  critical: boolean;
+  /** The name looks like production and nobody has said either way. */
+  guessed: boolean;
+}
+
+export function criticalityOf(
+  context: string | null | undefined,
+  mark: ClusterMark | undefined
+): Criticality {
+  if (!context) return { critical: false, guessed: false };
+  if (mark?.critical !== undefined) {
+    return { critical: mark.critical, guessed: false };
+  }
+  return { critical: false, guessed: isProductionContext(context) };
+}

--- a/src/pages/DeploymentDetail.tsx
+++ b/src/pages/DeploymentDetail.tsx
@@ -63,6 +63,7 @@ import {
   WorkloadOverview,
 } from "@/components/resources/workload-overview";
 import { InterceptedAction } from "@/components/resources/delivery-intercept";
+import { useCriticalGate } from "@/hooks/useCriticalGate";
 import { useDeliveryIntercept } from "@/hooks/useDelivery";
 import {
   Composition,
@@ -94,6 +95,13 @@ export function DeploymentDetail() {
   const [imageDialogOpen, setImageDialogOpen] = useState(false);
   const [newImage, setNewImage] = useState("");
   const [selectedContainer, setSelectedContainer] = useState("");
+  // Updating a container image rolls out new code — a change to the cluster,
+  // gated on a critical one exactly like Scale, Restart and Delete beside it.
+  const imageGate = useCriticalGate();
+  const imageGateReset = imageGate.reset;
+  useEffect(() => {
+    if (!imageDialogOpen) imageGateReset();
+  }, [imageDialogOpen, imageGateReset]);
   const [selectedLogPod, setSelectedLogPod] = useState<string | null>(null);
   const {
     name,
@@ -635,6 +643,7 @@ export function DeploymentDetail() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t("action", "updateContainerImage")}</DialogTitle>
+            {imageGate.notice}
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-2">
@@ -650,6 +659,7 @@ export function DeploymentDetail() {
                 placeholder={t("action", "imagePlaceholder")}
               />
             </div>
+            {imageGate.input}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setImageDialogOpen(false)}>
@@ -657,7 +667,9 @@ export function DeploymentDetail() {
             </Button>
             <Button
               onClick={() => updateImageMutation.mutate()}
-              disabled={updateImageMutation.isPending || !newImage}
+              disabled={
+                updateImageMutation.isPending || !newImage || imageGate.blocked
+              }
             >
               {t("action", "update")}
             </Button>

--- a/src/pages/InfrastructureBuilder.tsx
+++ b/src/pages/InfrastructureBuilder.tsx
@@ -28,6 +28,7 @@ import { SectionHeader } from "@/components/ui/section";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { useCritical } from "@/hooks/useCritical";
 import { Spinner } from "@/components/ui/spinner";
 import {
   Dialog,
@@ -113,6 +114,12 @@ export function InfrastructureBuilder() {
   const [isValidating, setIsValidating] = useState(false);
   const [clearOpen, setClearOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
+  // Applying a built manifest is the same kubectl-apply the YAML editor gates;
+  // on a critical cluster it goes through a typed-name confirmation too. Kept
+  // to critical clusters so the ordinary builder stays one click.
+  const [applyConfirmOpen, setApplyConfirmOpen] = useState(false);
+  const critical = useCritical();
+  const criticalActive = critical.critical && !!critical.context;
   const [includeImported, setIncludeImported] = useState(false);
   const [selection, setSelection] = useState<{
     nodes: Node<ResourceNodeData>[];
@@ -571,7 +578,15 @@ export function InfrastructureBuilder() {
                 )}
                 {t("action", "validate")}
               </Button>
-              <Button size="sm" onClick={handleApply} disabled={isApplying}>
+              <Button
+                size="sm"
+                onClick={() =>
+                  criticalActive
+                    ? setApplyConfirmOpen(true)
+                    : void handleApply()
+                }
+                disabled={isApplying}
+              >
                 {isApplying ? (
                   <Spinner size="sm" className="mr-1.5" />
                 ) : (
@@ -725,6 +740,17 @@ export function InfrastructureBuilder() {
           </div>
         </TabsContent>
       </Tabs>
+      <ConfirmDialog
+        open={applyConfirmOpen}
+        onOpenChange={setApplyConfirmOpen}
+        title={t("action", "applyChangesQuestion")}
+        description={t("action", "applyManifestConfirm")}
+        confirmLabel={t("action", "apply")}
+        onConfirm={() => {
+          setApplyConfirmOpen(false);
+          void handleApply();
+        }}
+      />
       <ConfirmDialog
         open={clearOpen}
         onOpenChange={setClearOpen}

--- a/src/stores/clusterIdentityStore.test.ts
+++ b/src/stores/clusterIdentityStore.test.ts
@@ -50,15 +50,20 @@ describe("what colour it wears", () => {
   });
 });
 
-describe("what is read back off this machine", () => {
-  const migrate = (persisted: unknown) =>
-    (
-      useClusterIdentityStore.persist.getOptions().migrate as (
-        p: unknown,
-        v: number
-      ) => { marks: Record<string, { alias?: string; hue?: number }> }
-    )(persisted, 0).marks;
+const migrate = (persisted: unknown) =>
+  (
+    useClusterIdentityStore.persist.getOptions().migrate as (
+      p: unknown,
+      v: number
+    ) => {
+      marks: Record<
+        string,
+        { alias?: string; hue?: number; critical?: boolean }
+      >;
+    }
+  )(persisted, 0).marks;
 
+describe("what is read back off this machine", () => {
   it("refuses a hue that is not on the palette", () => {
     // A hue off the ring would be worn at a saturation and lightness the
     // themes were never calibrated for, which is the one thing a fixed
@@ -77,5 +82,23 @@ describe("what is read back off this machine", () => {
   it("starts empty on a payload it did not write", () => {
     expect(migrate(undefined)).toEqual({});
     expect(migrate({ marks: "nonsense" })).toEqual({});
+  });
+});
+
+describe("whether it is critical infrastructure", () => {
+  /** A cleared flag that left `{critical: undefined}` behind would keep the row forever. */
+  it("is unsaid again once unticked, leaving no residue", () => {
+    state().setCritical(ARN, true);
+    expect(state().marks[ARN]).toEqual({ critical: true });
+    state().setCritical(ARN, null);
+    expect(ARN in state().marks).toBe(false);
+  });
+
+  /** Dropping the flag on read would silently disarm every guard after a restart. */
+  it("comes back off this machine, and only as a yes or a no", () => {
+    expect(migrate({ marks: { [ARN]: { critical: true } } })).toEqual({
+      [ARN]: { critical: true },
+    });
+    expect(migrate({ marks: { [ARN]: { critical: "yes" } } })).toEqual({});
   });
 });

--- a/src/stores/clusterIdentityStore.ts
+++ b/src/stores/clusterIdentityStore.ts
@@ -30,12 +30,19 @@ export interface ClusterMark {
   alias?: string;
   /** One of `CLUSTER_HUES`, or absent for the colour derived from the name. */
   hue?: number;
+  /**
+   * Critical infrastructure, said by the person: every change on it asks
+   * for the context name. Absent means never decided, which a name that
+   * looks like production turns into a question, never into the answer.
+   */
+  critical?: boolean;
 }
 
 interface ClusterIdentityState {
   marks: Record<string, ClusterMark>;
   setAlias: (context: string, alias: string) => void;
   setHue: (context: string, hue: number | null) => void;
+  setCritical: (context: string, critical: boolean | null) => void;
 }
 
 /** Drop a mark that no longer says anything, so a reset leaves no residue. */
@@ -45,7 +52,12 @@ function write(
   mark: ClusterMark
 ): Record<string, ClusterMark> {
   const next = { ...marks };
-  if (mark.alias === undefined && mark.hue === undefined) delete next[context];
+  if (
+    mark.alias === undefined &&
+    mark.hue === undefined &&
+    mark.critical === undefined
+  )
+    delete next[context];
   else next[context] = mark;
   return next;
 }
@@ -66,6 +78,13 @@ export const useClusterIdentityStore = create<ClusterIdentityState>()(
           marks: write(state.marks, context, {
             ...state.marks[context],
             hue: hue ?? undefined,
+          }),
+        })),
+      setCritical: (context, critical) =>
+        set((state) => ({
+          marks: write(state.marks, context, {
+            ...state.marks[context],
+            critical: critical ?? undefined,
           }),
         })),
     }),
@@ -93,7 +112,14 @@ export const useClusterIdentityStore = create<ClusterIdentityState>()(
             ) {
               mark.hue = raw.hue;
             }
-            if (mark.alias !== undefined || mark.hue !== undefined) {
+            if (typeof raw?.critical === "boolean") {
+              mark.critical = raw.critical;
+            }
+            if (
+              mark.alias !== undefined ||
+              mark.hue !== undefined ||
+              mark.critical !== undefined
+            ) {
               marks[context] = mark;
             }
           }


### PR DESCRIPTION
## What is wrong today

The only thing standing between a person and a deletion on production is which window they happened to click in. The name of the cluster is a 2px line at the top of the window that everybody has stopped seeing by the second day, and the typed confirmation asks for the pod's name, which proves nothing about which cluster the pod is on.

## What changes

A cluster can be marked **critical infrastructure** in Settings › Clusters. The mark is the person's word: a name that looks like production (`prod`, `live`, `production`) only paints a hint beside the checkbox saying the name suggests it. A guard armed by the name alone would fire on `product-catalog-dev` until somebody found the setting that turns it off, so a guess never arms anything.

Once marked:

- the 2px stripe becomes a red band with the words `Critical: <context>` across the top of the window;
- every `ConfirmDialog` opens with a red notice naming the cluster and holds its button until the context name is typed;
- every `DangerousConfirmDialog` asks for the **cluster's** name instead of the object's;
- the scale dialog and the YAML apply confirmation carry the same notice.

The flag lives on the existing `ClusterMark` beside alias and hue, persists with them, and survives the store's migrate (which previously dropped any field it did not know).

## How to check it

`bun run test` covers: the plain dialog stays disabled until the exact name is typed and asks nothing on a merely production-looking name; the typed dialog rejects the object's name and accepts the cluster's; the flag round-trips through persistence and leaves no residue when unticked. Each was sabotaged and failed for the stated reason.

Not rendered: this machine has no display for the Tauri window. The stripe, notice and checkbox are reviewed from source only.

## Risk and rollback

Additive. Nothing changes for a cluster nobody has marked. Rollback leaves a `critical` key in the persisted marks that the older migrate ignores.