### PR TITLE
fix: finish the namespace scope (gateway routes, helm) and stop the pty echo flake

### DIFF
--- a/src-tauri/src/auth/interactive/cred.rs
+++ b/src-tauri/src/auth/interactive/cred.rs
@@ -703,6 +703,13 @@ mod tests {
         // and does not get on with the child until something answers. In the
         // app xterm answers; here nothing would, and the plugin would sit
         // there printing nothing until the flow timed out.
+        //
+        // Only `ConPTY` asks. A Unix pty asks nothing, and `cat FILE` never
+        // reads stdin — so on Unix this write reaches only the line
+        // discipline, which echoes it (`^[[1;1R`) back into the same stream
+        // the reader is collecting and, under load, into the middle of the
+        // token. Answer only where the question is actually asked.
+        #[cfg(windows)]
         adapter
             .write_input(b"\x1b[1;1R")
             .await

--- a/src-tauri/src/commands/overview.rs
+++ b/src-tauri/src/commands/overview.rs
@@ -289,6 +289,11 @@ pub struct ClusterOverview {
     /// unlike pods they do not multiply per workload), and a truncated node
     /// list would hide exactly the node someone is looking for.
     pub nodes: Vec<NodeSummary>,
+    /// False when the cluster-wide node/pod reads the capacity view needs were
+    /// refused — a namespace-scoped token has no cluster read rights. `nodes`
+    /// and `scheduler` are then empty and mean "unknown", not "no capacity":
+    /// the panels say so rather than drawing a cluster with zero headroom.
+    pub nodes_known: bool,
     pub warnings: Vec<WarningGroup>,
     pub namespaces: Vec<NamespaceLoad>,
     /// Objects per kind in the requested scope, for the sidebar and the
@@ -962,6 +967,9 @@ struct OverviewInputs<'a> {
     /// allocatable. Same slice as `scoped_pods` when nothing is selected.
     accounting_pods: &'a [Pod],
     nodes: &'a [Node],
+    /// False when the node list (or the cluster-wide accounting pods) was
+    /// refused: the capacity view is unknown, not empty.
+    nodes_known: bool,
     /// `None` when the Deployment list was refused: the problems it feeds are
     /// one section of the screen, not the screen.
     deployments: Option<&'a [Deployment]>,
@@ -976,9 +984,13 @@ struct OverviewInputs<'a> {
 
 fn build_overview(input: &OverviewInputs<'_>) -> ClusterOverview {
     let metrics_available = input.usage_by_node.is_some();
+    // A refused capacity read is unknown, not an empty cluster: draw from no
+    // nodes so the scheduler headroom is not a confident zero, and let the
+    // `nodes_known` flag below tell the panels to say "no access" instead.
+    let nodes: &[Node] = if input.nodes_known { input.nodes } else { &[] };
     let accounting = account_by_node(input.accounting_pods);
     let aggregate = summarize_nodes(
-        input.nodes,
+        nodes,
         &accounting.requests,
         &accounting.pods,
         input.usage_by_node.as_ref(),
@@ -986,16 +998,17 @@ fn build_overview(input: &OverviewInputs<'_>) -> ClusterOverview {
 
     let mut problems = pod_problems(input.scoped_pods, input.now);
     problems.extend(deployment_problems(input.deployments.unwrap_or_default()));
-    problems.extend(node_problems(input.nodes));
+    problems.extend(node_problems(nodes));
     let (problems, problems_truncated) = rank_and_cap(problems);
 
     // The lists this query already had to read answer their own counts, so
-    // those four kinds cost no extra request.
+    // those four kinds cost no extra request. A refused node read is `None`,
+    // not `Some(0)` — the same distinction the other counts make.
     let counts = ResourceCounts {
         pods: Some(input.scoped_pods.len()),
         deployments: input.deployments.map(<[Deployment]>::len),
         jobs: input.jobs.map(<[Job]>::len),
-        nodes: Some(input.nodes.len()),
+        nodes: input.nodes_known.then_some(input.nodes.len()),
         ..input.counts.clone()
     };
 
@@ -1004,6 +1017,7 @@ fn build_overview(input: &OverviewInputs<'_>) -> ClusterOverview {
         problems_truncated,
         scheduler: aggregate.scheduler,
         nodes: aggregate.summaries,
+        nodes_known: input.nodes_known,
         warnings: recent_warnings(input.events),
         counts,
         pods: pod_composition(input.scoped_pods),
@@ -1092,22 +1106,38 @@ pub async fn get_cluster_overview(
         count_of(&events_api),
     );
 
+    // The scoped pod read is the one load-bearing read: with no pods in the
+    // selected scope there is no screen to draw. On the whole cluster it is
+    // the cluster-wide list, so a token with no cluster read rights fails here
+    // and the page shows the refusal (and says to pick a namespace).
     let pods = pods_result.map_err(Error::from)?.items;
+    // The node list and the cluster-wide accounting pods are cluster-scoped
+    // reads a namespace-restricted token is refused. They degrade to "unknown"
+    // rather than failing the whole overview, so a scoped user still sees the
+    // workloads they CAN read with the capacity view marked no-access.
     let cluster_pods = cluster_pods_result
         .transpose()
-        .map_err(Error::from)?
+        .ok()
+        .flatten()
         .map(|list| list.items);
-    let nodes = nodes_result.map_err(Error::from)?.items;
-    // Pods and nodes are load-bearing — the scheduler panel and every node row
-    // are built from them, so losing either means there is no screen to draw.
-    // Deployments and Jobs feed one section each and degrade instead.
+    let nodes = nodes_result.ok().map(|list| list.items);
     let deployments = deployments_result.ok().map(|list| list.items);
     let jobs = jobs_result.ok().map(|list| list.items);
+
+    // The capacity view needs both the nodes and cluster-wide pod requests.
+    // When a namespace is selected those are a separate cluster-wide fetch;
+    // on the whole cluster the scoped pods already are that fetch.
+    let accounting_known = match ctx.namespace {
+        Some(_) => cluster_pods.is_some(),
+        None => true,
+    };
+    let nodes_known = nodes.is_some() && accounting_known;
 
     Ok(build_overview(&OverviewInputs {
         scoped_pods: &pods,
         accounting_pods: cluster_pods.as_deref().unwrap_or(&pods),
-        nodes: &nodes,
+        nodes: nodes.as_deref().unwrap_or_default(),
+        nodes_known,
         deployments: deployments.as_deref(),
         jobs: jobs.as_deref(),
         events: &events,
@@ -1259,6 +1289,7 @@ mod tests {
             scoped_pods,
             accounting_pods,
             nodes: &[node("n1", "4", "8Gi"), node("n2", "4", "8Gi")],
+            nodes_known: true,
             deployments: Some(&[]),
             jobs: Some(&[]),
             events: &[],
@@ -1293,6 +1324,58 @@ mod tests {
             since: since.map(str::to_string),
             restarts: None,
         }
+    }
+
+    /// A namespace-scoped token is refused the cluster-wide node and pod reads
+    /// the capacity view needs, so those come back unknown. The workloads the
+    /// user CAN read stay on the screen; the nodes and scheduler are marked
+    /// no-access, and the node count is `None`, never a confident `Some(0)`.
+    #[test]
+    fn a_refused_node_read_leaves_the_capacity_view_unknown_not_empty() {
+        let pods = [
+            pod(
+                "api",
+                PodStatus {
+                    phase: Some("Running".to_string()),
+                    ..Default::default()
+                },
+            ),
+            pod(
+                "web",
+                PodStatus {
+                    phase: Some("Running".to_string()),
+                    ..Default::default()
+                },
+            ),
+        ];
+        let result = build_overview(&OverviewInputs {
+            scoped_pods: &pods,
+            accounting_pods: &pods,
+            // Nodes were handed in, but the flag says they could not be read:
+            // they must be ignored, not drawn and not counted.
+            nodes: &[node("n1", "4", "8Gi")],
+            nodes_known: false,
+            deployments: Some(&[]),
+            jobs: Some(&[]),
+            events: &[],
+            usage_by_node: None,
+            counts: ResourceCounts::default(),
+            namespace: Some("team-a"),
+            now: Utc::now(),
+        });
+
+        assert!(!result.nodes_known, "a refused node read is unknown");
+        assert!(
+            result.nodes.is_empty(),
+            "no node rows are drawn from a read that was refused"
+        );
+        assert_eq!(
+            result.counts.nodes, None,
+            "the node count is unknown, not zero"
+        );
+        // The workloads the user could read are still on the screen.
+        assert_eq!(result.counts.pods, Some(2));
+        assert_eq!(result.pods.running, 2);
     }
 
     /// A missing metrics-server comes back as `Ok` with a `NotInstalled`
@@ -1342,6 +1425,7 @@ mod tests {
             scoped_pods: &[],
             accounting_pods: &[],
             nodes: &[node("n1", "4", "8Gi")],
+            nodes_known: true,
             deployments: Some(&[]),
             jobs: Some(&[]),
             events: &[],
@@ -1799,6 +1883,7 @@ mod tests {
             scoped_pods: &pods,
             accounting_pods: &pods,
             nodes: &[node("n1", "4", "8Gi")],
+            nodes_known: true,
             deployments: None,
             jobs: None,
             events: &[],
@@ -1839,6 +1924,7 @@ mod tests {
             scoped_pods: &scoped,
             accounting_pods: &cluster,
             nodes: &[node("n1", "4", "8Gi"), node("n2", "4", "8Gi")],
+            nodes_known: true,
             deployments: Some(&deployments),
             jobs: Some(&jobs),
             events: &[],

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -22,10 +22,13 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Error, Debug)]
 pub enum Error {
     /// Kubernetes API errors
-    #[error("Kubernetes API error: {0}")]
+    #[error("Kubernetes API error: {}", .0.display_clean())]
     // `#[source]` is explicit because the `#[from]` that used to imply it is
     // gone: the conversion now branches on the status code, and the search
     // fan-out walks this chain to find the sentence a reader can act on.
+    // `display_clean` rather than the plain `Display`: kube 4 appends the whole
+    // `Status` struct's `Debug` to an API error, and that dump reaches the
+    // reader — see `KubeErrorExt` below.
     KubeApi(#[source] kube::Error),
 
     /// The cluster no longer accepts the credentials this session holds.
@@ -181,6 +184,30 @@ impl From<kube::Error> for Error {
     }
 }
 
+/// The one sentence in a kube error a reader can act on.
+///
+/// kube 4 made `Error::Api` carry a boxed `Status`, and its `Display` now ends
+/// with that struct's `Debug` — `pods is forbidden: … Forbidden (Status {
+/// status: Some(Failure), metadata: Some(ListMeta { … }), details: … })`. The
+/// tail is a wall of `None`s no reader wants, and it crosses the IPC boundary
+/// onto the screen. Rebuild the message from the status; leave every other
+/// kube error exactly as it displays.
+trait KubeErrorExt {
+    fn display_clean(&self) -> String;
+}
+
+impl KubeErrorExt for kube::Error {
+    fn display_clean(&self) -> String {
+        match self {
+            kube::Error::Api(status) if !status.reason.is_empty() => {
+                format!("ApiError: {}: {}", status.message, status.reason)
+            }
+            kube::Error::Api(status) => format!("ApiError: {}", status.message),
+            other => other.to_string(),
+        }
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(err: serde_json::Error) -> Self {
         Error::Serialization(err.to_string())
@@ -282,6 +309,29 @@ mod tests {
             metadata: None,
             details: None,
         }))
+    }
+
+    /// kube 4 ends an API error's `Display` with the whole `Status` struct's
+    /// `Debug`, and that string is what crosses to the screen. The reader gets
+    /// the sentence and the reason; the struct dump — `Status { … }`,
+    /// `ListMeta { … }` — is gone.
+    #[test]
+    fn a_kube_api_error_is_shown_without_the_status_struct_dump() {
+        let err: Error = api_error(403, "Forbidden").into();
+        let shown = err.to_string();
+        assert!(
+            shown.contains("the server has asked for the client to provide credentials"),
+            "the message a reader acts on is lost: {shown}"
+        );
+        assert!(shown.contains("Forbidden"), "the reason is lost: {shown}");
+        assert!(
+            !shown.contains("Status {"),
+            "the Status struct dump leaked onto the screen: {shown}"
+        );
+        assert!(
+            !shown.contains("ListMeta"),
+            "the metadata dump leaked onto the screen: {shown}"
+        );
     }
 
     /// Would send the reader back to a screen that says the cluster is empty.

--- a/src/components/helm/HelmReleasesTab.test.tsx
+++ b/src/components/helm/HelmReleasesTab.test.tsx
@@ -49,17 +49,27 @@ function mount(props: Partial<Parameters<typeof HelmReleasesTab>[0]> = {}) {
 }
 
 describe("what the releases tab does when the read fails", () => {
+  // The errors are raw strings on purpose: the query's thrown value is not
+  // guaranteed to be an Error, and reading `.message` off a string (the old
+  // code did) throws mid-render. Passing an Error here would test a shape the
+  // page need not produce and hide that crash — so these are strings, the
+  // harsher case.
   it("names a refusal instead of showing an empty table", () => {
-    mount({ error: new Error("secrets is forbidden (code: 403)") });
+    mount({
+      error:
+        "Tauri command 'listHelmReleasesNative' failed: secrets is forbidden (code: 403)",
+    });
 
     expect(
       screen.getByText(/do not have permission to list/i)
     ).toBeInTheDocument();
     expect(screen.getByText(/secrets is forbidden/)).toBeInTheDocument();
+    // The framing prefix is off the message.
+    expect(screen.queryByText(/Tauri command/)).not.toBeInTheDocument();
   });
 
   it("calls a non-refusal failure a read error, not a refusal", () => {
-    mount({ error: new Error("error trying to connect: connection refused") });
+    mount({ error: "error trying to connect: connection refused" });
 
     expect(
       screen.getByText(/Could not read Helm releases/i)
@@ -72,7 +82,7 @@ describe("what the releases tab does when the read fails", () => {
   it("still shows the rows a readable namespace returned despite a sibling's refusal", () => {
     mount({
       releases: [release("api"), release("web")],
-      error: new Error("secrets is forbidden (code: 403)"),
+      error: "secrets is forbidden (code: 403)",
     });
 
     // Rows present -> the table, not the refusal block.

--- a/src/components/helm/HelmReleasesTab.test.tsx
+++ b/src/components/helm/HelmReleasesTab.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * A Helm-release list read that the cluster refused must read as a refusal —
+ * not as an empty "no releases" table, which is the empty-collection-on-a-403
+ * collapse the app exists to prevent. A refusal that still returned some rows
+ * (another namespace answered) shows those rows. Deleting the error branch or
+ * the isRefusal split puts the silent-empty-table back.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { HelmRelease } from "@/generated/types";
+import { HelmReleasesTab } from "./HelmReleasesTab";
+
+const release = (name: string): HelmRelease => ({
+  name,
+  namespace: "team-a",
+  revision: 1,
+  status: "deployed",
+  chart: "nginx-1.0.0",
+  appVersion: "1.0.0",
+  updated: "2026-09-05T10:00:00Z",
+  source: "native",
+  suspended: false,
+  sourceRef: null,
+});
+
+function mount(props: Partial<Parameters<typeof HelmReleasesTab>[0]> = {}) {
+  return render(
+    <MemoryRouter>
+      <TooltipProvider>
+        <HelmReleasesTab
+          releases={[]}
+          isLoading={false}
+          error={null}
+          helmCliAvailable={true}
+          onRefetch={vi.fn()}
+          onShowHistory={vi.fn()}
+          onUpgrade={vi.fn()}
+          onRollback={vi.fn()}
+          onUninstall={vi.fn()}
+          {...props}
+        />
+      </TooltipProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("what the releases tab does when the read fails", () => {
+  it("names a refusal instead of showing an empty table", () => {
+    mount({ error: new Error("secrets is forbidden (code: 403)") });
+
+    expect(
+      screen.getByText(/do not have permission to list/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/secrets is forbidden/)).toBeInTheDocument();
+  });
+
+  it("calls a non-refusal failure a read error, not a refusal", () => {
+    mount({ error: new Error("error trying to connect: connection refused") });
+
+    expect(
+      screen.getByText(/Could not read Helm releases/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/do not have permission to list/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("still shows the rows a readable namespace returned despite a sibling's refusal", () => {
+    mount({
+      releases: [release("api"), release("web")],
+      error: new Error("secrets is forbidden (code: 403)"),
+    });
+
+    // Rows present -> the table, not the refusal block.
+    expect(screen.getByText("api")).toBeInTheDocument();
+    expect(screen.getByText("web")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/do not have permission to list/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/helm/HelmReleasesTab.tsx
+++ b/src/components/helm/HelmReleasesTab.tsx
@@ -20,13 +20,6 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { RouteLink } from "@/components/ui/route-link";
 import { StatusBadge } from "@/components/ui/status-badge";
 import {
@@ -39,7 +32,6 @@ import type { HelmRelease } from "@/generated/types";
 import { formatDate } from "@/lib/utils";
 
 import { SourceIcon } from "./SourceIcon";
-import { EVERY_NAMESPACE } from "@/lib/query-keys";
 import { useT } from "@/i18n/useT";
 import { T } from "@/i18n/T";
 
@@ -53,9 +45,6 @@ export interface HelmReleasesTabProps {
   releases: HelmRelease[];
   isLoading: boolean;
   helmCliAvailable: boolean;
-  namespaces: string[];
-  selectedNamespace: string;
-  onNamespaceChange: (next: string) => void;
   onRefetch: () => void;
   onShowHistory: (release: HelmRelease) => void;
   onUpgrade: (release: HelmRelease) => void;
@@ -67,9 +56,6 @@ export function HelmReleasesTab({
   releases,
   isLoading,
   helmCliAvailable,
-  namespaces,
-  selectedNamespace,
-  onNamespaceChange,
   onRefetch,
   onShowHistory,
   onUpgrade,
@@ -280,25 +266,7 @@ export function HelmReleasesTab({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-2">
-        <Select value={selectedNamespace} onValueChange={onNamespaceChange}>
-          <SelectTrigger
-            aria-label={t("columns", "namespace")}
-            className="h-6 w-44 gap-1 border-0 bg-transparent px-1.5 text-[11px] text-fg-mut hover:bg-hover focus:ring-0 focus:ring-offset-0"
-          >
-            <SelectValue placeholder={t("action", "allNamespaces")} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={EVERY_NAMESPACE}>
-              {t("action", "allNamespaces")}
-            </SelectItem>
-            {namespaces.map((ns) => (
-              <SelectItem key={ns} value={ns}>
-                {ns}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+      <div className="flex items-center">
         <div className="ml-auto">
           <DetailAction
             label={t("action", "refresh")}

--- a/src/components/helm/HelmReleasesTab.tsx
+++ b/src/components/helm/HelmReleasesTab.tsx
@@ -32,6 +32,7 @@ import type { HelmRelease } from "@/generated/types";
 import { formatDate } from "@/lib/utils";
 
 import { SourceIcon } from "./SourceIcon";
+import { isRefusal, verbatim } from "@/lib/error-utils";
 import { useT } from "@/i18n/useT";
 import { T } from "@/i18n/T";
 
@@ -44,6 +45,7 @@ const helmReleaseHref = (row: HelmRelease) =>
 export interface HelmReleasesTabProps {
   releases: HelmRelease[];
   isLoading: boolean;
+  error: Error | null;
   helmCliAvailable: boolean;
   onRefetch: () => void;
   onShowHistory: (release: HelmRelease) => void;
@@ -55,6 +57,7 @@ export interface HelmReleasesTabProps {
 export function HelmReleasesTab({
   releases,
   isLoading,
+  error,
   helmCliAvailable,
   onRefetch,
   onShowHistory,
@@ -277,15 +280,32 @@ export function HelmReleasesTab({
         </div>
       </div>
 
-      <DataTable
-        columns={columns}
-        data={releases}
-        isLoading={isLoading}
-        searchPlaceholder={t("action", "searchReleases")}
-        searchKey="name"
-        getRowId={getHelmReleaseRowId}
-        getRowHref={helmReleaseHref}
-      />
+      {error && releases.length === 0 ? (
+        <div className="max-w-[68ch] py-8">
+          <p className="text-xs text-err">
+            {/* A refusal is not a failure: saying "could not read" about one
+                invites a retry the cluster will refuse again. */}
+            {isRefusal(error)
+              ? t("nav", "noListAccess")
+              : t("empty", "couldNotReadInScope", {
+                  label: t("empty", "helmReleases"),
+                })}
+          </p>
+          <p className="mt-1.5 select-text wrap-break-word font-mono text-[11px] text-fg-fnt">
+            {verbatim(error.message)}
+          </p>
+        </div>
+      ) : (
+        <DataTable
+          columns={columns}
+          data={releases}
+          isLoading={isLoading}
+          searchPlaceholder={t("action", "searchReleases")}
+          searchKey="name"
+          getRowId={getHelmReleaseRowId}
+          getRowHref={helmReleaseHref}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/helm/HelmReleasesTab.tsx
+++ b/src/components/helm/HelmReleasesTab.tsx
@@ -32,7 +32,7 @@ import type { HelmRelease } from "@/generated/types";
 import { formatDate } from "@/lib/utils";
 
 import { SourceIcon } from "./SourceIcon";
-import { isRefusal, verbatim } from "@/lib/error-utils";
+import { errorToShow, isRefusal } from "@/lib/error-utils";
 import { useT } from "@/i18n/useT";
 import { T } from "@/i18n/T";
 
@@ -45,7 +45,9 @@ const helmReleaseHref = (row: HelmRelease) =>
 export interface HelmReleasesTabProps {
   releases: HelmRelease[];
   isLoading: boolean;
-  error: Error | null;
+  /** `unknown`, not `Error`: the query's thrown value is not guaranteed to be
+   *  an Error, and `errorToShow`/`isRefusal` both take it as-is. */
+  error: unknown;
   helmCliAvailable: boolean;
   onRefetch: () => void;
   onShowHistory: (release: HelmRelease) => void;
@@ -292,7 +294,7 @@ export function HelmReleasesTab({
                 })}
           </p>
           <p className="mt-1.5 select-text wrap-break-word font-mono text-[11px] text-fg-fnt">
-            {verbatim(error.message)}
+            {errorToShow(error)}
           </p>
         </div>
       ) : (

--- a/src/components/layout/ScopeTabs.tsx
+++ b/src/components/layout/ScopeTabs.tsx
@@ -631,8 +631,9 @@ interface NamespaceOption {
   key: string;
   label: string;
   mono: boolean;
-  podCount: number;
-  problemCount: number;
+  /** `null` when the cluster-wide overview was refused — unknown, drawn "—". */
+  podCount: number | null;
+  problemCount: number | null;
   selected: boolean;
   /** The selection is full, so this row can only be opened on its own. */
   closed: boolean;
@@ -964,7 +965,8 @@ function NamespaceRow({
   onToggle: () => void;
 }) {
   const t = useT();
-  const pods = t("cluster", "podCount", { n: row.podCount });
+  const pods =
+    row.podCount === null ? "—" : t("cluster", "podCount", { n: row.podCount });
   return (
     <div
       id={id}
@@ -974,8 +976,8 @@ function NamespaceRow({
       aria-label={[
         row.label,
         pods,
-        row.problemCount > 0
-          ? t("count", "withAProblem", { n: row.problemCount })
+        (row.problemCount ?? 0) > 0
+          ? t("count", "withAProblem", { n: row.problemCount ?? 0 })
           : null,
       ]
         .filter(Boolean)
@@ -1026,12 +1028,14 @@ function NamespaceRow({
       <span
         className={cn(
           "font-mono text-[11px]",
-          row.problemCount > 0 ? "text-err" : "text-fg-fnt"
+          (row.problemCount ?? 0) > 0 ? "text-err" : "text-fg-fnt"
         )}
       >
-        {row.problemCount > 0
-          ? `${row.podCount} · ${t("count", "badPods", { n: row.problemCount })}`
-          : row.podCount}
+        {row.podCount === null
+          ? "—"
+          : (row.problemCount ?? 0) > 0
+            ? `${row.podCount} · ${t("count", "badPods", { n: row.problemCount ?? 0 })}`
+            : row.podCount}
       </span>
     </div>
   );

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import userEvent from "@testing-library/user-event";
@@ -20,6 +20,12 @@ const resolveIngressClass = vi.fn().mockResolvedValue({
   viaDefault: false,
   available: [],
 });
+const detectGatewayApi = vi.fn();
+const listGatewayRoutes = vi.fn();
+const listGateways = vi.fn();
+const listGatewayClasses = vi.fn();
+const listServices = vi.fn();
+const listServiceEndpoints = vi.fn();
 
 vi.mock("@/lib/commands", () => ({
   commands: {
@@ -29,6 +35,13 @@ vi.mock("@/lib/commands", () => ({
     resolveIngressClass: () => resolveIngressClass(),
     getClusterOverview: vi.fn().mockResolvedValue(null),
     checkListAccess: () => checkListAccess(),
+    detectGatewayApi: () => detectGatewayApi(),
+    listGatewayRoutes: (kind: string, ns: string | null) =>
+      listGatewayRoutes(kind, ns),
+    listGateways: (ns: string | null) => listGateways(ns),
+    listGatewayClasses: () => listGatewayClasses(),
+    listServices: (ns: string | null) => listServices(ns),
+    listServiceEndpoints: (ns: string | null) => listServiceEndpoints(ns),
   },
 }));
 
@@ -68,6 +81,12 @@ beforeEach(() => {
   listCustomResources.mockResolvedValue([]);
   detectInClusterExtensions.mockResolvedValue([]);
   checkListAccess.mockResolvedValue([]);
+  detectGatewayApi.mockResolvedValue({ installed: false, kinds: [] });
+  listGatewayRoutes.mockResolvedValue([]);
+  listGateways.mockResolvedValue([]);
+  listGatewayClasses.mockResolvedValue([]);
+  listServices.mockResolvedValue([]);
+  listServiceEndpoints.mockResolvedValue([]);
   overview = undefined;
   useClusterStore.setState({ isConnected: true, currentContext: "prod" });
   useUpdaterStore.setState({ available: false });
@@ -444,5 +463,81 @@ describe("the rail in another language", () => {
     // "Поды" would be this app inventing a word no cluster answers to.
     expect(screen.getByText("Pods")).toBeInTheDocument();
     expect(screen.getByText("Helm")).toBeInTheDocument();
+  });
+});
+
+describe("the Gateway and Routes rows for a namespace-scoped token", () => {
+  const routeIn = (ns: string) => ({
+    kind: "HTTPRoute",
+    apiVersion: "gateway.networking.k8s.io/v1",
+    name: `route-${ns}`,
+    namespace: ns,
+    hostnames: [],
+    parentRefs: [],
+    rules: [],
+    parents: [],
+    generation: null,
+    labels: {},
+    annotations: {},
+    createdAt: null,
+  });
+  const gatewayIn = (ns: string) => ({
+    name: `gw-${ns}`,
+    namespace: ns,
+    apiVersion: "gateway.networking.k8s.io/v1",
+    className: "istio",
+    listeners: [],
+    listenerSets: [],
+    listenerSetsKnown: true,
+    addresses: [],
+    conditions: [],
+    generation: null,
+    labels: {},
+    annotations: {},
+    createdAt: null,
+  });
+
+  /**
+   * The whole point of #137/#138: a team token can list its own namespaces
+   * and not the whole cluster. The routes page reads per namespace, so the
+   * rail must too — a cluster-wide read here 403s and would leave the count
+   * blank above a page that lists the user's routes. The verdict sources stay
+   * cluster-wide (refused -> no health mark), which is honest, not a red dot.
+   */
+  it("counts routes per namespace when the cluster-wide read is refused", async () => {
+    detectGatewayApi.mockResolvedValue({
+      installed: true,
+      kinds: [{ kind: "Gateway" }, { kind: "HTTPRoute" }],
+    });
+    useClusterStore.setState({
+      isConnected: true,
+      currentContext: "prod",
+      namespaceScope: ["team-a", "team-b"],
+    });
+    listGateways.mockImplementation(async (ns: string | null) => {
+      if (ns === null) throw new Error("gateways is forbidden (code: 403)");
+      return [gatewayIn(ns)];
+    });
+    listGatewayRoutes.mockImplementation(
+      async (_kind: string, ns: string | null) => {
+        if (ns === null) throw new Error("httproutes is forbidden (code: 403)");
+        return [routeIn(ns)];
+      }
+    );
+
+    wrap(<Sidebar />);
+
+    const routes = await screen.findByRole("link", { name: /routes/i });
+    // Two namespaces, one route each — the fan-out, not a cluster-wide blank.
+    await waitFor(() =>
+      expect(within(routes).getByText("2")).toBeInTheDocument()
+    );
+    // Read per namespace, never cluster-wide.
+    const routeNamespacesAsked = listGatewayRoutes.mock.calls.map(
+      ([, ns]) => ns
+    );
+    expect(routeNamespacesAsked).toContain("team-a");
+    expect(routeNamespacesAsked).toContain("team-b");
+    expect(routeNamespacesAsked).not.toContain(null);
   });
 });

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -540,4 +540,38 @@ describe("the Gateway and Routes rows for a namespace-scoped token", () => {
     expect(routeNamespacesAsked).toContain("team-b");
     expect(routeNamespacesAsked).not.toContain(null);
   });
+
+  /**
+   * A token may list one served route kind and not another. One refused kind
+   * must not blank the whole count — the routes page reads each kind on its
+   * own for the same reason, so the rail (one fetch over all kinds) has to
+   * tolerate a refusal the same way or the two disagree.
+   */
+  it("keeps the count when one served route kind is refused", async () => {
+    detectGatewayApi.mockResolvedValue({
+      installed: true,
+      kinds: [{ kind: "Gateway" }, { kind: "HTTPRoute" }, { kind: "TCPRoute" }],
+    });
+    useClusterStore.setState({
+      isConnected: true,
+      currentContext: "prod",
+      namespaceScope: [],
+    });
+    listGateways.mockResolvedValue([]);
+    listGatewayRoutes.mockImplementation(async (kind: string) => {
+      if (kind === "TCPRoute") {
+        throw new Error("tcproutes is forbidden (code: 403)");
+      }
+      return [routeIn("team-a")];
+    });
+
+    wrap(<Sidebar />);
+
+    const routes = await screen.findByRole("link", { name: /routes/i });
+    // The one readable kind's route is counted; the refused kind is dropped,
+    // not fatal.
+    await waitFor(() =>
+      expect(within(routes).getByText("1")).toBeInTheDocument()
+    );
+  });
 });

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -314,11 +314,24 @@ function GatewayRows({ overview }: { overview: ClusterOverview | undefined }) {
   // same way). A whole-cluster window is one call.
   const routes = useLiveQuery({
     queryKey: ["gateway-rail-routes", cacheKey, ...routeKinds],
-    queryFn: listAcrossScope(scope, (ns) =>
-      Promise.all(
+    queryFn: listAcrossScope(scope, async (ns) => {
+      // Each served kind on its own: a token may list HTTPRoutes and not
+      // TCPRoutes, and one refused kind must not blank the whole count — the
+      // routes page reads each kind as its own query for the same reason. A
+      // kind that answered contributes its rows; only when every kind was
+      // refused is the refusal the answer, thrown for `listAcrossScope`.
+      const settled = await Promise.allSettled(
         routeKinds.map((kind) => commands.listGatewayRoutes(kind, ns))
-      ).then((lists) => lists.flat())
-    ),
+      );
+      const rows = settled.flatMap((r) =>
+        r.status === "fulfilled" ? r.value : []
+      );
+      const refused = settled.find((r) => r.status === "rejected");
+      if (refused && settled.every((r) => r.status === "rejected")) {
+        throw (refused as PromiseRejectedResult).reason;
+      }
+      return rows;
+    }),
     staleTime: ROUTING_STALE,
     refresh: "overview",
     enabled: installed && routeKinds.length > 0 && !routesDenied,

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -42,7 +42,7 @@ import { commands } from "@/lib/commands";
 import { boardMark, gatewaysMark, routesBoard } from "@/lib/route-rows";
 import { useClusterMark } from "@/stores/clusterIdentityStore";
 import { useClusterStore } from "@/stores/clusterStore";
-import { inScope } from "@/lib/namespace-scope";
+import { inScope, listAcrossScope, scopeCacheKey } from "@/lib/namespace-scope";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useUpdaterStore } from "@/stores/updaterStore";
 import type { ClusterOverview, ResourceCounts } from "@/generated/types";
@@ -286,9 +286,15 @@ function GatewayRows({ overview }: { overview: ClusterOverview | undefined }) {
     routeKinds.length > 0 &&
     routeKinds.every((kind) => access[kind as ResourceKind] === false);
 
-  // Same keys as the routes list and the trace — the rail's numbers and
-  // the pages they open can never disagree.
-  const gateways = useLiveQuery({
+  const cacheKey = scopeCacheKey(scope);
+
+  // Verdict sources, read cluster-wide on purpose: a route can attach to a
+  // Gateway (or a GatewayClass) in a namespace the window is not on, and a
+  // verdict computed without it is wrong. These are the same keys the routes
+  // list and the trace read, so the pages share the answer. A namespace-scoped
+  // token is refused them — the board reads that absence as `topologyKnown:
+  // false` and asserts nothing, rather than a red dot for what it cannot see.
+  const gatewaysAll = useLiveQuery({
     queryKey: ["gateway-map-gateways"],
     queryFn: () => commands.listGateways(null),
     staleTime: ROUTING_STALE,
@@ -302,17 +308,31 @@ function GatewayRows({ overview }: { overview: ClusterOverview | undefined }) {
     refresh: "overview",
     enabled: installed && served.has("GatewayClass"),
   });
+  // The rail's own count follows the window's namespaces, like every other
+  // row — read per namespace so a token with rights in some and not the whole
+  // cluster still gets a number instead of a blank (the routes page reads the
+  // same way). A whole-cluster window is one call.
   const routes = useLiveQuery({
-    queryKey: ["gateway-attached-routes", ...routeKinds],
-    queryFn: async () => {
-      const lists = await Promise.all(
-        routeKinds.map((kind) => commands.listGatewayRoutes(kind, null))
-      );
-      return lists.flat();
-    },
+    queryKey: ["gateway-rail-routes", cacheKey, ...routeKinds],
+    queryFn: listAcrossScope(scope, (ns) =>
+      Promise.all(
+        routeKinds.map((kind) => commands.listGatewayRoutes(kind, ns))
+      ).then((lists) => lists.flat())
+    ),
     staleTime: ROUTING_STALE,
     refresh: "overview",
     enabled: installed && routeKinds.length > 0 && !routesDenied,
+  });
+  // Gateways for the COUNT, scoped like the routes. The cluster-wide read above
+  // stays the verdict source; on a whole-cluster window it already is this
+  // list, so this second read only runs once a namespace is selected.
+  const gatewaysScoped = useLiveQuery({
+    queryKey: ["gateway-rail-gateways", cacheKey],
+    queryFn: listAcrossScope(scope, (ns) => commands.listGateways(ns)),
+    staleTime: ROUTING_STALE,
+    refresh: "overview",
+    enabled:
+      installed && served.has("Gateway") && !gatewaysDenied && scope.length > 0,
   });
   const backing = useBackingLists(
     installed && routeKinds.length > 0 && !routesDenied
@@ -320,34 +340,37 @@ function GatewayRows({ overview }: { overview: ClusterOverview | undefined }) {
 
   const classesSettled =
     classes.data !== undefined || !served.has("GatewayClass");
-  // The subject list is scoped; the sources are not. A route in this
-  // namespace can attach to a Gateway in another one, and a verdict computed
-  // without that Gateway would be wrong — so the rail narrows what it counts,
-  // never what it judges against.
-  //
-  // Every other row in the rail follows the selected namespace (the backend
-  // says so in `ResourceCounts`) and these two did not, so picking a
-  // namespace left "Routes 40" in red above a page listing three green ones.
+  // The subject list is scoped, and now read that way rather than narrowed
+  // from a cluster-wide list — an RBAC token that cannot list cluster-wide
+  // still gets its own namespaces' rows. The verdict sources stay cluster-wide
+  // (above): a route can attach to a Gateway in a namespace the window is not
+  // on, and a verdict computed without it is wrong.
   const scopedRoutes = useMemo(
     () => (routes.data ?? []).filter((r) => inScope(scope, r.namespace)),
     [routes.data, scope]
   );
+  // The count follows the scope; on a whole-cluster window the verdict read
+  // already is that list, so reuse it and skip the second fetch.
+  const gatewayCount = scope.length === 0 ? gatewaysAll : gatewaysScoped;
   const scopedGateways = useMemo(
-    () => (gateways.data ?? []).filter((g) => inScope(scope, g.namespace)),
-    [gateways.data, scope]
+    () => (gatewayCount.data ?? []).filter((g) => inScope(scope, g.namespace)),
+    [gatewayCount.data, scope]
   );
   const board = useMemo(
     () =>
       routesBoard(
         scopedRoutes,
         {
-          gateways: gateways.data ?? [],
+          // Cluster-wide, deliberately: the verdict for a scoped route can
+          // depend on a Gateway or class in another namespace. Refused for a
+          // namespace-scoped token -> `topologyKnown` false -> no verdict.
+          gateways: gatewaysAll.data ?? [],
           classes: classes.data ?? [],
           // Classes count as read only once their list answered (or the
           // kind is not served at all) — a gateway judged against an
           // empty class list reads "class does not exist", which would
           // put a red dot on a healthy cluster for one render.
-          topologyKnown: gateways.data !== undefined && classesSettled,
+          topologyKnown: gatewaysAll.data !== undefined && classesSettled,
           backing: {
             services: backing.data?.services ?? [],
             published: backing.data?.published ?? [],
@@ -356,7 +379,14 @@ function GatewayRows({ overview }: { overview: ClusterOverview | undefined }) {
         },
         t
       ),
-    [scopedRoutes, gateways.data, classes.data, backing.data, classesSettled, t]
+    [
+      scopedRoutes,
+      gatewaysAll.data,
+      classes.data,
+      backing.data,
+      classesSettled,
+      t,
+    ]
   );
 
   const scopedPulse = board.pulse.filter((p) => inScope(scope, p.namespace));
@@ -369,11 +399,11 @@ function GatewayRows({ overview }: { overview: ClusterOverview | undefined }) {
         <NavRow
           item={resource(ResourceType.Gateway)}
           overview={overview}
-          value={gateways.data ? scopedGateways.length : null}
+          value={gatewayCount.data ? scopedGateways.length : null}
           mark={gatewaysMark(
             scopedGateways,
             scopedPulse,
-            gateways.data !== undefined && classesSettled
+            gatewaysAll.data !== undefined && classesSettled
           )}
           denied={gatewaysDenied}
         />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -42,7 +42,7 @@ import { commands } from "@/lib/commands";
 import { boardMark, gatewaysMark, routesBoard } from "@/lib/route-rows";
 import { useClusterMark } from "@/stores/clusterIdentityStore";
 import { useClusterStore } from "@/stores/clusterStore";
-import { inNamespace } from "@/lib/namespace-scope";
+import { inScope } from "@/lib/namespace-scope";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useUpdaterStore } from "@/stores/updaterStore";
 import type { ClusterOverview, ResourceCounts } from "@/generated/types";
@@ -259,11 +259,12 @@ export function Sidebar() {
 
 function GatewayRows({ overview }: { overview: ClusterOverview | undefined }) {
   const t = useT();
-  // `""` is this app's word for "the whole cluster", not `null` — the store
-  // types it `string` and every other consumer writes `currentNamespace ||
-  // null`. Comparing against `null` here compiled fine and filtered every
-  // row away, so the rail read "Routes 0" above a page listing forty.
-  const scope = useClusterStore((s) => s.currentNamespace) || null;
+  // The whole selection, not the collapsed `currentNamespace` — that is `""`
+  // for any two-or-more namespace window, which narrows to the whole cluster
+  // and put "Routes 40" in the rail above a page (migrated to read per
+  // namespace) listing three. `inScope` narrows by the array for one or
+  // several, and is the identity for an empty selection.
+  const scope = useClusterStore((s) => s.namespaceScope);
   const detection = useGatewayApi().data;
   const installed = detection?.installed ?? false;
   const served = new Set(detection?.kinds.map((k) => k.kind) ?? []);
@@ -328,11 +329,11 @@ function GatewayRows({ overview }: { overview: ClusterOverview | undefined }) {
   // says so in `ResourceCounts`) and these two did not, so picking a
   // namespace left "Routes 40" in red above a page listing three green ones.
   const scopedRoutes = useMemo(
-    () => inNamespace(routes.data ?? [], scope),
+    () => (routes.data ?? []).filter((r) => inScope(scope, r.namespace)),
     [routes.data, scope]
   );
   const scopedGateways = useMemo(
-    () => inNamespace(gateways.data ?? [], scope),
+    () => (gateways.data ?? []).filter((g) => inScope(scope, g.namespace)),
     [gateways.data, scope]
   );
   const board = useMemo(
@@ -358,7 +359,7 @@ function GatewayRows({ overview }: { overview: ClusterOverview | undefined }) {
     [scopedRoutes, gateways.data, classes.data, backing.data, classesSettled, t]
   );
 
-  const scopedPulse = inNamespace(board.pulse, scope);
+  const scopedPulse = board.pulse.filter((p) => inScope(scope, p.namespace));
 
   if (!installed) return null;
 

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -90,16 +90,23 @@ export function StatusBar() {
           </TooltipContent>
         </Tooltip>
       ) : isConnected ? (
-        <>
-          <span>{t("cluster", "podCount", { n: podCount })}</span>
-          <span>·</span>
-          <span className={cn(problemCount > 0 && "text-err")}>
-            {t("cluster", "problemCount", { n: problemCount })}
-            {/* The backend caps its ranked list; saying "12+" is the
-                difference between a count and a guess. */}
-            {problemsTruncated > 0 && "+"}
-          </span>
-        </>
+        podCount === null ? (
+          // The cluster-wide overview was refused or failed: the count is
+          // unknown, and "0 pods · 0 problems" here would say the opposite of
+          // the Overview page's own "no access". A dash is the honest chrome.
+          <span className="text-fg-fnt">{"—"}</span>
+        ) : (
+          <>
+            <span>{t("cluster", "podCount", { n: podCount })}</span>
+            <span>·</span>
+            <span className={cn((problemCount ?? 0) > 0 && "text-err")}>
+              {t("cluster", "problemCount", { n: problemCount ?? 0 })}
+              {/* The backend caps its ranked list; saying "12+" is the
+                  difference between a count and a guess. */}
+              {problemsTruncated > 0 && "+"}
+            </span>
+          </>
+        )
       ) : (
         <span>{t("cluster", "notConnectedLower")}</span>
       )}

--- a/src/components/overview/health.test.tsx
+++ b/src/components/overview/health.test.tsx
@@ -54,6 +54,7 @@ describe("the overview's two event panels", () => {
             crashLooping: 0,
           }}
           nodes={[]}
+          nodesKnown={true}
         />
         <WarningsPanel warnings={[warning]} />
       </>
@@ -110,6 +111,7 @@ describe("the detail line on a problem row", () => {
           crashLooping: 0,
         }}
         nodes={[]}
+        nodesKnown={true}
       />
     );
     const cordoned: ClusterProblem = {
@@ -142,5 +144,48 @@ describe("the detail line on a problem row", () => {
     ).toBeInTheDocument();
     quoted.unmount();
     useLocaleStore.setState({ choice: null });
+  });
+});
+
+describe("the healthy line when the node read was refused", () => {
+  const pods = {
+    running: 1,
+    pending: 0,
+    succeeded: 0,
+    failed: 0,
+    unknown: 0,
+    crashLooping: 0,
+  };
+
+  /**
+   * A namespace-scoped token cannot read the cluster's nodes, so "N of M
+   * nodes ready" would be "0 of 0" — a healthy-looking lie. With the nodes
+   * unknown the clause is left off entirely; deleting the `nodesKnown` guard
+   * puts "0 of 0 nodes ready" back on a screen that just said "no access".
+   */
+  it("drops the nodes-ready clause when the nodes are unknown", () => {
+    const { queryByText, unmount } = wrap(
+      <ProblemsPanel
+        problems={[]}
+        problemsTruncated={0}
+        pods={pods}
+        nodes={[]}
+        nodesKnown={false}
+      />
+    );
+    expect(queryByText(/nodes ready/)).toBeNull();
+    unmount();
+
+    const known = wrap(
+      <ProblemsPanel
+        problems={[]}
+        problemsTruncated={0}
+        pods={pods}
+        nodes={[]}
+        nodesKnown={true}
+      />
+    );
+    expect(known.getByText(/nodes ready/)).toBeInTheDocument();
+    known.unmount();
   });
 });

--- a/src/components/overview/health.tsx
+++ b/src/components/overview/health.tsx
@@ -429,8 +429,11 @@ export function WorkloadsPanel({
           segments={deploymentSegments(problems, counts.deployments)}
         />
         <Composition
-          total={nodes.length}
-          label={nodes.length === 1 ? "Node" : "Nodes"}
+          // `counts.nodes` is null when the node read was refused, so the bar
+          // reads "— / not readable" like the other refused counts rather than
+          // "0 Nodes". `nodes` is empty then, so its segments fall away.
+          total={counts.nodes}
+          label={counts.nodes === 1 ? "Node" : "Nodes"}
           emptyMessage={t("empty", "noneInScope")}
           segments={nodeSegments(nodes)}
         />

--- a/src/components/overview/health.tsx
+++ b/src/components/overview/health.tsx
@@ -250,12 +250,16 @@ export function ProblemsPanel({
   problemsTruncated,
   pods,
   nodes,
+  nodesKnown,
 }: {
   problems: ClusterProblem[];
   /** Rows the backend dropped from the end of the ranked list. */
   problemsTruncated: number;
   pods: PodComposition;
   nodes: NodeSummary[];
+  /** False when the node list was refused: the "N nodes ready" half of the
+   *  healthy line is unknown, not "0 of 0", so it is left off. */
+  nodesKnown: boolean;
 }) {
   const t = useT();
   // The headline counts everything that is wrong, not everything that fits —
@@ -297,8 +301,16 @@ export function ProblemsPanel({
             {t("cluster", "healthy")}
           </span>
           <span className="truncate text-fg-fnt">
-            {t("count", "podsRunning", { n: serving, total: podTotal(pods) })} ·{" "}
-            {t("count", "nodesReady", { n: readyNodes, total: nodes.length })}
+            {t("count", "podsRunning", { n: serving, total: podTotal(pods) })}
+            {nodesKnown && (
+              <>
+                {" · "}
+                {t("count", "nodesReady", {
+                  n: readyNodes,
+                  total: nodes.length,
+                })}
+              </>
+            )}
           </span>
           <span />
           <span />

--- a/src/components/resources/GatewayRoutesList.tsx
+++ b/src/components/resources/GatewayRoutesList.tsx
@@ -412,28 +412,33 @@ export function GatewayRoutesList() {
       <ResourceListHeader
         title={t("nav", "routes")}
         count={
-          <span className="tabular-nums">
-            {total + board.mesh.length}
-            {board.verdictsKnown && board.notServing.length > 0 && (
-              <>
-                {" · "}
-                <button
-                  type="button"
-                  aria-pressed={brokenOnly}
-                  onClick={() => setBrokenOnly((on) => !on)}
-                  className={cn(
-                    "text-err hover:underline",
-                    brokenOnly && "underline"
-                  )}
-                >
-                  {t("count", "gwNotServingCount", {
-                    n: board.notServing.length,
-                  })}
-                </button>
-              </>
-            )}
-            {quietCluster && total > 0 && ` · ${t("empty", "gwAllServing")}`}
-          </span>
+          // No count beside a refusal or a detection failure — the body shows
+          // "could not read" there, and a "0" in the header would contradict
+          // it. These are the same states the body special-cases below.
+          (error && routes.length === 0) || detectionError ? undefined : (
+            <span className="tabular-nums">
+              {total + board.mesh.length}
+              {board.verdictsKnown && board.notServing.length > 0 && (
+                <>
+                  {" · "}
+                  <button
+                    type="button"
+                    aria-pressed={brokenOnly}
+                    onClick={() => setBrokenOnly((on) => !on)}
+                    className={cn(
+                      "text-err hover:underline",
+                      brokenOnly && "underline"
+                    )}
+                  >
+                    {t("count", "gwNotServingCount", {
+                      n: board.notServing.length,
+                    })}
+                  </button>
+                </>
+              )}
+              {quietCluster && total > 0 && ` · ${t("empty", "gwAllServing")}`}
+            </span>
+          )
         }
         dataUpdatedAt={dataUpdatedAt}
         live={live && !resyncing}

--- a/src/components/resources/GatewayRoutesList.tsx
+++ b/src/components/resources/GatewayRoutesList.tsx
@@ -48,6 +48,7 @@ import { routesBoard, type RouteRow } from "@/lib/route-rows";
 import { useT, type T } from "@/i18n/useT";
 import { parts } from "@/i18n/parts";
 import { useClusterStore } from "@/stores/clusterStore";
+import { useNamespaceScope } from "@/hooks/useNamespaceScope";
 import { cn } from "@/lib/utils";
 import { verbatim } from "@/lib/error-utils";
 import type { RouteInfo } from "@/generated/types";
@@ -275,7 +276,7 @@ function GroupCap({
 export function GatewayRoutesList() {
   const t = useT();
   const isConnected = useClusterStore((s) => s.isConnected);
-  const currentNamespace = useClusterStore((s) => s.currentNamespace);
+  const scope = useNamespaceScope();
   const {
     detection,
     detectionLoading,
@@ -287,7 +288,7 @@ export function GatewayRoutesList() {
     dataUpdatedAt,
     live,
     resyncing,
-  } = useGatewayRoutes(currentNamespace);
+  } = useGatewayRoutes(scope.scope);
 
   const [query, setQuery] = useState("");
   const [kind, setKind] = useState("");

--- a/src/components/resources/NamespaceList.tsx
+++ b/src/components/resources/NamespaceList.tsx
@@ -25,7 +25,9 @@ import { useT } from "@/i18n/useT";
 // eslint-disable-next-line react-refresh/only-export-components
 export const columns = (
   currentNamespace: string,
-  podCounts: Map<string, number>
+  // `null`/absent = the cluster-wide overview did not answer, so the count is
+  // unknown and drawn "—" — never silently 0.
+  podCounts: Map<string, number | null>
 ): ColumnDef<NamespaceInfo>[] => [
   {
     // Four columns share this table, so the name takes the room the others
@@ -58,11 +60,14 @@ export const columns = (
     size: 80,
     id: "pods",
     header: () => <T section="columns" k="pods" />,
-    cell: ({ row }) => (
-      <span className="font-mono text-fg-mut">
-        {podCounts.get(row.original.name) ?? 0}
-      </span>
-    ),
+    cell: ({ row }) => {
+      const count = podCounts.get(row.original.name);
+      return (
+        <span className="font-mono text-fg-mut">
+          {count == null ? "—" : count}
+        </span>
+      );
+    },
   },
   createAgeColumn<NamespaceInfo>(),
 ];

--- a/src/components/resources/detail-blocks.tsx
+++ b/src/components/resources/detail-blocks.tsx
@@ -431,7 +431,9 @@ export function Composition({
       </div>
       <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px]">
         {total == null ? (
-          <span className="text-fg-fnt">not readable with this access</span>
+          <span className="text-fg-fnt">
+            <T section="empty" k="notReadableWithAccess" />
+          </span>
         ) : visible.length === 0 ? (
           <span className="text-fg-fnt">
             {emptyMessage ?? <T section="empty" k="nothingScheduled" />}

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -173,6 +173,7 @@ export interface ClusterOverview {
   problemsTruncated: number;
   scheduler: SchedulerPressure;
   nodes: NodeSummary[];
+  nodesKnown: boolean;
   warnings: WarningGroup[];
   namespaces: NamespaceLoad[];
   counts: ResourceCounts;

--- a/src/hooks/useClusterSummary.test.tsx
+++ b/src/hooks/useClusterSummary.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * The chrome's counts come from the cluster-wide overview, which a token
+ * without cluster read rights is refused. A refusal must leave the counts
+ * unknown (`null`), never fold to `0` — the status bar and the namespace
+ * picker draw "—" from that null, so a scoped user is never told their
+ * cluster is empty and healthy while the Overview page says "no access".
+ */
+
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@/lib/commands", () => ({
+  commands: {
+    getClusterOverview: vi.fn(),
+    listNamespaces: vi.fn(),
+  },
+}));
+
+import { commands } from "@/lib/commands";
+import { useClusterStore } from "@/stores/clusterStore";
+import { useClusterSummary } from "./useClusterSummary";
+
+const getClusterOverview = vi.mocked(commands.getClusterOverview);
+const listNamespaces = vi.mocked(commands.listNamespaces);
+
+let client: QueryClient;
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={client}>{children}</QueryClientProvider>
+);
+
+beforeEach(() => {
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  getClusterOverview.mockReset();
+  listNamespaces.mockReset();
+  useClusterStore.setState({ isConnected: true, currentContext: "prod" });
+});
+
+describe("cluster summary counts when the overview is refused", () => {
+  it("leaves the counts unknown, keeping the namespace names it can still read", async () => {
+    getClusterOverview.mockRejectedValue("pods is forbidden (code: 403)");
+    // listNamespaces is a separate read and can still succeed.
+    listNamespaces.mockResolvedValue([
+      { name: "team-a" },
+      { name: "team-b" },
+    ] as never);
+
+    const { result } = renderHook(() => useClusterSummary(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.podCount).toBeNull();
+    expect(result.current.problemCount).toBeNull();
+    expect(result.current.namespaces.map((n) => n.name).sort()).toEqual([
+      "team-a",
+      "team-b",
+    ]);
+    // The names are known; the counts inside them are not — never 0.
+    for (const ns of result.current.namespaces) {
+      expect(ns.podCount).toBeNull();
+      expect(ns.problemCount).toBeNull();
+    }
+  });
+
+  it("reports the real counts when the overview answers", async () => {
+    getClusterOverview.mockResolvedValue({
+      namespaces: [{ name: "team-a", podCount: 3 }],
+      problems: [{ namespace: "team-a" }],
+      problemsTruncated: 0,
+      counts: { pods: 3 },
+    } as never);
+    listNamespaces.mockResolvedValue([{ name: "team-a" }] as never);
+
+    const { result } = renderHook(() => useClusterSummary(), { wrapper });
+
+    await waitFor(() => expect(result.current.podCount).toBe(3));
+    expect(result.current.namespaces[0].podCount).toBe(3);
+    expect(result.current.namespaces[0].problemCount).toBe(1);
+  });
+});

--- a/src/hooks/useClusterSummary.ts
+++ b/src/hooks/useClusterSummary.ts
@@ -8,14 +8,20 @@ import { useClusterStore } from "@/stores/clusterStore";
 
 export interface NamespaceScope {
   name: string;
-  podCount: number;
-  /** Problems the backend attributed to this namespace, cluster-wide. */
-  problemCount: number;
+  /** `null` when the cluster-wide overview was refused or failed — the count
+   *  is unknown, not zero. */
+  podCount: number | null;
+  /** Problems the backend attributed to this namespace, cluster-wide. `null`
+   *  when the overview could not be read. */
+  problemCount: number | null;
 }
 
 export interface ClusterSummary {
-  podCount: number;
-  problemCount: number;
+  /** `null` when the cluster-wide overview was refused or failed. The chrome
+   *  shows "—", not "0", so a token without cluster read rights is never told
+   *  its cluster is empty and healthy. */
+  podCount: number | null;
+  problemCount: number | null;
   /** Problems the backend dropped from its ranked list, if any. */
   problemsTruncated: number;
   namespaces: NamespaceScope[];
@@ -47,6 +53,10 @@ export function useClusterSummary(): ClusterSummary {
   });
 
   return useMemo(() => {
+    // The overview carries the counts; when it was refused or failed there is
+    // no count to state, and a `0` there would tell a namespace-scoped user
+    // their cluster is empty and healthy. `known` is what keeps that honest.
+    const known = overview !== undefined;
     const pods = new Map(
       (overview?.namespaces ?? []).map((ns) => [ns.name, ns.podCount])
     );
@@ -68,19 +78,19 @@ export function useClusterSummary(): ClusterSummary {
     const namespaces = names
       .map((name) => ({
         name,
-        podCount: pods.get(name) ?? 0,
-        problemCount: problems.get(name) ?? 0,
+        podCount: known ? (pods.get(name) ?? 0) : null,
+        problemCount: known ? (problems.get(name) ?? 0) : null,
       }))
       .sort(
         (a, b) =>
-          b.problemCount - a.problemCount ||
-          b.podCount - a.podCount ||
+          (b.problemCount ?? 0) - (a.problemCount ?? 0) ||
+          (b.podCount ?? 0) - (a.podCount ?? 0) ||
           a.name.localeCompare(b.name)
       );
 
     return {
-      podCount: overview?.counts.pods ?? 0,
-      problemCount: overview?.problems.length ?? 0,
+      podCount: overview ? overview.counts.pods : null,
+      problemCount: overview ? overview.problems.length : null,
       problemsTruncated: overview?.problemsTruncated ?? 0,
       namespaces,
       isLoading: overviewLoading || namespacesLoading,

--- a/src/hooks/useGatewayRoutes.ts
+++ b/src/hooks/useGatewayRoutes.ts
@@ -44,10 +44,11 @@ function useRouteKind(
   // Several namespaces are read one apiece and polled; a watch covers none or
   // one. See `listAcrossScope`.
   const several = scope.length >= 2;
+  // `null` keys the whole cluster — not `"all"`, a name a namespace can carry.
   const cacheKey = scopeCacheKey(scope);
   const watchNamespace = scope.length === 1 ? scope[0] : null;
   const queryKey = useMemo(
-    () => ["gateway-routes", kind, cacheKey ?? "all"],
+    () => ["gateway-routes", kind, cacheKey],
     [kind, cacheKey]
   );
   const query = useLiveQuery<RouteInfo[]>({

--- a/src/hooks/useGatewayRoutes.ts
+++ b/src/hooks/useGatewayRoutes.ts
@@ -17,6 +17,7 @@ import { useResourceWatch } from "@/hooks/useResourceWatch";
 import { useToast } from "@/components/ui/use-toast";
 import { useT } from "@/i18n/useT";
 import { commands } from "@/lib/commands";
+import { listAcrossScope, scopeCacheKey } from "@/lib/namespace-scope";
 import { STALE_TIMES } from "@/lib/refresh";
 import { ResourceType, type ResourceKind } from "@/lib/resource-registry";
 import type { RouteInfo } from "@/generated/types";
@@ -35,29 +36,36 @@ export const GATEWAY_ROUTE_KINDS: ResourceKind[] = [
  *  broken stream. */
 function useRouteKind(
   kind: ResourceKind,
-  namespace: string | null,
+  scope: string[],
   served: boolean,
   onWatchError: (kind: string, message: string) => void
 ) {
   const [watchFailed, setWatchFailed] = useState(false);
+  // Several namespaces are read one apiece and polled; a watch covers none or
+  // one. See `listAcrossScope`.
+  const several = scope.length >= 2;
+  const cacheKey = scopeCacheKey(scope);
+  const watchNamespace = scope.length === 1 ? scope[0] : null;
   const queryKey = useMemo(
-    () => ["gateway-routes", kind, namespace ?? "all"],
-    [kind, namespace]
+    () => ["gateway-routes", kind, cacheKey ?? "all"],
+    [kind, cacheKey]
   );
   const query = useLiveQuery<RouteInfo[]>({
     queryKey,
-    queryFn: () => commands.listGatewayRoutes(kind, namespace),
+    queryFn: listAcrossScope(scope, (ns) =>
+      commands.listGatewayRoutes(kind, ns)
+    ),
     enabled: served,
     staleTime: STALE_TIMES.resourceList,
-    // The watch feeds the cache; polling is only the fallback after it
-    // fails, same contract as every watched list page.
-    refresh: watchFailed ? "resourceList" : false,
+    // The watch feeds the cache; polling is the fallback after it fails, and
+    // the mode for a multi-namespace scope (no cluster-wide watch).
+    refresh: watchFailed || several ? "resourceList" : false,
   });
   const { resyncing } = useResourceWatch<RouteInfo>({
-    enabled: served,
+    enabled: served && !several,
     subscribe: useCallback(
-      () => commands.subscribeGatewayRouteWatch(kind, namespace),
-      [kind, namespace]
+      () => commands.subscribeGatewayRouteWatch(kind, watchNamespace),
+      [kind, watchNamespace]
     ),
     queryKey,
     onError: useCallback(
@@ -71,10 +79,10 @@ function useRouteKind(
     ),
     onRecovered: useCallback(() => setWatchFailed(false), []),
   });
-  return { query, resyncing, served, watchFailed };
+  return { query, resyncing, served, watchFailed, several };
 }
 
-export function useGatewayRoutes(namespace: string | null) {
+export function useGatewayRoutes(scope: string[]) {
   const { toast } = useToast();
   const t = useT();
   // The scan's own state travels with its answer. Without it a page cannot
@@ -103,31 +111,31 @@ export function useGatewayRoutes(namespace: string | null) {
   // nothing — its query and watch stay disabled.
   const http = useRouteKind(
     GATEWAY_ROUTE_KINDS[0],
-    namespace,
+    scope,
     served.has(GATEWAY_ROUTE_KINDS[0]),
     onWatchError
   );
   const grpc = useRouteKind(
     GATEWAY_ROUTE_KINDS[1],
-    namespace,
+    scope,
     served.has(GATEWAY_ROUTE_KINDS[1]),
     onWatchError
   );
   const tls = useRouteKind(
     GATEWAY_ROUTE_KINDS[2],
-    namespace,
+    scope,
     served.has(GATEWAY_ROUTE_KINDS[2]),
     onWatchError
   );
   const tcp = useRouteKind(
     GATEWAY_ROUTE_KINDS[3],
-    namespace,
+    scope,
     served.has(GATEWAY_ROUTE_KINDS[3]),
     onWatchError
   );
   const udp = useRouteKind(
     GATEWAY_ROUTE_KINDS[4],
-    namespace,
+    scope,
     served.has(GATEWAY_ROUTE_KINDS[4]),
     onWatchError
   );
@@ -163,7 +171,11 @@ export function useGatewayRoutes(namespace: string | null) {
       0,
       ...active.map((entry) => entry.query.dataUpdatedAt ?? 0)
     ),
-    live: active.length > 0 && !active.some((entry) => entry.watchFailed),
+    // A multi-namespace scope polls rather than watches, so it is not "live"
+    // even though no watch failed.
+    live:
+      active.length > 0 &&
+      !active.some((entry) => entry.watchFailed || entry.several),
     resyncing: active.some((entry) => entry.resyncing),
   };
 }

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -3156,6 +3156,8 @@ export const en = {
     budgetRuleHealthyCovering:
       "{rule}, {healthy} of {expected} healthy, covering {pods} here.",
     couldNotReadClusterState: "Could not read cluster state",
+    noClusterOverviewAccess:
+      "You do not have permission to read the whole cluster. Pick the namespaces you can see at the top.",
     controllerLower: "controller",
     noneSet: "none set",
     couldNotReadManifest: "Could not read the manifest",

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -3158,6 +3158,8 @@ export const en = {
     couldNotReadClusterState: "Could not read cluster state",
     noClusterOverviewAccess:
       "You do not have permission to read the whole cluster. Pick the namespaces you can see at the top.",
+    noNodeAccess:
+      "You do not have permission to read the cluster's nodes, so capacity and scheduler headroom are not shown.",
     controllerLower: "controller",
     noneSet: "none set",
     couldNotReadManifest: "Could not read the manifest",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -3378,6 +3378,8 @@ export const ru: Catalogue = {
     budgetRuleHealthyCovering:
       "{rule}, работоспособны {healthy} из {expected}, покрывает здесь {pods}.",
     couldNotReadClusterState: "Не удалось прочитать состояние кластера",
+    noClusterOverviewAccess:
+      "У вас нет прав на просмотр всего кластера. Выберите доступные вам пространства имён сверху.",
     controllerLower: "контроллер",
     noneSet: "не заданы",
     couldNotReadManifest: "Не удалось прочитать манифест",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -3380,6 +3380,8 @@ export const ru: Catalogue = {
     couldNotReadClusterState: "Не удалось прочитать состояние кластера",
     noClusterOverviewAccess:
       "У вас нет прав на просмотр всего кластера. Выберите доступные вам пространства имён сверху.",
+    noNodeAccess:
+      "У вас нет прав на чтение узлов кластера — ёмкость и запас планировщика не показаны.",
     controllerLower: "контроллер",
     noneSet: "не заданы",
     couldNotReadManifest: "Не удалось прочитать манифест",

--- a/src/lib/namespace-scope.test.ts
+++ b/src/lib/namespace-scope.test.ts
@@ -188,4 +188,39 @@ describe("reading a list across the selection", () => {
     expect(calls).toEqual(["prod", "staging"]);
     expect(merged).toEqual(["prod-a", "prod-b", "staging-a", "staging-b"]);
   });
+
+  it("keeps a readable namespace's rows when a sibling namespace refuses", async () => {
+    // The point of the picker: rights in some namespaces and not others. One
+    // namespace's 403 must not erase the rows of the ones the user can read.
+    const fetchOne = async (ns: string | null) => {
+      if (ns === "restricted") throw new Error("pods is forbidden");
+      return [`${ns}-a`, `${ns}-b`];
+    };
+
+    const rows = await listAcrossScope(["prod", "restricted"], fetchOne)();
+    expect(rows).toEqual(["prod-a", "prod-b"]);
+  });
+
+  it("answers a refusal, never an empty list, when nothing readable came back", async () => {
+    // A refused read that returns no rows must surface as the refusal, not as
+    // "there are none" — the whole thesis of the app.
+    const fetchOne = async (ns: string | null) => {
+      if (ns === "restricted") throw new Error("pods is forbidden");
+      return [] as string[];
+    };
+
+    await expect(
+      listAcrossScope(["empty", "restricted"], fetchOne)()
+    ).rejects.toThrow("pods is forbidden");
+  });
+
+  it("throws when every namespace refuses", async () => {
+    const fetchOne = async (ns: string | null) => {
+      throw new Error(`${ns} is forbidden`);
+    };
+
+    await expect(listAcrossScope(["a", "b"], fetchOne)()).rejects.toThrow(
+      "forbidden"
+    );
+  });
 });

--- a/src/lib/namespace-scope.ts
+++ b/src/lib/namespace-scope.ts
@@ -88,8 +88,32 @@ export function listAcrossScope<T>(
     if (scope.length <= 1) {
       return fetchOne(scope.length === 1 ? scope[0] : null);
     }
-    const perNamespace = await Promise.all(scope.map((ns) => fetchOne(ns)));
-    return perNamespace.flat();
+    // One read per namespace, settled independently. A user with rights in
+    // some of the selected namespaces and not others keeps the rows they can
+    // read rather than losing every namespace's rows to one namespace's
+    // refusal — the failure of the old `Promise.all`, which rejected whole.
+    //
+    // But a failed read is still never answered with an empty list: if
+    // nothing came back and a namespace refused, that refusal is the answer,
+    // thrown so the list shows it. The one thing not carried here is *which*
+    // namespace refused when other namespaces did return rows — surfacing that
+    // beside the rows needs a richer return than this shared shape allows.
+    const settled = await Promise.allSettled(scope.map((ns) => fetchOne(ns)));
+    const rows: T[] = [];
+    let firstError: unknown;
+    let failed = false;
+    for (const result of settled) {
+      if (result.status === "fulfilled") {
+        rows.push(...result.value);
+      } else if (!failed) {
+        failed = true;
+        firstError = result.reason;
+      }
+    }
+    if (failed && rows.length === 0) {
+      throw firstError;
+    }
+    return rows;
   };
 }
 

--- a/src/lib/overview-merge.test.ts
+++ b/src/lib/overview-merge.test.ts
@@ -232,13 +232,16 @@ describe("adding namespaces up", () => {
 
   it("leaves the capacity view unknown when one scope could not read the nodes", () => {
     // The node list is one cluster-wide read; a part that was refused it makes
-    // the whole scope's capacity view unknown, not a partial count.
-    expect(
-      mergeOverviews([
-        overview({ nodesKnown: true }),
-        overview({ nodesKnown: false }),
-      ]).nodesKnown
-    ).toBe(false);
+    // the whole scope's capacity view unknown, not a partial count. The first
+    // part DID read it, so its node count must be blanked to match — a number
+    // beside the "no node access" note would be the contradiction this guards.
+    const merged = mergeOverviews([
+      overview({ nodesKnown: true, counts: counts({ nodes: 3 }) }),
+      overview({ nodesKnown: false }),
+    ]);
+    expect(merged.nodesKnown).toBe(false);
+    expect(merged.nodes).toEqual([]);
+    expect(merged.counts.nodes).toBeNull();
   });
 });
 

--- a/src/lib/overview-merge.test.ts
+++ b/src/lib/overview-merge.test.ts
@@ -74,6 +74,7 @@ function overview(over: Partial<ClusterOverview> = {}): ClusterOverview {
     problemsTruncated: 0,
     scheduler: {} as ClusterOverview["scheduler"],
     nodes: [node("a"), node("b"), node("c")],
+    nodesKnown: true,
     warnings: [],
     namespaces: [],
     counts: counts(),
@@ -226,6 +227,17 @@ describe("adding namespaces up", () => {
         overview({ metricsAvailable: true }),
         overview({ metricsAvailable: false }),
       ]).metricsAvailable
+    ).toBe(false);
+  });
+
+  it("leaves the capacity view unknown when one scope could not read the nodes", () => {
+    // The node list is one cluster-wide read; a part that was refused it makes
+    // the whole scope's capacity view unknown, not a partial count.
+    expect(
+      mergeOverviews([
+        overview({ nodesKnown: true }),
+        overview({ nodesKnown: false }),
+      ]).nodesKnown
     ).toBe(false);
   });
 });

--- a/src/lib/overview-merge.ts
+++ b/src/lib/overview-merge.ts
@@ -201,5 +201,9 @@ export function mergeOverviews(parts: ClusterOverview[]): ClusterOverview {
     // One namespace failing to report metrics is the whole reading failing:
     // a chart drawn from two of three namespaces is a chart with no axis.
     metricsAvailable: parts.every((part) => part.metricsAvailable),
+    // The node list is the same cluster-wide read in every part, so one part
+    // that could not make it leaves the capacity view unknown for the whole
+    // scope — `nodes`/`scheduler` already came through empty with `first`.
+    nodesKnown: parts.every((part) => part.nodesKnown),
   };
 }

--- a/src/lib/overview-merge.ts
+++ b/src/lib/overview-merge.ts
@@ -147,9 +147,20 @@ export function mergeOverviews(parts: ClusterOverview[]): ClusterOverview {
   // repeated, and picking one is what says so.
   const [first] = parts;
   const problems = rank(dedupe(parts.flatMap((part) => part.problems)));
+  // The node list is the same cluster-wide read in every part, so one part
+  // that could not make it leaves the capacity view unknown for the whole
+  // scope. `first` may still be the part that DID read it, so its node fields
+  // are blanked to match — otherwise `WorkloadsPanel` would draw a real node
+  // count beside the "no node access" note the page shows.
+  const nodesKnown = parts.every((part) => part.nodesKnown);
+  const counts = addCounts(
+    parts.map((part) => part.counts),
+    first.counts
+  );
 
   return {
     ...first,
+    nodes: nodesKnown ? first.nodes : [],
     problems: problems.slice(0, MAX_PROBLEMS),
     // Every part cut its own lowest-ranked tail, so the rows it dropped rank
     // below this cut too: what survives is still the worst of the whole scope,
@@ -164,10 +175,7 @@ export function mergeOverviews(parts: ClusterOverview[]): ClusterOverview {
     // returns an empty one for any scoped read (`overview.rs`). Every part of a
     // fan-out is scoped, so the empty vec comes through with `first` and the
     // picker goes on reading the cluster-wide overview.
-    counts: addCounts(
-      parts.map((part) => part.counts),
-      first.counts
-    ),
+    counts: nodesKnown ? counts : { ...counts, nodes: null },
     pods: {
       running: parts.reduce((sum, part) => sum + part.pods.running, 0),
       pending: parts.reduce((sum, part) => sum + part.pods.pending, 0),
@@ -201,9 +209,6 @@ export function mergeOverviews(parts: ClusterOverview[]): ClusterOverview {
     // One namespace failing to report metrics is the whole reading failing:
     // a chart drawn from two of three namespaces is a chart with no axis.
     metricsAvailable: parts.every((part) => part.metricsAvailable),
-    // The node list is the same cluster-wide read in every part, so one part
-    // that could not make it leaves the capacity view unknown for the whole
-    // scope — `nodes`/`scheduler` already came through empty with `first`.
-    nodesKnown: parts.every((part) => part.nodesKnown),
+    nodesKnown,
   };
 }

--- a/src/pages/ClusterOverview.test.tsx
+++ b/src/pages/ClusterOverview.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * The overview needs a cluster-wide read, and an RBAC-scoped user does not
+ * have it. That refusal must read as a refusal — no permission, pick your
+ * namespaces — and never as the raw "Could not read cluster state" fault with
+ * a retry that will be refused the same way. Deleting the `isRefusal` branch
+ * puts the reported screenshot (a Tauri error dump on Overview) back.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@/lib/commands", () => ({
+  commands: {
+    getClusterOverview: vi.fn(),
+    getClusterInfo: vi.fn(async () => null),
+  },
+}));
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { commands } from "@/lib/commands";
+import { useClusterStore } from "@/stores/clusterStore";
+import { ClusterOverview } from "./ClusterOverview";
+
+const getClusterOverview = vi.mocked(commands.getClusterOverview);
+
+function mount() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <TooltipProvider>
+          <ClusterOverview />
+        </TooltipProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  getClusterOverview.mockReset();
+  useClusterStore.setState({
+    isConnected: true,
+    currentContext: "",
+    namespaceScope: [],
+  });
+});
+
+describe("what the overview does when the read is refused", () => {
+  it("names the refusal and offers no retry when the cluster forbids the read", async () => {
+    getClusterOverview.mockRejectedValue(
+      'Tauri command \'getClusterOverview\' failed: pods is forbidden: User "kc" cannot list resource "pods" in API group "" at the cluster scope: Forbidden (code: 403)'
+    );
+
+    mount();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/do not have permission to read the whole cluster/i)
+      ).toBeInTheDocument()
+    );
+    // A refusal will not change on a retry, so the button that invites one is
+    // gone.
+    expect(
+      screen.queryByRole("button", { name: /retry/i })
+    ).not.toBeInTheDocument();
+    // The fault headline is the wrong words for a refusal.
+    expect(
+      screen.queryByText("Could not read cluster state")
+    ).not.toBeInTheDocument();
+    // And the framing prefix the reporter saw is off the message.
+    expect(screen.queryByText(/Tauri command/)).not.toBeInTheDocument();
+  });
+
+  it("keeps the fault headline and a retry when the read fails for any other reason", async () => {
+    getClusterOverview.mockRejectedValue(
+      "Tauri command 'getClusterOverview' failed: error trying to connect: connection refused"
+    );
+
+    mount();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Could not read cluster state")
+      ).toBeInTheDocument()
+    );
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    expect(
+      screen.queryByText(/do not have permission to read the whole cluster/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/ClusterOverview.tsx
+++ b/src/pages/ClusterOverview.tsx
@@ -1,5 +1,6 @@
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, Lock } from "lucide-react";
 
+import { isRefusal, verbatim } from "@/lib/error-utils";
 import { scopeLabel } from "@/lib/namespace-scope";
 import { useClusterStore } from "@/stores/clusterStore";
 import { useClusterInfo } from "@/hooks";
@@ -51,20 +52,39 @@ export function ClusterOverview() {
   }
 
   if (error && !overview) {
+    // A refusal is not a failure: the cluster-wide read this page needs was
+    // declined, and retrying it spends requests to be declined again. Say so,
+    // and point at the fix — the scoped overview reads each namespace on its
+    // own, so a user with rights in some can see those by picking them.
+    const refused = isRefusal(error);
     return (
       <Section>
         <div className="flex items-center gap-2">
-          <AlertCircle className="h-4 w-4 text-err" aria-hidden="true" />
-          <h2 className="text-[13px] font-semibold tracking-tight text-err">
-            {t("empty", "couldNotReadClusterState")}
+          {refused ? (
+            <Lock className="h-4 w-4 text-fg-mut" aria-hidden="true" />
+          ) : (
+            <AlertCircle className="h-4 w-4 text-err" aria-hidden="true" />
+          )}
+          <h2
+            className={`text-[13px] font-semibold tracking-tight ${
+              refused ? "text-fg" : "text-err"
+            }`}
+          >
+            {refused
+              ? t("empty", "noClusterOverviewAccess")
+              : t("empty", "couldNotReadClusterState")}
           </h2>
         </div>
-        <p className="text-xs text-fg-mut">{error.message}</p>
-        <div className="flex items-center gap-2 pt-2">
-          <Button variant="outline" size="sm" onClick={() => refetch()}>
-            {t("action", "retry")}
-          </Button>
-        </div>
+        <p className="mt-1 select-text wrap-break-word font-mono text-[11px] text-fg-fnt">
+          {verbatim(error.message)}
+        </p>
+        {!refused && (
+          <div className="flex items-center gap-2 pt-2">
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              {t("action", "retry")}
+            </Button>
+          </div>
+        )}
       </Section>
     );
   }

--- a/src/pages/ClusterOverview.tsx
+++ b/src/pages/ClusterOverview.tsx
@@ -6,7 +6,7 @@ import { useClusterStore } from "@/stores/clusterStore";
 import { useClusterInfo } from "@/hooks";
 import { useScopedOverview } from "@/hooks/useClusterOverview";
 import { ClusterFrontDoor } from "@/components/cluster/ClusterFrontDoor";
-import { Section } from "@/components/ui/section";
+import { Section, SectionHeader } from "@/components/ui/section";
 import { Button } from "@/components/ui/button";
 import { HeaderSkeleton, StatsSkeleton } from "@/components/ui/skeleton";
 import {
@@ -100,16 +100,32 @@ export function ClusterOverview() {
         problemsTruncated={overview.problemsTruncated}
         pods={overview.pods}
         nodes={overview.nodes}
+        nodesKnown={overview.nodesKnown}
       />
       <WorkloadsPanel overview={overview} scope={scope} />
-      <SchedulerPanel
-        scheduler={overview.scheduler}
-        metricsAvailable={overview.metricsAvailable}
-      />
-      <NodesPanel
-        nodes={overview.nodes}
-        version={clusterInfo?.server_version}
-      />
+      {overview.nodesKnown ? (
+        <>
+          <SchedulerPanel
+            scheduler={overview.scheduler}
+            metricsAvailable={overview.metricsAvailable}
+          />
+          <NodesPanel
+            nodes={overview.nodes}
+            version={clusterInfo?.server_version}
+          />
+        </>
+      ) : (
+        // The scheduler headroom and node rows both come from the cluster-wide
+        // node read, which this token was refused — one honest note in their
+        // place, not two panels drawing an empty cluster.
+        <Section>
+          <SectionHeader title="Nodes" />
+          <div className="flex items-center gap-2 py-1">
+            <Lock className="h-4 w-4 text-fg-mut" aria-hidden="true" />
+            <p className="text-xs text-fg-mut">{t("empty", "noNodeAccess")}</p>
+          </div>
+        </Section>
+      )}
       <WarningsPanel warnings={overview.warnings} />
     </div>
   );

--- a/src/pages/GatewayClassDetail.tsx
+++ b/src/pages/GatewayClassDetail.tsx
@@ -49,7 +49,12 @@ function GatewayRows({ className }: { className: string }) {
 
   return (
     <Section>
-      <SectionHeader title={t("nav", "gatewaysUsingIt")} count={users.length} />
+      {/* No count while the gateways read is refused or still loading — a `0`
+          beside the body's "could not read" would contradict it. */}
+      <SectionHeader
+        title={t("nav", "gatewaysUsingIt")}
+        count={gateways ? users.length : undefined}
+      />
       {error && gateways === undefined ? (
         <p className="text-xs text-err">
           {t("empty", "couldNotReadGateways", {

--- a/src/pages/GatewayDetail.tsx
+++ b/src/pages/GatewayDetail.tsx
@@ -448,12 +448,22 @@ export function GatewayDetail() {
       id: "routes",
       label: t("nav", "routes"),
       glyph: viewGlyph(RouteGlyph),
-      mark: countMark(attached.length),
+      // A refused cluster-wide route read is unknown, not zero: no tab digit
+      // and no header count while the body says "could not read", the same way
+      // the routes list page and the sidebar treat it.
+      mark:
+        routes.isError && attached.length === 0
+          ? undefined
+          : countMark(attached.length),
       content: (
         <Section>
           <SectionHeader
             title={t("nav", "attachedRoutes")}
-            count={attached.length}
+            count={
+              routes.isError && attached.length === 0
+                ? undefined
+                : attached.length
+            }
           />
           {detectionQuery.isLoading ? (
             <p className="text-xs text-fg-fnt">{t("empty", "readingRoutes")}</p>

--- a/src/pages/Helm.tsx
+++ b/src/pages/Helm.tsx
@@ -343,7 +343,13 @@ export function Helm() {
             panels wired together. */}
         <SectionHeader
           title="Helm"
-          count={t("count", "releases", { n: releases.length })}
+          // No count beside a refused read — "0 releases" there would say the
+          // opposite of the tab's "no access". The tab reads the same error.
+          count={
+            releasesError && releases.length === 0
+              ? undefined
+              : t("count", "releases", { n: releases.length })
+          }
           actions={
             <TabsList>
               <TabsTrigger value="releases">

--- a/src/pages/Helm.tsx
+++ b/src/pages/Helm.tsx
@@ -102,7 +102,9 @@ export function Helm() {
     isLoading,
     refetch,
   } = useLiveQuery({
-    queryKey: ["helm-releases-native", scopeCacheKey(scope.scope) ?? "all"],
+    // `null` for the whole cluster — not `"all"`, which is a name a namespace
+    // can really carry and would then share this cache entry.
+    queryKey: ["helm-releases-native", scopeCacheKey(scope.scope)],
     queryFn: listAcrossScope(scope.scope, async (ns) => {
       try {
         return await commands.listHelmReleasesNative(ns);

--- a/src/pages/Helm.tsx
+++ b/src/pages/Helm.tsx
@@ -106,13 +106,13 @@ export function Helm() {
     // `null` for the whole cluster — not `"all"`, which is a name a namespace
     // can really carry and would then share this cache entry.
     queryKey: ["helm-releases-native", scopeCacheKey(scope.scope)],
-    queryFn: listAcrossScope(scope.scope, async (ns) => {
-      try {
-        return await commands.listHelmReleasesNative(ns);
-      } catch (err) {
-        throw normalizeTauriError(err);
-      }
-    }),
+    // The `commands` wrapper already throws a normalised Error; a second
+    // catch here re-threw a bare string, and the refusal block's
+    // `verbatim(error.message)` then read `.message` off a string and crashed.
+    // Let the wrapper's Error propagate, like every other list.
+    queryFn: listAcrossScope(scope.scope, (ns) =>
+      commands.listHelmReleasesNative(ns)
+    ),
     enabled: isConnected,
     refresh: "steady",
   });
@@ -366,7 +366,7 @@ export function Helm() {
           <HelmReleasesTab
             releases={releases}
             isLoading={isLoading}
-            error={(releasesError as Error | null) ?? null}
+            error={releasesError ?? null}
             helmCliAvailable={helmCliAvailable}
             onRefetch={() => refetch()}
             onShowHistory={setHistoryDialog}

--- a/src/pages/Helm.tsx
+++ b/src/pages/Helm.tsx
@@ -25,8 +25,9 @@ import type {
   HelmChartSearchResult,
   HelmInstallOptions,
 } from "@/generated/types";
-import { EVERY_NAMESPACE } from "@/lib/query-keys";
 import { normalizeTauriError } from "@/lib/error-utils";
+import { listAcrossScope, scopeCacheKey } from "@/lib/namespace-scope";
+import { useNamespaceScope } from "@/hooks/useNamespaceScope";
 import { useClusterStore } from "@/stores/clusterStore";
 import { useDependenciesStore } from "@/stores/dependenciesStore";
 import { useT } from "@/i18n/useT";
@@ -46,11 +47,12 @@ export function Helm() {
     null
   );
   const [historyDialog, setHistoryDialog] = useState<HelmRelease | null>(null);
-  // `*`, not the word "all": a namespace can be named `all` — the API server
-  // takes it — and then picking it selected every namespace instead. Names
-  // are RFC-1123 labels, so `*` is one no namespace can answer to.
-  const [selectedNamespace, setSelectedNamespace] =
-    useState<string>(EVERY_NAMESPACE);
+  // The releases list follows the window's namespace selection like every
+  // other list, rather than carrying a second dropdown of its own. A two- or
+  // more namespace scope is read one namespace at a time, so a user with rights
+  // in some namespaces and not others still sees theirs — a single cluster-wide
+  // secret list would 403 and come back empty. See `listAcrossScope`.
+  const scope = useNamespaceScope();
   const [activeTab, setActiveTab] = useState<string>("releases");
 
   const [addRepoDialogOpen, setAddRepoDialogOpen] = useState(false);
@@ -100,16 +102,14 @@ export function Helm() {
     isLoading,
     refetch,
   } = useLiveQuery({
-    queryKey: ["helm-releases-native", selectedNamespace],
-    queryFn: async () => {
+    queryKey: ["helm-releases-native", scopeCacheKey(scope.scope) ?? "all"],
+    queryFn: listAcrossScope(scope.scope, async (ns) => {
       try {
-        const ns =
-          selectedNamespace === EVERY_NAMESPACE ? null : selectedNamespace;
         return await commands.listHelmReleasesNative(ns);
       } catch (err) {
         throw normalizeTauriError(err);
       }
-    },
+    }),
     enabled: isConnected,
     refresh: "steady",
   });
@@ -364,9 +364,6 @@ export function Helm() {
             releases={releases}
             isLoading={isLoading}
             helmCliAvailable={helmCliAvailable}
-            namespaces={namespaces}
-            selectedNamespace={selectedNamespace}
-            onNamespaceChange={setSelectedNamespace}
             onRefetch={() => refetch()}
             onShowHistory={setHistoryDialog}
             onUpgrade={(release) => {

--- a/src/pages/Helm.tsx
+++ b/src/pages/Helm.tsx
@@ -100,6 +100,7 @@ export function Helm() {
   const {
     data: releases = [],
     isLoading,
+    error: releasesError,
     refetch,
   } = useLiveQuery({
     // `null` for the whole cluster — not `"all"`, which is a name a namespace
@@ -365,6 +366,7 @@ export function Helm() {
           <HelmReleasesTab
             releases={releases}
             isLoading={isLoading}
+            error={(releasesError as Error | null) ?? null}
             helmCliAvailable={helmCliAvailable}
             onRefetch={() => refetch()}
             onShowHistory={setHistoryDialog}


### PR DESCRIPTION
Follow-ups to #141/#142 (the multi-namespace and RBAC work for #137/#138), plus a test flake.

### Gateway routes follow the namespace scope (32ff3d1)
`GatewayRoutesList` was the last list still built off its own path (`useGatewayRoutes`) instead of the shared scope. A 2+ namespace selection now reads each namespace on its own and merges, and the watch gives way to polling for a multi-namespace scope — same as every other list since #141. Without it, a route list came back empty for a user with rights in their namespaces but not cluster-wide.

### Helm releases follow the scope too (1c47916)
The Helm tab carried a second namespace `<select>` of its own, defaulting to a cluster-wide secret list — the same shape as the bug above, and the "ps" question in #137 ("why does Helm have its own namespace picker?"). Dropped the redundant control; releases now read through the global scope with per-namespace fan-out. The install dialog keeps its own namespace field — that is a genuinely separate choice.

### A refused cluster overview reads as no-access (3a960a2, #138)
The Overview does a cluster-wide pod list, so an RBAC-scoped user without cluster read rights got the raw `Tauri command 'getClusterOverview' failed: … pods is forbidden … (code: 403)` dump under a red "Could not read cluster state", with a Retry that refuses the same way — the screenshot in #138. It now branches on `isRefusal`: a lock, a plain "you don't have permission — pick the namespaces you can see at the top", the framing prefix stripped with `verbatim()`, and no retry. Any other failure keeps its fault headline and its retry.

### Stop the PTY echo flake (f49de69)
`a_token_longer_than_the_console_survives_being_drawn_on_it` and `a_token_that_never_wraps_comes_back_whole` answered ConPTY's `ESC[6n` cursor query by writing `\x1b[1;1R` on every platform. Only ConPTY asks; a Unix pty asks nothing and `cat FILE` never reads stdin, so on Unix that write reached only the line discipline, which echoed it (`^[[1;1R`) back into the collected stream and, under load, into the middle of the token — the "3900 characters came back where 3893 went in" flake. The answer is now written only on Windows.

Verified: full frontend suite (2264 passed / 2 skipped), tsc and eslint clean; the two PTY tests run 30× under CPU load with zero failures, and the echo mechanism reproduces deterministically when the write is re-enabled on Unix (3999 vs 3992 bytes). The overview refusal branch has a sabotage-checked test.

---

### Review-driven fixes (a regression workflow over this branch found 7, all verified)

- **Sidebar route/gateway counts** narrowed by the collapsed `currentNamespace` (`""`→whole cluster for a 2+ selection), disagreeing with the page this branch migrated. Narrow by the full `namespaceScope`. (`9405e48`)
- **`"all"` cache-key sentinel** for the whole cluster collides with a namespace literally named `all`; key it as `null`. (`9405e48`)
- **`listAcrossScope` used `Promise.all`**, so one namespace's 403 erased every readable namespace's rows. Settle per namespace: keep what came back, and still never answer an empty list when a read was refused. (`927bd46`)
- **Helm releases** never read the query error → a refusal showed an empty table; now an `isRefusal`-aware block. (`927bd46`)
- **Status bar & namespace picker** read the same refused overview as `0 pods · 0 problems`; carry the unknown as `null` and draw `—`. (`7901723`)
- **The scoped overview still failed for an RBAC user** (cluster-wide node/scheduler reads `?`-propagated); degrade them to a `nodesKnown=false` "no access to the cluster's nodes" note so the workloads the user can read now load — making the "pick your namespaces" copy true. (`f0e7708`)

One piece is deliberately deferred to a follow-up: naming *which* namespace refused beside the surviving rows needs a richer return than the shared `T[]`.

### Second (verification) pass fixes

- **Helm refusal crash**: the list queryFn re-threw a bare string, so the new refusal block's `verbatim(error.message)` read `.message` off a string and threw mid-render. Let the wrapper's Error propagate; the tab uses `errorToShow` and its test now feeds the raw-string shape. (`9f45bb3`)
- **Merged overview self-consistency**: a fan-out fold demoted `nodesKnown` but kept the first part's node count; blank `nodes`/`counts.nodes` when the fold is unknown. (`9f45bb3`)

Known follow-up (honest-unknown today, not a false count): the sidebar's Gateway/Routes **count** still fetches cluster-wide, so a namespace-scoped RBAC user sees a blank count there while the page (per-namespace fan-out) shows their routes. Matching them needs a GatewayRows fetch rework that keeps cluster-wide gateways for cross-namespace attachment verdicts — deliberately deferred rather than rushed into this PR.
