### PR TITLE
fix(namespaces): a multi-namespace selection reads per namespace, not cluster-wide (#137)

### DIFF
--- a/src/components/resources/CustomResourceList.tsx
+++ b/src/components/resources/CustomResourceList.tsx
@@ -6,7 +6,8 @@ import { Eye, Trash2 } from "lucide-react";
 import { RouteLink } from "@/components/ui/route-link";
 import { StatusBadge } from "@/components/ui/status-badge";
 import type { QuickAction } from "@/components/ui/quick-actions";
-import { useClusterStore } from "@/stores/clusterStore";
+import { useNamespaceScope } from "@/hooks/useNamespaceScope";
+import { listAcrossScope, scopeCacheKey } from "@/lib/namespace-scope";
 import { createAgeColumn, createNamespaceColumn } from "./columns";
 import { RealtimeAge } from "@/components/ui/realtime";
 import { ResourceType, toPlural } from "@/lib/resource-registry";
@@ -48,13 +49,21 @@ export function CustomResourceList({
   embedded = false,
 }: CustomResourceListProps) {
   const t = useT();
-  const { currentNamespace } = useClusterStore();
+  const nsScope = useNamespaceScope();
 
   // How the vendor that installed this CRD draws it, if the app knows one.
   const crdView = useCrdView(crdGroup, crdKind);
 
   const navigate = useNavigate();
-  const namespace = scope === "Namespaced" ? currentNamespace : null;
+  // A cluster-scoped CRD ignores the namespace selection; a namespaced one is
+  // read across it — several namespaces one apiece and polled, one or none as
+  // a single request/watch. See `listAcrossScope`.
+  const isNamespaced = scope === "Namespaced";
+  const namespaceScope = isNamespaced ? nsScope.scope : [];
+  const watchNamespace =
+    isNamespaced && nsScope.scope.length === 1 ? nsScope.scope[0] : null;
+  const cacheKey = isNamespaced ? scopeCacheKey(nsScope.scope) : null;
+  const watchEnabled = !(isNamespaced && nsScope.several);
 
   // Generate detail path for a custom resource. Wrapped in
   // `useCallback` so the two `useMemo` blocks below can list it as a
@@ -179,8 +188,8 @@ export function CustomResourceList({
   const queryKey = useMemo(
     // Not `as const`: one of the two readers wants a mutable array, and a
     // copy made for it is what defeated this memo in the first place.
-    () => queryKeys.customResourceList(crdName, namespace),
-    [crdName, namespace]
+    () => queryKeys.customResourceList(crdName, cacheKey),
+    [crdName, cacheKey]
   );
   const subscribeCustomResource = useCallback(
     () =>
@@ -189,9 +198,9 @@ export function CustomResourceList({
         crdVersion,
         crdKind,
         crdPlural,
-        namespace || null
+        watchNamespace
       ),
-    [crdGroup, crdVersion, crdKind, crdPlural, namespace]
+    [crdGroup, crdVersion, crdKind, crdPlural, watchNamespace]
   );
   const { toast } = useToast();
   const [watchFailed, setWatchFailed] = useState(false);
@@ -210,7 +219,7 @@ export function CustomResourceList({
     [toast, watchFailed, crdKind, t]
   );
   const { resyncing } = useResourceWatch<CustomResourceListItem>({
-    enabled: true,
+    enabled: watchEnabled,
     subscribe: subscribeCustomResource,
     // The memoised array itself, not a copy of it: the watch effect has this
     // in its dependencies, and a fresh array on every render tore the subscription
@@ -227,10 +236,10 @@ export function CustomResourceList({
       }
       queryKey={queryKey}
       getRowId={getResourceRowId}
-      queryFn={async () => {
+      queryFn={listAcrossScope(namespaceScope, async (ns) => {
         const result = await commands.listCustomResources(
           crdName,
-          namespace || null,
+          ns,
           null,
           null
         );
@@ -238,7 +247,7 @@ export function CustomResourceList({
           ...r,
           namespace: r.namespace || "",
         }));
-      }}
+      })}
       columns={baseColumns}
       quickActions={quickActions}
       emptyStateLabel={crdPlural}
@@ -246,10 +255,10 @@ export function CustomResourceList({
       // message a CRD list must not show: the whole question a reader
       // opens it with is whether this kind exists on the cluster at all.
       emptyMessage={
-        namespace
+        watchNamespace
           ? t("empty", "crdNoInstancesInNamespace", {
               kind: crdKind,
-              namespace,
+              namespace: watchNamespace,
             })
           : t("empty", "crdNoInstances", { kind: crdKind })
       }
@@ -264,8 +273,8 @@ export function CustomResourceList({
         resourceType: crdKind,
       }}
       staleTime={STALE_TIMES.resourceList}
-      refresh={watchFailed ? "resourceList" : false}
-      live={!watchFailed}
+      refresh={watchFailed || !watchEnabled ? "resourceList" : false}
+      live={watchEnabled && !watchFailed}
       resyncing={resyncing}
       searchKey="name"
       searchPlaceholder={t("action", "searchKindPlaceholder", {

--- a/src/components/resources/IngressList.tsx
+++ b/src/components/resources/IngressList.tsx
@@ -1,7 +1,8 @@
 import { sayWords } from "@/i18n/say";
 import { commands } from "@/lib/commands";
 import { T } from "@/i18n/T";
-import { useClusterStore } from "@/stores/clusterStore";
+import { useNamespaceScope } from "@/hooks/useNamespaceScope";
+import { listAcrossScope, scopeCacheKey } from "@/lib/namespace-scope";
 import type { ColumnDef } from "@/components/ui/table-features";
 import {
   createContext,
@@ -214,16 +215,29 @@ export const baseColumns: ColumnDef<IngressInfo>[] = [
 
 export function IngressList() {
   const t = useT();
-  const { currentNamespace } = useClusterStore();
+  const scope = useNamespaceScope();
   const navigate = useNavigate();
 
+  // Several namespaces are read one apiece and polled; a watch covers none or
+  // one. See `listAcrossScope`.
+  const watchNamespace = scope.scope.length === 1 ? scope.scope[0] : null;
+  const cacheKey = scopeCacheKey(scope.scope);
+  const watchEnabled = !scope.several;
+  const listIngressesFor = (namespace: string | null) =>
+    commands.listIngresses({
+      namespace,
+      labelSelector: null,
+      fieldSelector: null,
+      limit: null,
+    });
+
   const queryKey = useMemo(
-    () => queryKeys.resources(ResourceType.Ingress, currentNamespace),
-    [currentNamespace]
+    () => queryKeys.resources(ResourceType.Ingress, cacheKey),
+    [cacheKey]
   );
   const subscribe = useCallback(
-    () => commands.subscribeIngressWatch(currentNamespace || null),
-    [currentNamespace]
+    () => commands.subscribeIngressWatch(watchNamespace),
+    [watchNamespace]
   );
 
   const { toast } = useToast();
@@ -243,7 +257,7 @@ export function IngressList() {
     [t, toast, watchFailed]
   );
   const { resyncing } = useResourceWatch<IngressInfo>({
-    enabled: true,
+    enabled: watchEnabled,
     subscribe,
     queryKey,
     onError: handleWatchError,
@@ -252,13 +266,9 @@ export function IngressList() {
 
   // A second observer on the list's own cache entry, so the rows cost one
   // request and not two — the same trick the sidebar counts use.
-  const listed = useResourceList<IngressInfo[]>(queryKey, () =>
-    commands.listIngresses({
-      namespace: currentNamespace || null,
-      labelSelector: null,
-      fieldSelector: null,
-      limit: null,
-    })
+  const listed = useResourceList<IngressInfo[]>(
+    queryKey,
+    listAcrossScope(scope.scope, listIngressesFor)
   );
   const asked = useMemo(
     () =>
@@ -326,30 +336,21 @@ export function IngressList() {
     <VendorTls.Provider value={vendorFor}>
       <ResourceList<IngressInfo>
         title="Ingresses"
-        queryKey={queryKeys.resources(ResourceType.Ingress, currentNamespace)}
+        queryKey={queryKey}
         getRowId={getResourceRowId}
-        queryFn={() =>
-          commands.listIngresses({
-            namespace: currentNamespace || null,
-            labelSelector: null,
-            fieldSelector: null,
-            limit: null,
-          })
-        }
+        queryFn={listAcrossScope(scope.scope, listIngressesFor)}
         columns={baseColumns}
         quickActions={quickActions}
         emptyStateLabel={toPlural(ResourceType.Ingress)}
         deleteConfig={{
           mutationFn: (item) =>
             commands.deleteIngress(item.name, item.namespace ?? null),
-          invalidateQueryKeys: [
-            queryKeys.resources(ResourceType.Ingress, currentNamespace),
-          ],
+          invalidateQueryKeys: [queryKey],
           resourceType: ResourceType.Ingress,
         }}
         staleTime={STALE_TIMES.resourceList}
-        refresh={watchFailed ? undefined : false}
-        live={!watchFailed}
+        refresh={watchFailed || scope.several ? undefined : false}
+        live={watchEnabled && !watchFailed}
         resyncing={resyncing}
         searchKey="name"
         getRowHref={(row) =>

--- a/src/components/resources/PersistentVolumeClaimList.tsx
+++ b/src/components/resources/PersistentVolumeClaimList.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { T } from "@/i18n/T";
 import { useNavigate } from "react-router-dom";
 import { useNamespaceScope } from "@/hooks/useNamespaceScope";
-import { useClusterStore } from "@/stores/clusterStore";
+import { listAcrossScope, scopeCacheKey } from "@/lib/namespace-scope";
 import { PhaseBadge } from "@/components/ui/status-badge";
 import type { ColumnDef } from "@/components/ui/table-features";
 import { Eye, Trash2 } from "lucide-react";
@@ -73,18 +73,29 @@ export const columns: ColumnDef<PersistentVolumeClaimInfo>[] = [
 
 export function PersistentVolumeClaimList() {
   const t = useT();
-  const { currentNamespace } = useClusterStore();
   const scope = useNamespaceScope();
   const navigate = useNavigate();
 
+  // Several namespaces are read one apiece and polled; a watch covers none or
+  // one. See `listAcrossScope`.
+  const watchNamespace = scope.scope.length === 1 ? scope.scope[0] : null;
+  const cacheKey = scopeCacheKey(scope.scope);
+  const watchEnabled = !scope.several;
+  const listPvcsFor = (namespace: string | null) =>
+    commands.listPersistentVolumeClaims({
+      namespace,
+      labelSelector: null,
+      fieldSelector: null,
+      limit: null,
+    });
+
   const queryKey = useMemo(
-    () =>
-      queryKeys.resources(ResourceType.PersistentVolumeClaim, currentNamespace),
-    [currentNamespace]
+    () => queryKeys.resources(ResourceType.PersistentVolumeClaim, cacheKey),
+    [cacheKey]
   );
   const subscribe = useCallback(
-    () => commands.subscribePvcWatch(currentNamespace || null),
-    [currentNamespace]
+    () => commands.subscribePvcWatch(watchNamespace),
+    [watchNamespace]
   );
 
   const { toast } = useToast();
@@ -104,7 +115,7 @@ export function PersistentVolumeClaimList() {
     [t, toast, watchFailed]
   );
   const { resyncing } = useResourceWatch<PersistentVolumeClaimInfo>({
-    enabled: true,
+    enabled: watchEnabled,
     subscribe,
     queryKey,
     onError: handleWatchError,
@@ -145,19 +156,9 @@ export function PersistentVolumeClaimList() {
       description={t("empty", "pvcListDescription", {
         scope: scope.inWords,
       })}
-      queryKey={queryKeys.resources(
-        ResourceType.PersistentVolumeClaim,
-        currentNamespace
-      )}
+      queryKey={queryKey}
       getRowId={getResourceRowId}
-      queryFn={() =>
-        commands.listPersistentVolumeClaims({
-          namespace: currentNamespace || null,
-          labelSelector: null,
-          fieldSelector: null,
-          limit: null,
-        })
-      }
+      queryFn={listAcrossScope(scope.scope, listPvcsFor)}
       columns={columns}
       quickActions={quickActions}
       emptyStateLabel={toPlural(ResourceType.PersistentVolumeClaim)}
@@ -167,17 +168,12 @@ export function PersistentVolumeClaimList() {
             item.name,
             item.namespace ?? null
           ),
-        invalidateQueryKeys: [
-          queryKeys.resources(
-            ResourceType.PersistentVolumeClaim,
-            currentNamespace
-          ),
-        ],
+        invalidateQueryKeys: [queryKey],
         resourceType: ResourceType.PersistentVolumeClaim,
       }}
       staleTime={STALE_TIMES.resourceList}
-      refresh={watchFailed ? undefined : false}
-      live={!watchFailed}
+      refresh={watchFailed || scope.several ? undefined : false}
+      live={watchEnabled && !watchFailed}
       resyncing={resyncing}
       searchKey="name"
       getRowHref={(row) =>

--- a/src/components/resources/createResourceListPage.tsx
+++ b/src/components/resources/createResourceListPage.tsx
@@ -18,7 +18,7 @@ import {
   useNamespaceScope,
   type NamespaceScope,
 } from "@/hooks/useNamespaceScope";
-import { useClusterStore } from "@/stores/clusterStore";
+import { listAcrossScope, scopeCacheKey } from "@/lib/namespace-scope";
 import { useToast } from "@/components/ui/use-toast";
 import { queryKeys } from "@/lib/query-keys";
 import { getResourceDetailUrl } from "@/lib/navigation-utils";
@@ -84,10 +84,19 @@ export function createResourceListPage<T extends ListableResource>(
 ) {
   const ListPage = function ResourceListPage() {
     const t = useT();
-    const currentNamespace = useClusterStore((s) => s.currentNamespace);
     const scope = useNamespaceScope();
     const navigate = useNavigate();
-    const namespace = config.scope === "cluster" ? null : currentNamespace;
+    const isCluster = config.scope === "cluster";
+    // The single namespace a watch subscribes to. A watch runs only for a
+    // selection of none or one; several is read per namespace and polled.
+    const watchNamespace = isCluster
+      ? null
+      : scope.scope.length === 1
+        ? scope.scope[0]
+        : null;
+    // The cache key rides on the whole selection, not one namespace, so two
+    // different multi-namespace scopes never read each other's rows.
+    const cacheKey = isCluster ? null : scopeCacheKey(scope.scope);
 
     const columns = useMemo(() => config.columns({ navigate }), [navigate]);
 
@@ -125,14 +134,26 @@ export function createResourceListPage<T extends ListableResource>(
     );
 
     const watchFactory = config.watch;
+    // A watch is one cluster-wide or one single-namespace stream. A selection
+    // of several is polled per namespace instead (see `listAcrossScope`): a
+    // cluster-wide watch needs rights this user may lack and would stream
+    // namespaces they did not ask for.
+    const watchEnabled = !!watchFactory && (isCluster || !scope.several);
     const subscribe = useCallback(
-      () => watchFactory!({ namespace }),
-      [watchFactory, namespace]
+      () => watchFactory!({ namespace: watchNamespace }),
+      [watchFactory, watchNamespace]
     );
     const queryKey = useMemo(
-      () => queryKeys.resources(config.resourceType, namespace),
-      [namespace]
+      () => queryKeys.resources(config.resourceType, cacheKey),
+      [cacheKey]
     );
+    // Rebuilt each render, which React Query is fine with — it keys on
+    // `queryKey`, and `cacheKey` moves with the selection.
+    const queryFn = isCluster
+      ? () => config.fetcher({ namespace: null })
+      : listAcrossScope(scope.scope, (namespace) =>
+          config.fetcher({ namespace })
+        );
 
     // When the backend's watcher fails N times in a row (typical cause: the
     // kubeconfig user lacks the `watch` verb on this kind), fall back to
@@ -156,7 +177,7 @@ export function createResourceListPage<T extends ListableResource>(
     );
 
     const { resyncing } = useResourceWatch<T>({
-      enabled: !!watchFactory,
+      enabled: watchEnabled,
       subscribe,
       queryKey,
       onError: handleWatchError,
@@ -173,9 +194,9 @@ export function createResourceListPage<T extends ListableResource>(
             : config.description
         }
         searchKey={config.searchKey}
-        queryKey={queryKeys.resources(config.resourceType, namespace)}
+        queryKey={queryKey}
         getRowId={getResourceRowId}
-        queryFn={() => config.fetcher({ namespace })}
+        queryFn={queryFn}
         columns={columns}
         quickActions={quickActions}
         emptyStateLabel={config.emptyStateLabel ?? config.title}
@@ -188,17 +209,15 @@ export function createResourceListPage<T extends ListableResource>(
                 mutationFn: async (item) => {
                   await deleter(item);
                 },
-                invalidateQueryKeys: [
-                  queryKeys.resources(config.resourceType, namespace),
-                ],
+                invalidateQueryKeys: [queryKey],
                 resourceType: config.resourceType,
               }
             : undefined
         }
         delivery={deliveryScopeOf(config.resourceType)}
         staleTime={STALE_TIMES.resourceList}
-        refresh={watchFactory && !watchFailed ? false : undefined}
-        live={!!watchFactory && !watchFailed}
+        refresh={watchEnabled && !watchFailed ? false : undefined}
+        live={watchEnabled && !watchFailed}
         resyncing={resyncing}
       />
     );

--- a/src/components/resources/createWorkloadListPage.tsx
+++ b/src/components/resources/createWorkloadListPage.tsx
@@ -18,7 +18,8 @@ import type { ColumnDef } from "@/components/ui/table-features";
 
 import { ResourceList } from "./ResourceList";
 import { deliveryScopeOf } from "@/lib/delivery";
-import { useClusterStore } from "@/stores/clusterStore";
+import { useNamespaceScope } from "@/hooks/useNamespaceScope";
+import { listAcrossScope, scopeCacheKey } from "@/lib/namespace-scope";
 import { useResourceList } from "@/hooks/useResource";
 import { usePodsWithMetrics } from "@/hooks/usePodsWithMetrics";
 import {
@@ -75,21 +76,27 @@ export function createWorkloadListPage<T extends Workload>(
 ) {
   const ListPage = function WorkloadListPage() {
     const t = useT();
-    const currentNamespace = useClusterStore((s) => s.currentNamespace);
+    const scope = useNamespaceScope();
     const navigate = useNavigate();
 
     // Read for the aggregated CPU and memory columns only. The workloads are
     // this page's subject and do not wait on them — see `usePodsWithMetrics`.
     const { data: pods, podStatus } = usePodsWithMetrics();
 
-    const queryKey = useMemo(
-      () => queryKeys.resources(config.resourceType, currentNamespace),
-      [currentNamespace]
-    );
+    // Several namespaces are read one apiece and polled; a watch covers none
+    // or one. See `listAcrossScope` / createResourceListPage.
+    const watchNamespace = scope.scope.length === 1 ? scope.scope[0] : null;
+    const cacheKey = scopeCacheKey(scope.scope);
     const watchFactory = config.watch;
+    const watchEnabled = !!watchFactory && !scope.several;
+
+    const queryKey = useMemo(
+      () => queryKeys.resources(config.resourceType, cacheKey),
+      [cacheKey]
+    );
     const subscribe = useCallback(
-      () => watchFactory!({ namespace: currentNamespace || null }),
-      [watchFactory, currentNamespace]
+      () => watchFactory!({ namespace: watchNamespace }),
+      [watchFactory, watchNamespace]
     );
 
     // See createResourceListPage for the watch-failure rationale.
@@ -114,12 +121,14 @@ export function createWorkloadListPage<T extends Workload>(
 
     const listQuery = useResourceList(
       queryKey,
-      () => config.fetchList({ namespace: currentNamespace || null }),
-      watchFactory && !watchFailed ? ({ refresh: false } as const) : undefined
+      listAcrossScope(scope.scope, (namespace) =>
+        config.fetchList({ namespace })
+      ),
+      watchEnabled && !watchFailed ? ({ refresh: false } as const) : undefined
     );
 
     const { resyncing } = useResourceWatch<T>({
-      enabled: !!watchFactory,
+      enabled: watchEnabled,
       subscribe,
       queryKey,
       onError: handleWatchError,
@@ -179,7 +188,7 @@ export function createWorkloadListPage<T extends Workload>(
         }
         error={listQuery.error}
         dataUpdatedAt={listQuery.dataUpdatedAt}
-        live={!!watchFactory && !watchFailed}
+        live={watchEnabled && !watchFailed}
         slowed={listQuery.freshness.slowed}
         getRowId={getResourceRowId}
         delivery={deliveryScopeOf(config.resourceType)}
@@ -201,9 +210,7 @@ export function createWorkloadListPage<T extends Workload>(
           mutationFn: async (item) => {
             await config.deleter(item);
           },
-          invalidateQueryKeys: [
-            queryKeys.resources(config.resourceType, currentNamespace),
-          ],
+          invalidateQueryKeys: [queryKey],
           resourceType: config.resourceType,
         }}
       />

--- a/src/hooks/usePodsWithMetrics.ts
+++ b/src/hooks/usePodsWithMetrics.ts
@@ -9,6 +9,8 @@ import { useMetrics } from "@/hooks/useMetrics";
 import { mergePodsWithMetrics, type PodWithMetrics } from "@/lib/metrics";
 import { STALE_TIMES } from "@/lib/refresh";
 import { useLiveQuery } from "@/hooks/useLiveQuery";
+import { useNamespaceScope } from "@/hooks/useNamespaceScope";
+import { listAcrossScope, scopeCacheKey } from "@/lib/namespace-scope";
 import { useSilentNodes } from "@/hooks/useSilentNodes";
 import { withNodeSilence, type WithNodeSilence } from "@/lib/node-reporting";
 import { queryKeys } from "@/lib/query-keys";
@@ -31,17 +33,21 @@ interface UsePodsWithMetricsOptions {
  */
 export function usePodsWithMetrics(options?: UsePodsWithMetricsOptions) {
   const t = useT();
-  const { isConnected, currentNamespace } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const scope = useNamespaceScope();
   const enabled = isConnected && options?.enabled !== false;
+
+  // The one namespace a watch or metrics call is scoped to. Several is read
+  // per namespace and polled instead — a cluster-wide LIST needs rights a
+  // namespace-scoped user may not have. See `listAcrossScope`.
+  const watchNamespace = scope.scope.length === 1 ? scope.scope[0] : null;
+  const cacheKey = scopeCacheKey(scope.scope);
 
   // Fetch pods - cached by TanStack Query. Real-time updates after
   // the initial fetch arrive through `useResourceWatch` below.
   // Polling falls back on if the watcher reports a sustained failure
   // (e.g. RBAC `watch` denial); see handleWatchError below.
-  const queryKey = useMemo(
-    () => queryKeys.pods(currentNamespace),
-    [currentNamespace]
-  );
+  const queryKey = useMemo(() => queryKeys.pods(cacheKey), [cacheKey]);
 
   const { toast } = useToast();
   const [watchFailed, setWatchFailed] = useState(false);
@@ -67,10 +73,10 @@ export function usePodsWithMetrics(options?: UsePodsWithMetricsOptions) {
     dataUpdatedAt,
   } = useLiveQuery({
     queryKey,
-    queryFn: async () => {
+    queryFn: listAcrossScope(scope.scope, async (namespace) => {
       try {
         return await commands.listPods({
-          namespace: currentNamespace || null,
+          namespace,
           labelSelector: null,
           fieldSelector: null,
           limit: null,
@@ -81,19 +87,20 @@ export function usePodsWithMetrics(options?: UsePodsWithMetricsOptions) {
       } catch (err) {
         throw new Error(normalizeTauriError(err), { cause: err });
       }
-    },
+    }),
     enabled,
     placeholderData: keepPreviousData,
     staleTime: STALE_TIMES.resourceList,
-    refresh: watchFailed ? "resourceList" : false,
+    // A watch covers none or one; several is polled (the watch is off below).
+    refresh: watchFailed || scope.several ? "resourceList" : false,
   });
 
   const subscribePods = useCallback(
-    () => commands.subscribePodWatch(currentNamespace || null),
-    [currentNamespace]
+    () => commands.subscribePodWatch(watchNamespace),
+    [watchNamespace]
   );
   const { resyncing } = useResourceWatch<PodInfo>({
-    enabled,
+    enabled: enabled && !scope.several,
     subscribe: subscribePods,
     queryKey,
     onError: handleWatchError,
@@ -101,7 +108,7 @@ export function usePodsWithMetrics(options?: UsePodsWithMetricsOptions) {
   });
 
   const { podMetrics, podStatus } = useMetrics({
-    namespace: currentNamespace || null,
+    namespace: watchNamespace,
     enabled,
     includeNodes: false,
   });

--- a/src/lib/namespace-scope.test.ts
+++ b/src/lib/namespace-scope.test.ts
@@ -5,7 +5,9 @@ import {
   clampScope,
   decodeScope,
   inScope,
+  listAcrossScope,
   sameScope,
+  scopeCacheKey,
   scopeIn,
   scopeLabel,
   inNamespace,
@@ -143,5 +145,47 @@ describe("the items a scoped rail counts", () => {
    *  fall back to all of them. */
   it("counts none when the picked namespace holds none", () => {
     expect(inNamespace(rows, "kube-system")).toHaveLength(0);
+  });
+});
+
+describe("reading a list across the selection", () => {
+  it("keys a multi-namespace selection apart from a single one and the cluster", () => {
+    expect(scopeCacheKey([])).toBeNull();
+    expect(scopeCacheKey(["prod"])).toBe("prod");
+    // Sorted and joined, so the same two namespaces in either order share a
+    // key, and a comma is a thing no real namespace name can hold.
+    expect(scopeCacheKey(["staging", "prod"])).toBe("prod,staging");
+    expect(scopeCacheKey(["prod", "staging"])).toBe(
+      scopeCacheKey(["staging", "prod"])
+    );
+  });
+
+  it("asks the cluster once for none selected, and that namespace for one", async () => {
+    const calls: Array<string | null> = [];
+    const fetchOne = async (ns: string | null) => {
+      calls.push(ns);
+      return [{ ns }];
+    };
+
+    expect(await listAcrossScope([], fetchOne)()).toEqual([{ ns: null }]);
+    expect(await listAcrossScope(["prod"], fetchOne)()).toEqual([
+      { ns: "prod" },
+    ]);
+    expect(calls).toEqual([null, "prod"]);
+  });
+
+  it("asks each namespace on its own and merges, for a selection of several", async () => {
+    // The bug this fixes: a cluster-wide LIST needs rights across the whole
+    // cluster, which a namespace-scoped user lacks — so several selected
+    // namespaces came back empty. Each is now read on its own.
+    const calls: Array<string | null> = [];
+    const fetchOne = async (ns: string | null) => {
+      calls.push(ns);
+      return [`${ns}-a`, `${ns}-b`];
+    };
+
+    const merged = await listAcrossScope(["prod", "staging"], fetchOne)();
+    expect(calls).toEqual(["prod", "staging"]);
+    expect(merged).toEqual(["prod-a", "prod-b", "staging-a", "staging-b"]);
   });
 });

--- a/src/lib/namespace-scope.ts
+++ b/src/lib/namespace-scope.ts
@@ -61,6 +61,38 @@ export function wireNamespace(scope: readonly string[]): string {
   return scope.length === 1 ? scope[0] : "";
 }
 
+/**
+ * The cache key a scoped list rides under: `null` or a single namespace as
+ * always, and a selection of several as its own key — sorted and joined, which
+ * no real namespace can be (a name holds no comma), so two multi-namespace
+ * selections never read each other's rows.
+ */
+export function scopeCacheKey(scope: readonly string[]): string | null {
+  if (scope.length === 0) return null;
+  if (scope.length === 1) return scope[0];
+  return [...scope].sort().join(",");
+}
+
+/**
+ * Read a list across the selection: none or one as a single `LIST`, several as
+ * one request per namespace, merged. A cluster-wide `LIST` needs list rights
+ * across the whole cluster, which a namespace-scoped RBAC user lacks — so every
+ * such selection came back empty and unexplained. Each namespace the user can
+ * read on its own, which is the whole point of the picker.
+ */
+export function listAcrossScope<T>(
+  scope: readonly string[],
+  fetchOne: (namespace: string | null) => Promise<T[]>
+): () => Promise<T[]> {
+  return async () => {
+    if (scope.length <= 1) {
+      return fetchOne(scope.length === 1 ? scope[0] : null);
+    }
+    const perNamespace = await Promise.all(scope.map((ns) => fetchOne(ns)));
+    return perNamespace.flat();
+  };
+}
+
 /** What a stored value means, including one an older build wrote. */
 export function decodeScope(stored: string | null | undefined): string[] {
   if (!stored) return [];


### PR DESCRIPTION
Fixes the core of #137: with two or more namespaces selected, every list came back empty for a namespace-scoped (RBAC-split-by-team) user, though each namespace was readable on its own.

## Root cause

A selection of several namespaces collapsed to the empty wire value, so the app asked the API server for a **cluster-wide LIST** and narrowed it client-side. That needs list rights across the whole cluster. Reproduced on a kind cluster with a ServiceAccount bound in two namespaces:

```
can-i list pods -n team-a   → yes
can-i list pods -n team-b   → yes
can-i list pods -A          → no      # what the old multi-namespace path asked for
```

So the cluster-wide LIST 403'd and the list rendered empty, with nothing saying why.

## Fix

`listAcrossScope` (one place, `lib/namespace-scope.ts`): none or one namespace stays a single request the API server scopes; **several is one request per namespace, merged** — each of which the user can do. The cache key now rides on the whole selection (`scopeCacheKey`) so two multi-namespace scopes don't read each other's rows, and the watch (a single cluster-wide stream) is switched off for a multi-namespace selection, which polls per namespace instead.

Wired through both list factories (`createResourceListPage`, `createWorkloadListPage`), pods, ingresses, PVCs and custom resources — one strategy, every reader. Admins with cluster-wide rights keep a single cluster-wide request for none/one selected; a multi-namespace selection costs one request per namespace, which `SCOPE_LIMIT` already bounds to four and the overview already pays.

## Verification

- Unit tests for `listAcrossScope` / `scopeCacheKey` (fan-out, merge, keying), sabotage-checked.
- Full frontend suite green (2255 tests); tsc, eslint clean.
- Root cause and strategy confirmed against a real RBAC-restricted kind cluster (above).

## Not covered here

`GatewayRoutesList` (a specialized multi-source hook for the niche Gateway API) still reads its routes the old way — a follow-up. `Events` already fans out per namespace.
