### PR TITLE
feat: namespace/RBAC picker and nav fixes (#137, #138)

### DIFF
--- a/src-tauri/src/commands/access.rs
+++ b/src-tauri/src/commands/access.rs
@@ -121,6 +121,62 @@ pub async fn check_list_access(
         .collect())
 }
 
+/// Whether this user may use a namespace at all.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NamespaceAccess {
+    pub namespace: String,
+    /// `None` where the cluster could not be asked — never folded into a
+    /// refusal. A namespace the app merely failed to check must keep being
+    /// offered, or it would vanish from the picker as if the reader had been
+    /// turned away from it.
+    pub allowed: Option<bool>,
+}
+
+/// The one list a namespace is probed with: pods, the verb any grant that
+/// makes a namespace worth selecting carries. One named place, spelled once.
+#[must_use]
+fn namespace_probe_query() -> ListQuery {
+    ListQuery {
+        group: String::new(),
+        resource: "pods".to_string(),
+        namespaced: true,
+    }
+}
+
+/// Ask the cluster which of these namespaces this user may use.
+///
+/// One review per namespace — "may I list pods in it" — asked at once. A
+/// namespace the authorizer will not answer about comes back `None`, kept
+/// offered rather than hidden: the same three-state discipline as
+/// [`check_list_access`].
+///
+/// # Errors
+///
+/// If there is no connected cluster.
+#[tauri::command]
+pub async fn check_namespace_access(
+    namespaces: Vec<String>,
+    state: State<'_, AppState>,
+) -> Result<Vec<NamespaceAccess>> {
+    let ctx = ResourceContext::for_list(&state, None)?;
+    let api: Api<SelfSubjectAccessReview> = Api::all(ctx.client.clone());
+    let probe = namespace_probe_query();
+
+    let answers = join_all(namespaces.iter().map(|namespace| {
+        let api = api.clone();
+        let attributes = list_attributes(&probe, Some(namespace));
+        async move { ask(&api, attributes).await }
+    }))
+    .await;
+
+    Ok(namespaces
+        .into_iter()
+        .zip(answers)
+        .map(|(namespace, allowed)| NamespaceAccess { namespace, allowed })
+        .collect())
+}
+
 /// The namespaces one kind has to be asked about.
 ///
 /// A cluster-scoped kind has exactly one answer however many namespaces are
