### PR TITLE
fix(test): the pod-metrics mock answers through the selector, like every reader of the store

### DIFF
--- a/src/hooks/usePodsWithMetrics.test.ts
+++ b/src/hooks/usePodsWithMetrics.test.ts
@@ -5,14 +5,29 @@ import type { NodeSilence } from "@/lib/node-reporting";
 import * as metricsModule from "@/lib/metrics";
 import { usePodsWithMetrics } from "./usePodsWithMetrics";
 
+interface ClusterState {
+  isConnected: boolean;
+  currentNamespace: string;
+  namespaceScope: string[];
+}
+
 const state = vi.hoisted(() => ({
   pods: [] as PodInfo[],
   metrics: [] as PodMetrics[],
   silent: new Map<string, NodeSilence>(),
+  cluster: {
+    isConnected: true,
+    currentNamespace: "default",
+    namespaceScope: [],
+  } as ClusterState,
 }));
 
+// Through the selector, not around it: every reader of this store passes one,
+// and a mock that answers with the whole state hands `useNamespaceScope` an
+// object where it expects the array it selected.
 vi.mock("@/stores/clusterStore", () => ({
-  useClusterStore: () => ({ isConnected: true, currentNamespace: "default" }),
+  useClusterStore: (selector?: (cluster: ClusterState) => unknown) =>
+    selector ? selector(state.cluster) : state.cluster,
 }));
 vi.mock("@/hooks/useLiveQuery", () => ({
   useLiveQuery: () => ({ data: state.pods, isLoading: false, error: null }),


### PR DESCRIPTION
**main is red right now**, and neither PR that made it so was wrong on its own.

## What is wrong

#125 added `usePodsWithMetrics.test.ts` with a store mock that answers with the whole state and ignores the selector it is handed. #142 changed `usePodsWithMetrics` to read its namespace scope through `useNamespaceScope`, which selects one field. Each was green against the main it was written on; together the hook selects `namespaceScope` from a mock that hands back an object, and four tests die with `TypeError: scope is not iterable`.

## What changes

The mock answers through the selector, the way the real store does, with `namespaceScope: []` in the state it selects from. Nothing in `src/` changes; the four tests assert exactly what they asserted before.

## How to check it

`bunx vitest run src/hooks/usePodsWithMetrics.test.ts` is 4 passed. Whole suite: 2322 passed.

## Risk and rollback

Test-only. Revert is one commit.