@@ -218,6 +274,19 @@ mod tests {
         assert_eq!(resolve(&[]), None);
         assert_eq!(resolve(&[None, Some(true)]), Some(true));
         assert_eq!(resolve(&[None, Some(false)]), Some(false));
+    }
+
+    /// A namespace is probed by asking to list pods *in it* — a namespaced
+    /// question, so the namespace stays on the attributes. Asking cluster-wide
+    /// would answer whether the reader can list pods everywhere, which is the
+    /// opposite of what a team-scoped account has.
+    #[test]
+    fn probes_a_namespace_by_listing_pods_in_it() {
+        let attrs = list_attributes(&namespace_probe_query(), Some("team-a"));
+        assert_eq!(attrs.group.as_deref(), Some(""));
+        assert_eq!(attrs.resource.as_deref(), Some("pods"));
+        assert_eq!(attrs.verb.as_deref(), Some("list"));
+        assert_eq!(attrs.namespace.as_deref(), Some("team-a"));
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -124,6 +124,7 @@ fn main() {
             commands::cluster::get_cluster_info,
             commands::cluster::get_kubeconfig_source,
             commands::access::check_list_access,
+            commands::access::check_namespace_access,
             commands::binaries::locate_binaries,
             commands::diagnostics::collect_diagnostics,
             // Namespace management

--- a/src/components/layout/ScopeTabs.test.tsx
+++ b/src/components/layout/ScopeTabs.test.tsx
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+/** What the authorizer answers about each namespace, per test. */
+const nsAccess = vi.hoisted(() => ({
+  answers: [] as Array<{ namespace: string; allowed: boolean | null }>,
+}));
 
 vi.mock("@/lib/commands", () => ({
   commands: {
@@ -10,6 +15,7 @@ vi.mock("@/lib/commands", () => ({
     disconnectCluster: vi.fn(async () => undefined),
     saveClusterPreferences: vi.fn(async () => undefined),
     listContexts: vi.fn(async () => []),
+    checkNamespaceAccess: vi.fn(async () => nsAccess.answers),
   },
 }));
 
@@ -71,6 +77,7 @@ const tabs = () => screen.getAllByRole("tab");
 beforeEach(() => {
   localStorage.clear();
   summary.namespaces = [];
+  nsAccess.answers = [];
   useClusterIdentityStore.setState({ marks: {} });
   useClusterStore.setState({
     contexts: [],
@@ -265,6 +272,51 @@ describe("watching several namespaces at once", () => {
     // the summary's own order.
     expect(order.slice(0, 3)).toEqual(["all", "ns-3", "ns-4"]);
     expect(order.slice(3)).toEqual(["ns-0", "ns-1", "ns-2", "ns-5"]);
+  });
+
+  /**
+   * #137: on a cluster split across teams the reader can see namespaces they
+   * have no rights in. The picker stops offering the ones the authorizer
+   * firmly refuses — until asked to show them. Fails if a refused namespace
+   * is offered, or if the reveal stops bringing it back.
+   */
+  it("hides the namespaces the reader is refused, with a way to show them", async () => {
+    const user = userEvent.setup();
+    nsAccess.answers = [{ namespace: "ns-2", allowed: false }];
+    draw([]);
+    const list = await openPicker(user);
+
+    // The refused one is gone; the others stay.
+    await waitFor(() =>
+      expect(within(list).queryByRole("option", { name: /^ns-2,/ })).toBeNull()
+    );
+    expect(
+      within(list).getByRole("option", { name: /^ns-0,/ })
+    ).toBeInTheDocument();
+
+    // The footer says how many, and offers to show them.
+    await user.click(screen.getByRole("button", { name: /show them/i }));
+    expect(
+      within(list).getByRole("option", { name: /^ns-2,/ })
+    ).toBeInTheDocument();
+  });
+
+  /**
+   * The third state the hide must never swallow: a namespace the authorizer
+   * could not be asked about (null) is not a refusal, and stays offered.
+   */
+  it("keeps offering a namespace whose access could not be checked", async () => {
+    const user = userEvent.setup();
+    nsAccess.answers = [{ namespace: "ns-2", allowed: null }];
+    draw([]);
+    const list = await openPicker(user);
+
+    expect(
+      within(list).getByRole("option", { name: /^ns-2,/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /show them/i })
+    ).not.toBeInTheDocument();
   });
 
   /**

--- a/src/components/layout/ScopeTabs.test.tsx
+++ b/src/components/layout/ScopeTabs.test.tsx
@@ -242,6 +242,32 @@ describe("watching several namespaces at once", () => {
   });
 
   /**
+   * The reader from #137 stands in several namespaces on a cluster of many,
+   * and came to the list to turn one off. The ones already selected float to
+   * the top so they are found and deselected at a glance, instead of hunting
+   * them out of sixty. Would break if the list went back to raw summary order.
+   */
+  it("floats the selected namespaces to the top of the list", async () => {
+    const user = userEvent.setup();
+    // ns-3 and ns-4 are picked, and sit in the middle of the summary order.
+    draw(["ns-3", "ns-4"]);
+    const list = await openPicker(user);
+
+    const label = (option: HTMLElement) => {
+      const name = option.getAttribute("aria-label") ?? "";
+      return /^All namespaces/.test(name)
+        ? "all"
+        : (name.match(/^ns-\d+/)?.[0] ?? "?");
+    };
+    const order = within(list).getAllByRole("option").map(label);
+
+    // Row 0 is "All namespaces"; the two selected come next, then the rest in
+    // the summary's own order.
+    expect(order.slice(0, 3)).toEqual(["all", "ns-3", "ns-4"]);
+    expect(order.slice(3)).toEqual(["ns-0", "ns-1", "ns-2", "ns-5"]);
+  });
+
+  /**
    * Both gestures without a mouse, on a list that is one tab stop. Would
    * break if the rows went back to being focusable controls: an option's
    * children are presentational, so a button in one is announced as nothing

--- a/src/components/layout/ScopeTabs.tsx
+++ b/src/components/layout/ScopeTabs.tsx
@@ -24,6 +24,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useClusterSummary } from "@/hooks/useClusterSummary";
+import { useNamespaceAccess } from "@/hooks/useNamespaceAccess";
 import {
   clusterColor,
   detectProvider,
@@ -688,13 +689,27 @@ function NamespacePopover({
    *  reader came to deselect sit at the top — pinned at open rather than live,
    *  so a row does not slide out from under the pointer as it is toggled. */
   const [pinned, setPinned] = useState<readonly string[]>([]);
+  /** Whether the namespaces the reader has no access to are being shown
+   *  anyway — a per-open escape hatch, off again on close. */
+  const [showBlocked, setShowBlocked] = useState(false);
   const listId = useId();
   const noteId = `${listId}-note`;
+
+  const access = useNamespaceAccess(namespaces.map((ns) => ns.name));
 
   const needle = filter.trim().toLowerCase();
   const visible = needle
     ? namespaces.filter((ns) => ns.name.toLowerCase().includes(needle))
     : namespaces;
+
+  // A namespace the authorizer firmly refused is not offered. Never one the
+  // review could not reach (absent = unknown, kept) and never a selected one
+  // (hiding it would strand a scope the window is on); a reveal brings them
+  // back.
+  const usable = (name: string) =>
+    showBlocked || access.get(name) !== false || scope.includes(name);
+  const shown = visible.filter((ns) => usable(ns.name));
+  const hiddenCount = visible.length - shown.length;
 
   // Selected-at-open first, the rest after, each group keeping the summary's
   // own problem/pod/name order. A stable sort keyed only on membership does
@@ -702,7 +717,7 @@ function NamespacePopover({
   // below still read the live `scope`, so the ceiling and the checkmarks
   // stay honest as the reader toggles.
   const pinnedSet = new Set(pinned);
-  const ordered = [...visible].sort(
+  const ordered = [...shown].sort(
     (a, b) => Number(pinnedSet.has(b.name)) - Number(pinnedSet.has(a.name))
   );
 
@@ -803,6 +818,7 @@ function NamespacePopover({
           setFilter("");
           setCursor(-1);
           setRefused(null);
+          setShowBlocked(false);
         }
         onOpenChange(next);
       }}
@@ -891,6 +907,21 @@ function NamespacePopover({
                 ? t("empty", "noNamespacesVisible")
                 : t("empty", "nothingMatchesQuery", { query: filter })}
             </p>
+          )}
+          {hiddenCount > 0 && !showBlocked && (
+            // Not an option in the listbox: it is a sentence with a control,
+            // and no namespace to select. Says how many the reader was turned
+            // away from and offers to show them anyway.
+            <button
+              type="button"
+              onClick={() => setShowBlocked(true)}
+              className="flex w-full items-center justify-between gap-2 px-[7px] py-1.5 text-left text-[11px] text-fg-fnt"
+            >
+              <span>{t("count", "namespacesHidden", { n: hiddenCount })}</span>
+              <span className="underline underline-offset-2">
+                {t("action", "showInaccessibleNamespaces")}
+              </span>
+            </button>
           )}
         </div>
         {/* The ceiling is stated as a cost, not as a rule: each namespace

--- a/src/components/layout/ScopeTabs.tsx
+++ b/src/components/layout/ScopeTabs.tsx
@@ -684,6 +684,10 @@ function NamespacePopover({
   /** The namespace the ceiling has just turned down, until anything else
    *  happens. A refusal nobody is told about is a control that broke. */
   const [refused, setRefused] = useState<string | null>(null);
+  /** Which namespaces were selected when the list opened, so the ones the
+   *  reader came to deselect sit at the top — pinned at open rather than live,
+   *  so a row does not slide out from under the pointer as it is toggled. */
+  const [pinned, setPinned] = useState<readonly string[]>([]);
   const listId = useId();
   const noteId = `${listId}-note`;
 
@@ -691,6 +695,16 @@ function NamespacePopover({
   const visible = needle
     ? namespaces.filter((ns) => ns.name.toLowerCase().includes(needle))
     : namespaces;
+
+  // Selected-at-open first, the rest after, each group keeping the summary's
+  // own problem/pod/name order. A stable sort keyed only on membership does
+  // exactly that. Ordering is what changes here; `selected`/`closed`/`full`
+  // below still read the live `scope`, so the ceiling and the checkmarks
+  // stay honest as the reader toggles.
+  const pinnedSet = new Set(pinned);
+  const ordered = [...visible].sort(
+    (a, b) => Number(pinnedSet.has(b.name)) - Number(pinnedSet.has(a.name))
+  );
 
   const full = scope.length >= SCOPE_LIMIT;
 
@@ -706,7 +720,7 @@ function NamespacePopover({
       selected: scope.length === 0,
       closed: false,
     },
-    ...visible.map((ns) => ({
+    ...ordered.map((ns) => ({
       key: ns.name,
       label: ns.name,
       mono: true,
@@ -782,7 +796,10 @@ function NamespacePopover({
     <Popover
       open={open}
       onOpenChange={(next) => {
-        if (!next) {
+        if (next) {
+          // Freeze the selection to the top for as long as the list is open.
+          setPinned(scope);
+        } else {
           setFilter("");
           setCursor(-1);
           setRefused(null);

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -12,6 +12,7 @@ import type { ClusterOverview, DetectedExtension } from "@/generated/types";
 const detectInClusterExtensions = vi.fn<() => Promise<DetectedExtension[]>>();
 const listIngresses = vi.fn().mockResolvedValue([]);
 const listCustomResources = vi.fn().mockResolvedValue([]);
+const checkListAccess = vi.fn().mockResolvedValue([]);
 const resolveIngressClass = vi.fn().mockResolvedValue({
   requested: null,
   resolved: null,
@@ -27,6 +28,7 @@ vi.mock("@/lib/commands", () => ({
     listCustomResources: (crdName: string) => listCustomResources(crdName),
     resolveIngressClass: () => resolveIngressClass(),
     getClusterOverview: vi.fn().mockResolvedValue(null),
+    checkListAccess: () => checkListAccess(),
   },
 }));
 
@@ -65,6 +67,7 @@ beforeEach(() => {
   listIngresses.mockResolvedValue([]);
   listCustomResources.mockResolvedValue([]);
   detectInClusterExtensions.mockResolvedValue([]);
+  checkListAccess.mockResolvedValue([]);
   overview = undefined;
   useClusterStore.setState({ isConnected: true, currentContext: "prod" });
   useUpdaterStore.setState({ available: false });
@@ -266,6 +269,48 @@ describe("the Integrations category", () => {
     expect(
       screen.getByRole("link", { name: /AWS Load Balancer Controller/i })
     ).toHaveAttribute("href", "/integrations/aws-load-balancer-controller");
+  });
+
+  /**
+   * #138: a detected integration whose resources the reader is refused (403)
+   * must draw its row disabled with a reason, not link to a page that only
+   * errors. A mark, never a lock — the row stays a link. Fails if the gate
+   * check is dropped or the forbidden state stops reaching the row.
+   */
+  it("draws a detected vendor the reader cannot list as a denied row", async () => {
+    detectInClusterExtensions.mockResolvedValue([
+      { id: "flux", installed: true, version: "v2.3.0" },
+    ]);
+    // The authorizer refuses the flux page's primary list.
+    checkListAccess.mockResolvedValue([
+      { resource: "kustomizations", allowed: false },
+    ]);
+
+    wrap(<Sidebar />);
+
+    await screen.findByRole("link", { name: /Flux/ });
+    expect(
+      await screen.findByLabelText(/permission to list Flux/i)
+    ).toBeInTheDocument();
+  });
+
+  /**
+   * The other side of the three states: allowed, or could-not-ask, must never
+   * draw the lock. Fails if `forbidden` were set from anything but a firm
+   * `allowed === false`.
+   */
+  it("leaves a readable vendor row unlocked", async () => {
+    detectInClusterExtensions.mockResolvedValue([
+      { id: "flux", installed: true, version: "v2.3.0" },
+    ]);
+    checkListAccess.mockResolvedValue([
+      { resource: "kustomizations", allowed: true },
+    ]);
+
+    wrap(<Sidebar />);
+
+    await screen.findByRole("link", { name: /Flux/ });
+    expect(screen.queryByLabelText(/permission to list Flux/i)).toBeNull();
   });
 
   /**

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -513,6 +513,14 @@ function IntegrationsGroup() {
           overview={undefined}
           value={page.count}
           mark={page.tone ?? undefined}
+          // Detected but refused: the row is drawn disabled with a vendor
+          // reason instead of linking to a page that only errors.
+          denied={page.forbidden}
+          deniedReason={
+            page.forbidden
+              ? t("nav", "noVendorAccess", { vendor: page.name })
+              : undefined
+          }
           // A tunnel that is down is not a count and not a fault: it is a
           // thing this row can do something about, and says so.
           note={
@@ -649,6 +657,7 @@ function NavRow({
   mark,
   note,
   denied,
+  deniedReason,
   onPress,
   active,
 }: {
@@ -670,6 +679,12 @@ function NavRow({
    * clears, rather than a screen somebody cannot open.
    */
   denied?: boolean;
+  /**
+   * Why the row is denied, when a kind-agnostic row (an integration) can say
+   * something more specific than the generic "no permission to list". Falls
+   * back to `nav.noListAccess` for the resource rows that carry a kind.
+   */
+  deniedReason?: string;
   /**
    * A word at the end of the row instead of a count — for a state that is
    * neither a number nor a fault. A port-forward that is down is the case
@@ -717,9 +732,9 @@ function NavRow({
             // narrow, and would need translating into a space it does not have.
             <Lock
               className="ml-auto h-3 w-3 flex-none text-fg-fnt"
-              aria-label={t("nav", "noListAccess")}
+              aria-label={deniedReason ?? t("nav", "noListAccess")}
             >
-              <title>{t("nav", "noListAccess")}</title>
+              <title>{deniedReason ?? t("nav", "noListAccess")}</title>
             </Lock>
           )}
           {note !== undefined ? (

--- a/src/generated/commands.ts
+++ b/src/generated/commands.ts
@@ -64,6 +64,7 @@ import type {
   LokiPage,
   LokiProbe,
   ManifestResult,
+  NamespaceAccess,
   NamespaceInfo,
   NodeFilters,
   NodeInfo,
@@ -241,6 +242,12 @@ export async function checkListAccess(
   namespaces: string[]
 ): Promise<ListAccess[]> {
   return invoke<ListAccess[]>("check_list_access", { queries, namespaces });
+}
+
+export async function checkNamespaceAccess(
+  namespaces: string[]
+): Promise<NamespaceAccess[]> {
+  return invoke<NamespaceAccess[]>("check_namespace_access", { namespaces });
 }
 
 export async function listRegistryConfigs(): Promise<RegistryConfigInfo[]> {

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -1566,6 +1566,11 @@ export interface RegistryConfigInfo {
   token?: string;
 }
 
+export interface NamespaceAccess {
+  namespace: string;
+  allowed: boolean | null;
+}
+
 export interface ListAccess {
   resource: string;
   allowed: boolean | null;

--- a/src/hooks/useNamespaceAccess.ts
+++ b/src/hooks/useNamespaceAccess.ts
@@ -1,0 +1,44 @@
+/**
+ * Which namespaces this user may actually use, asked before the picker offers
+ * them — the wall {@link useListAccess} spares the nav, spared the picker. The
+ * map only ever removes an offer, and only on a firm refusal: a namespace the
+ * authorizer could not be asked about is absent, never `false`, so "could not
+ * check" is never drawn as "turned away".
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { commands } from "@/lib/commands";
+import { useClusterStore } from "@/stores/clusterStore";
+
+/** Rights change rarely, never within an open picker; matches useListAccess. */
+const REVIEW_FRESH_MS = 5 * 60 * 1000;
+
+/** Namespace name to whether the reader may use it; absent means unknown. */
+export type NamespaceAccessMap = Map<string, boolean>;
+
+export function useNamespaceAccess(names: string[]): NamespaceAccessMap {
+  const currentContext = useClusterStore((s) => s.currentContext);
+  const isConnected = useClusterStore((s) => s.isConnected);
+
+  // Sorted into the key: the same namespaces in a different order are one
+  // question, and keying on the order would ask it twice.
+  const sorted = [...names].sort();
+
+  const { data } = useQuery({
+    queryKey: ["namespace-access", currentContext, sorted],
+    queryFn: () => commands.checkNamespaceAccess(sorted),
+    enabled: isConnected && Boolean(currentContext) && names.length > 0,
+    staleTime: REVIEW_FRESH_MS,
+    retry: false,
+  });
+
+  const map: NamespaceAccessMap = new Map();
+  for (const answer of data ?? []) {
+    // `null`/`undefined` are both "could not ask", and both stay out.
+    if (answer.allowed !== null && answer.allowed !== undefined) {
+      map.set(answer.namespace, answer.allowed);
+    }
+  }
+  return map;
+}

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -505,6 +505,7 @@ export const en = {
     programmed: "Programmed",
   },
   action: {
+    showInaccessibleNamespaces: "Show them",
     connectToForward: "Connect to a cluster to start port-forwarding.",
     siteHasItAt: "{site} has it at {url}",
     addressOnClipboard:
@@ -4159,6 +4160,10 @@ export const en = {
       "timed out after 3s — packets go unanswered; a firewall, or the wrong address",
   },
   count: {
+    namespacesHidden: {
+      one: "{n} namespace hidden — no access",
+      other: "{n} namespaces hidden — no access",
+    },
     endpointsAcrossSlices: "{endpoints} across {slices}",
     endpointsCount: { one: "{n} endpoint", other: "{n} endpoints" },
     slicesCount: { one: "{n} slice", other: "{n} slices" },

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -58,6 +58,7 @@ export const en = {
     // The reader is not being told the app is broken: they are being told
     // whose decision it was, which is the one fact that makes it actionable.
     noListAccess: "You do not have permission to list these",
+    noVendorAccess: "You do not have permission to list {vendor}'s resources",
     relatedResources: "Related resources",
     runsOn: "Runs on",
     whatRunsHere: "What runs here",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -473,6 +473,7 @@ export const ru: Catalogue = {
     programmed: "Запрограммирован",
   },
   action: {
+    showInaccessibleNamespaces: "Показать",
     connectToForward: "Подключитесь к кластеру, чтобы начать проброс портов.",
     siteHasItAt: "{site} — по адресу {url}",
     addressOnClipboard: "Адрес {site} скопирован в буфер обмена: {url}",
@@ -4397,6 +4398,11 @@ export const ru: Catalogue = {
       "истекло 3 с — пакеты остаются без ответа: файрвол или неверный адрес",
   },
   count: {
+    namespacesHidden: {
+      one: "{n} пространство скрыто — нет доступа",
+      few: "{n} пространства скрыто — нет доступа",
+      other: "{n} пространств скрыто — нет доступа",
+    },
     endpointsAcrossSlices: "{endpoints} в {slices}",
     endpointsCount: {
       one: "{n} эндпоинт",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -35,6 +35,7 @@ export const ru: Catalogue = {
     mountedAt: "смонтирован в {path}",
     projectedInto: "проецируется в {path}",
     noListAccess: "У вас нет прав смотреть этот список",
+    noVendorAccess: "У вас нет прав смотреть ресурсы интеграции {vendor}",
     relatedResources: "Связанные ресурсы",
     runsOn: "Работает на",
     whatRunsHere: "Что здесь работает",

--- a/src/integrations/argocd/index.ts
+++ b/src/integrations/argocd/index.ts
@@ -45,6 +45,7 @@ export default defineVendor({
       staleTime: ARGO_STALE,
     }),
     load: () => import("./page"),
+    gate: { crd: "applications.argoproj.io", namespaced: true },
   },
   crd,
 });

--- a/src/integrations/cert-manager/index.ts
+++ b/src/integrations/cert-manager/index.ts
@@ -63,6 +63,7 @@ export default defineVendor({
       staleTime: CERT_MANAGER_STALE,
     }),
     load: () => import("./page"),
+    gate: { crd: "certificates.cert-manager.io", namespaced: true },
   },
   crd,
 });

--- a/src/integrations/flux/index.ts
+++ b/src/integrations/flux/index.ts
@@ -53,6 +53,10 @@ export default defineVendor({
       staleTime: FLUX_STALE,
     }),
     load: () => import("./page"),
+    gate: {
+      crd: "kustomizations.kustomize.toolkit.fluxcd.io",
+      namespaced: true,
+    },
   },
   crd,
 });

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -784,13 +784,10 @@ export interface IntegrationPageEntry {
    */
   asleep: boolean;
   /**
-   * The cluster's authorizer refused this reader the vendor's primary list,
-   * so its screen would only error — the row is drawn disabled with a reason.
-   *
-   * Set from the authorizer's `allowed === false` alone: a review that could
-   * not be asked (null) leaves this false, so "could not look" never renders
-   * as "forbidden". Distinct from `count === null`, which is a number that is
-   * loading, refused or uncountable.
+   * The authorizer refused this reader the vendor's primary list, so its
+   * screen would only error — the row is drawn disabled with a reason. Set
+   * from `allowed === false` alone, so a review that could not be asked never
+   * reads as forbidden; distinct from `count === null`.
    */
   forbidden: boolean;
 }

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -783,6 +783,16 @@ export interface IntegrationPageEntry {
    * says it is asleep; pressing it is what wakes it.
    */
   asleep: boolean;
+  /**
+   * The cluster's authorizer refused this reader the vendor's primary list,
+   * so its screen would only error — the row is drawn disabled with a reason.
+   *
+   * Set from the authorizer's `allowed === false` alone: a review that could
+   * not be asked (null) leaves this false, so "could not look" never renders
+   * as "forbidden". Distinct from `count === null`, which is a number that is
+   * loading, refused or uncountable.
+   */
+  forbidden: boolean;
 }
 
 /**
@@ -819,6 +829,8 @@ export function useIntegrationPages(): {
   const connections = useConnections();
 
   const context = useClusterStore((state) => state.currentContext);
+  const isConnected = useClusterStore((state) => state.isConnected);
+  const namespaceScope = useClusterStore((state) => state.namespaceScope);
   const saved = useClusterForwardStore((state) => state.forwards);
   const forwarded = new Set(
     forwardsFor(saved, context).map(([vendorId]) => vendorId)
@@ -877,6 +889,61 @@ export function useIntegrationPages(): {
     }),
   });
 
+  // The one list each detected vendor's page cannot open without. Ask the
+  // cluster's own authorizer once and draw the row disabled where it is
+  // refused — a screen that only errors is worse than one the reader was
+  // told not to open. Only detected vendors that declare a `gate` are asked.
+  const gated = here.filter(
+    (vendor): vendor is (typeof here)[number] & { page: VendorPage } =>
+      vendor.page?.gate !== undefined
+  );
+  const gateIds = (vendor: (typeof gated)[number]): string[] => {
+    const crd = vendor.page.gate!.crd;
+    return typeof crd === "string" ? [crd] : [...crd];
+  };
+  const gateQueries = gated.flatMap((vendor) =>
+    gateIds(vendor).map((id) => {
+      const dot = id.indexOf(".");
+      return {
+        group: id.slice(dot + 1),
+        resource: id.slice(0, dot),
+        namespaced: vendor.page.gate!.namespaced,
+      };
+    })
+  );
+  const namespaces = [...namespaceScope].sort();
+  const { data: gateAnswers } = useQuery({
+    queryKey: [
+      "integration-access",
+      context,
+      namespaces,
+      gateQueries.map((q) => q.resource).sort(),
+    ],
+    queryFn: () => commands.checkListAccess(gateQueries, namespaces),
+    enabled: isConnected && Boolean(context) && gateQueries.length > 0,
+    staleTime: 5 * 60 * 1000,
+    // A cluster that cannot answer leaves every row as it was — the state the
+    // app has always been in — rather than spending requests to hear it again.
+    retry: false,
+  });
+  // Plural resource -> allowed; null/undefined both mean "could not ask".
+  const allowedByResource = new Map(
+    (gateAnswers ?? []).map((answer) => [answer.resource, answer.allowed])
+  );
+  // Forbidden only when EVERY spelling of the gate was answered `false`. A
+  // could-not-ask (null), or any spelling allowed, leaves the row open — so a
+  // failed review never renders as a refusal.
+  const forbidden = new Set(
+    gated
+      .filter((vendor) => {
+        const answers = gateIds(vendor).map((id) =>
+          allowedByResource.get(id.slice(0, id.indexOf(".")))
+        );
+        return answers.length > 0 && answers.every((a) => a === false);
+      })
+      .map((vendor) => vendor.id)
+  );
+
   const pages = here.map((vendor): IntegrationPageEntry => {
     const index = withPages.findIndex(
       (candidate) => candidate.id === vendor.id
@@ -901,6 +968,7 @@ export function useIntegrationPages(): {
       count: measured?.count ?? null,
       tone: measured?.tone ?? null,
       own: index !== -1,
+      forbidden: forbidden.has(vendor.id),
     };
   });
 

--- a/src/integrations/istio/index.ts
+++ b/src/integrations/istio/index.ts
@@ -41,6 +41,7 @@ export default defineVendor({
       staleTime: ROUTING_STALE,
     }),
     load: () => import("./page"),
+    gate: { crd: "virtualservices.networking.istio.io", namespaced: true },
   },
   crd,
 });

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -875,6 +875,19 @@ export interface VendorPage {
    * first chunk is the difference between a facet and a cost everybody pays.
    */
   load: () => Promise<{ default: ComponentType }>;
+  /**
+   * The one list this page cannot do without — the custom resource whose 403
+   * makes the screen useless. When the cluster's own authorizer refuses the
+   * reader this list, the sidebar row is drawn disabled with a reason instead
+   * of linking to a page that only errors. Detected-but-forbidden and
+   * detected-and-readable are different states; a not-detected vendor has no
+   * row at all.
+   *
+   * The id is the CRD's `<plural>.<group>` (its `metadata.name`); an array
+   * lists alternative spellings of the SAME kind across a group rename, and
+   * the row is forbidden only when every spelling is refused.
+   */
+  gate?: { crd: string | readonly string[]; namespaced: boolean };
 }
 
 /**

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -877,15 +877,11 @@ export interface VendorPage {
   load: () => Promise<{ default: ComponentType }>;
   /**
    * The one list this page cannot do without — the custom resource whose 403
-   * makes the screen useless. When the cluster's own authorizer refuses the
-   * reader this list, the sidebar row is drawn disabled with a reason instead
-   * of linking to a page that only errors. Detected-but-forbidden and
-   * detected-and-readable are different states; a not-detected vendor has no
-   * row at all.
-   *
-   * The id is the CRD's `<plural>.<group>` (its `metadata.name`); an array
-   * lists alternative spellings of the SAME kind across a group rename, and
-   * the row is forbidden only when every spelling is refused.
+   * makes the screen useless. When the authorizer refuses the reader this
+   * list, the sidebar row is drawn disabled with a reason rather than linking
+   * to a page that only errors. The id is the CRD's `<plural>.<group>`; an
+   * array is alternative spellings of one kind across a group rename, refused
+   * only when every spelling is.
    */
   gate?: { crd: string | readonly string[]; namespaced: boolean };
 }

--- a/src/integrations/traefik/index.ts
+++ b/src/integrations/traefik/index.ts
@@ -45,6 +45,10 @@ export default defineVendor({
       staleTime: ROUTE_STALE,
     }),
     load: () => import("./page"),
+    gate: {
+      crd: ["ingressroutes.traefik.io", "ingressroutes.traefik.containo.us"],
+      namespaced: true,
+    },
   },
   crd,
 });

--- a/src/stores/scopeTabStore.test.ts
+++ b/src/stores/scopeTabStore.test.ts
@@ -169,19 +169,74 @@ describe("closing", () => {
     expect(state().pendingHref).toBeNull();
   });
 
-  // Zero tabs is a window with no scope and no chrome to pick one in.
-  it("resets the last tab instead of emptying the strip", async () => {
+  /**
+   * The reported #137 bug: the ✕ beside an open pod's name read as "close
+   * this view" but the store treated it as "leave the cluster", resetting
+   * context + namespace. A last tab on a page now returns to the overview
+   * with its connection and selection intact — like the peek ✕ and the
+   * detail back arrow. Fails if the route-aware branch of closeTab is deleted.
+   */
+  it("keeps the cluster and namespace when the last tab closes on a page", async () => {
     live("prod", "web");
-    seed([tab({ id: "a", context: "prod", namespace: "web", href: "/nodes" })]);
+    seed([
+      tab({
+        id: "a",
+        context: "prod",
+        namespace: "web",
+        href: "/pods/web/api",
+      }),
+    ]);
     await state().closeTab("a");
     expect(state().tabs).toHaveLength(1);
+    expect(state().tabs[0]).toMatchObject({
+      context: "prod",
+      namespace: "web",
+      href: "/",
+    });
+    expect(state().pendingHref).toBe("/");
+    expect(useClusterStore.getState().currentContext).toBe("prod");
+    expect(useClusterStore.getState().isConnected).toBe(true);
+  });
+
+  /**
+   * The one that must still reset: a last tab already at the overview is the
+   * fresh-install state and the only in-UI way back to the cluster picker.
+   * Fails if the keep-scope branch swallows the overview case too.
+   */
+  it("disconnects only when the last tab is already at the overview", async () => {
+    live("prod", "web");
+    seed([tab({ id: "a", context: "prod", namespace: "web", href: "/" })]);
+    await state().closeTab("a");
     expect(state().tabs[0]).toMatchObject({
       context: null,
       namespace: "",
       href: "/",
     });
-    expect(state().pendingHref).toBe("/");
     expect(useClusterStore.getState().currentContext).toBeNull();
+  });
+
+  /**
+   * The RBAC-split reader from #137 stands in several namespaces at once;
+   * closing a pod must carry that whole selection home, not throw it away.
+   */
+  it("carries a multi-namespace selection home when the last tab closes", async () => {
+    liveScope("prod", ["web", "api"]);
+    seed([
+      tab({
+        id: "a",
+        context: "prod",
+        namespace: "",
+        scope: ["web", "api"],
+        href: "/pods/web/burst",
+      }),
+    ]);
+    await state().closeTab("a");
+    expect(state().tabs[0]).toMatchObject({
+      context: "prod",
+      href: "/",
+      scope: ["web", "api"],
+    });
+    expect(useClusterStore.getState().isConnected).toBe(true);
   });
 });
 

--- a/src/stores/scopeTabStore.ts
+++ b/src/stores/scopeTabStore.ts
@@ -262,11 +262,29 @@ export const useScopeTabStore = create<ScopeTabState>()(
         const { tabs, activeId } = get();
         // The strip is the only way back to a scope, so it never empties: a
         // window with no tabs has no scope at all and nothing to put in its
-        // chrome. Closing the last one resets it to an empty scope on the
-        // overview instead, which is the state a fresh install boots into.
+        // chrome. Closing the last one has two meanings, told apart by where
+        // it sits:
+        //
+        //  - On a page (a pod, a list — any non-overview route), the ✕ beside
+        //    the name reads as "close this view", exactly as the peek panel's
+        //    ✕ and the detail page's back arrow do — both of which keep the
+        //    cluster and the namespace. So the tab returns to the overview
+        //    with its connection and selection intact.
+        //  - Already on the overview, it is the fresh-install reset — an empty
+        //    scope on a disconnected window, which is also the one way back to
+        //    the cluster picker.
         if (tabs.length < 2) {
+          const only = tabs[0];
+          if (only.href !== HOME && !only.missing) {
+            // Snapshot the live scope (the reader may have changed the
+            // namespace via the popover since this tab went live), keep it,
+            // and send the view home — no disconnect, no cleared namespace.
+            const parked = parkActive(tabs, only.id)[0];
+            set({ tabs: [{ ...parked, href: HOME }], pendingHref: HOME });
+            return;
+          }
           set({
-            tabs: [makeTab({ id: tabs[0].id })],
+            tabs: [makeTab({ id: only.id })],
             pendingHref: HOME,
           });
           // Disconnect first: switchNamespace only writes a preference while

--- a/src/stores/scopeTabStore.ts
+++ b/src/stores/scopeTabStore.ts
@@ -260,19 +260,12 @@ export const useScopeTabStore = create<ScopeTabState>()(
 
       closeTab: async (id: string) => {
         const { tabs, activeId } = get();
-        // The strip is the only way back to a scope, so it never empties: a
-        // window with no tabs has no scope at all and nothing to put in its
-        // chrome. Closing the last one has two meanings, told apart by where
-        // it sits:
-        //
-        //  - On a page (a pod, a list — any non-overview route), the ✕ beside
-        //    the name reads as "close this view", exactly as the peek panel's
-        //    ✕ and the detail page's back arrow do — both of which keep the
-        //    cluster and the namespace. So the tab returns to the overview
-        //    with its connection and selection intact.
-        //  - Already on the overview, it is the fresh-install reset — an empty
-        //    scope on a disconnected window, which is also the one way back to
-        //    the cluster picker.
+        // The strip never empties — a window with no tabs has no scope. So
+        // closing the last one has two meanings, told apart by where it sits:
+        // on a page, the ✕ reads as "close this view" like the peek ✕ and the
+        // detail back arrow, and returns to the overview keeping the cluster
+        // and namespace; already on the overview, it is the fresh-install
+        // reset (disconnect, empty scope) and the one way back to the picker.
         if (tabs.length < 2) {
           const only = tabs[0];
           if (only.href !== HOME && !only.missing) {


### PR DESCRIPTION
The rest of issues #137/#138, after the multi-namespace list fix (#141). Investigated with a small fan-out of read-only agents, then implemented and tested each; every fix is sabotage-checked.

## Fixed

- **Closing a pod keeps the cluster and namespace (#137).** The ✕ beside an open pod sits on its scope tab, and closing the last tab always disconnected and cleared the namespace — so closing a pod reset the whole flow and dropped the reader at the cluster picker. A last tab on a page now returns to the overview with its connection and selection (multi-namespace included) intact; only a tab already at the overview still resets, which stays the one way back to the picker. The peek ✕ and the detail back-arrow already did the right thing.
- **Selected namespaces float to the top of the picker (#137).** On a cluster of many, the ones a reader had selected were scattered, so turning one off meant hunting. They now sort to the top, pinned when the list opens so a row does not slide out from under the pointer as it is toggled.
- **A detected integration you cannot read is a disabled row (#138).** Flux, Istio, cert-manager and the rest are detected from their CRDs; a reader whose RBAC does not reach those resources got a live row that only errored. Each page now declares its primary list as a gate; the cluster's own authorizer is asked once, and a refused vendor row is drawn disabled with a reason — reusing the Lock+tooltip path the resource and Gateway rows already use.
- **The picker stops offering namespaces you cannot use (#137).** A team-scoped reader could see every namespace the API server names, most of which they have no rights inside. A new `check_namespace_access` asks the authorizer "may I list pods here" per namespace; the picker drops the ones it firmly refuses, with a "show them" reveal.

All four reuse the app's existing "three states, not two" discipline: a refusal is `allowed === false` alone, so "could not ask" never renders as "forbidden", and a selected namespace is never hidden out from under the window that points at it.

## Verification

- Unit/component tests for each, sabotage-checked; full frontend suite green (2259); Rust `access` tests pass; tsc, eslint, clippy clean.
- One new backend command (`check_namespace_access`) + one generated-bindings regen.
