### PR TITLE
fix(rbac): lock CRD-based integrations and Routes when CRDs are unreadable

### DIFF
--- a/src-tauri/src/commands/access.rs
+++ b/src-tauri/src/commands/access.rs
@@ -121,6 +121,40 @@ pub async fn check_list_access(
         .collect())
 }
 
+/// The attributes that ask "may I get a customresourcedefinition".
+///
+/// A different verb from `list`, and that difference is the whole reason this
+/// exists: a CRD-backed page (a route kind, a CRD-based integration) resolves
+/// its kind by `get`ting the CRD before it reads a single object, and a token
+/// granted `list` on `customresourcedefinitions` but not `get` — a real and
+/// common split — sails past the nav's list reviews and then meets the wall on
+/// the page. The nav asks the question the page will actually ask.
+#[must_use]
+fn crd_read_attributes() -> ResourceAttributes {
+    ResourceAttributes {
+        group: Some("apiextensions.k8s.io".to_string()),
+        resource: Some("customresourcedefinitions".to_string()),
+        verb: Some("get".to_string()),
+        ..ResourceAttributes::default()
+    }
+}
+
+/// Whether this user may `get` customresourcedefinitions cluster-wide.
+///
+/// `None` where the cluster could not be asked — never folded into a refusal,
+/// the same three-state discipline as [`check_list_access`]: a review that did
+/// not answer must leave the rows as they were, not lock them.
+///
+/// # Errors
+///
+/// If there is no connected cluster.
+#[tauri::command]
+pub async fn check_crd_read_access(state: State<'_, AppState>) -> Result<Option<bool>> {
+    let ctx = ResourceContext::for_list(&state, None)?;
+    let api: Api<SelfSubjectAccessReview> = Api::all(ctx.client.clone());
+    Ok(ask(&api, crd_read_attributes()).await)
+}
+
 /// Whether this user may use a namespace at all.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -233,6 +267,18 @@ mod tests {
         assert_eq!(core.resource.as_deref(), Some("pods"));
         assert_eq!(core.verb.as_deref(), Some("list"));
         assert_eq!(core.namespace.as_deref(), Some("default"));
+    }
+
+    /// The CRD review asks `get`, not `list` — the verb the CRD-backed pages
+    /// use — cluster-wide. A `list` review here would miss the token that may
+    /// list customresourcedefinitions but not get one.
+    #[test]
+    fn the_crd_review_asks_to_get_a_definition_cluster_wide() {
+        let crd = crd_read_attributes();
+        assert_eq!(crd.group.as_deref(), Some("apiextensions.k8s.io"));
+        assert_eq!(crd.resource.as_deref(), Some("customresourcedefinitions"));
+        assert_eq!(crd.verb.as_deref(), Some("get"));
+        assert_eq!(crd.namespace, None);
     }
 
     /// A cluster-scoped kind is not in a namespace. Naming one asks whether

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -124,6 +124,7 @@ fn main() {
             commands::cluster::get_cluster_info,
             commands::cluster::get_kubeconfig_source,
             commands::access::check_list_access,
+            commands::access::check_crd_read_access,
             commands::access::check_namespace_access,
             commands::binaries::locate_binaries,
             commands::diagnostics::collect_diagnostics,

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -13,6 +13,7 @@ const detectInClusterExtensions = vi.fn<() => Promise<DetectedExtension[]>>();
 const listIngresses = vi.fn().mockResolvedValue([]);
 const listCustomResources = vi.fn().mockResolvedValue([]);
 const checkListAccess = vi.fn().mockResolvedValue([]);
+const checkCrdReadAccess = vi.fn().mockResolvedValue(null);
 const resolveIngressClass = vi.fn().mockResolvedValue({
   requested: null,
   resolved: null,
@@ -35,6 +36,7 @@ vi.mock("@/lib/commands", () => ({
     resolveIngressClass: () => resolveIngressClass(),
     getClusterOverview: vi.fn().mockResolvedValue(null),
     checkListAccess: () => checkListAccess(),
+    checkCrdReadAccess: () => checkCrdReadAccess(),
     detectGatewayApi: () => detectGatewayApi(),
     listGatewayRoutes: (kind: string, ns: string | null) =>
       listGatewayRoutes(kind, ns),
@@ -81,6 +83,7 @@ beforeEach(() => {
   listCustomResources.mockResolvedValue([]);
   detectInClusterExtensions.mockResolvedValue([]);
   checkListAccess.mockResolvedValue([]);
+  checkCrdReadAccess.mockResolvedValue(null);
   detectGatewayApi.mockResolvedValue({ installed: false, kinds: [] });
   listGatewayRoutes.mockResolvedValue([]);
   listGateways.mockResolvedValue([]);
@@ -333,6 +336,32 @@ describe("the Integrations category", () => {
   });
 
   /**
+   * The gap #138's reporter hit: the reader can list the vendor's own CRs but
+   * cannot get `customresourcedefinitions` cluster-wide — which the page
+   * resolves first, so it can never open. The CR review alone said "allowed"
+   * and left the row unlocked; the CRD review has to lock it. Fails if the
+   * CRD-access gate is dropped from the vendor's forbidden state.
+   */
+  it("locks a CRD-based vendor the reader may list but whose CRD it cannot read", async () => {
+    detectInClusterExtensions.mockResolvedValue([
+      { id: "flux", installed: true, version: "v2.3.0" },
+    ]);
+    // The reader may list flux's own CRs — so the gate below says "allowed" —
+    // but cannot get the CRD the page resolves first.
+    checkListAccess.mockResolvedValue([
+      { resource: "kustomizations", allowed: true },
+    ]);
+    checkCrdReadAccess.mockResolvedValue(false);
+
+    wrap(<Sidebar />);
+
+    await screen.findByRole("link", { name: /Flux/ });
+    expect(
+      await screen.findByLabelText(/permission to list Flux/i)
+    ).toBeInTheDocument();
+  });
+
+  /**
    * The dot beside the number. A row that is all inventory stays quiet; a
    * page with something worth opening says so in one pixel, because the
    * count itself is not allowed to borrow a colour.
@@ -573,5 +602,44 @@ describe("the Gateway and Routes rows for a namespace-scoped token", () => {
     await waitFor(() =>
       expect(within(routes).getByText("1")).toBeInTheDocument()
     );
+  });
+
+  /**
+   * Same gap as the vendor rows: the route pages resolve each kind's CRD
+   * first — a cluster-scoped get on `customresourcedefinitions` — so a reader
+   * who may list httproutes/gateways but cannot read CRDs still cannot open
+   * them. Both rows must lock. Fails if the CRD gate is dropped from
+   * routesDenied / gatewaysDenied.
+   */
+  it("locks Routes and Gateways when the reader cannot read CRDs", async () => {
+    detectGatewayApi.mockResolvedValue({
+      installed: true,
+      kinds: [{ kind: "Gateway" }, { kind: "HTTPRoute" }],
+    });
+    useClusterStore.setState({
+      isConnected: true,
+      currentContext: "prod",
+      namespaceScope: [],
+    });
+    listGateways.mockResolvedValue([]);
+    listGatewayRoutes.mockResolvedValue([]);
+    // The reader may list the routes and gateways themselves, but cannot get
+    // the CRD each page resolves first.
+    checkListAccess.mockResolvedValue([
+      { resource: "httproutes", allowed: true },
+      { resource: "gateways", allowed: true },
+    ]);
+    checkCrdReadAccess.mockResolvedValue(false);
+
+    wrap(<Sidebar />);
+
+    const routes = await screen.findByRole("link", { name: /routes/i });
+    expect(
+      within(routes).getByLabelText(/permission to list these/i)
+    ).toBeInTheDocument();
+    const gateways = await screen.findByRole("link", { name: /gateways/i });
+    expect(
+      within(gateways).getByLabelText(/permission to list these/i)
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -16,7 +16,7 @@ import { ClusterMenu } from "@/components/cluster/ClusterMenu";
 import { ProviderMark } from "@/components/ui/provider-mark";
 import { Spinner } from "@/components/ui/spinner";
 import { useScopedOverview } from "@/hooks/useClusterOverview";
-import { useListAccess } from "@/hooks/useListAccess";
+import { useCrdReadDenied, useListAccess } from "@/hooks/useListAccess";
 import { useLiveQuery } from "@/hooks/useLiveQuery";
 import { useGatewayApi } from "@/hooks/useGatewayApi";
 import { GATEWAY_ROUTE_KINDS } from "@/hooks/useGatewayRoutes";
@@ -281,10 +281,17 @@ function GatewayRows({ overview }: { overview: ClusterOverview | undefined }) {
     ...(served.has("Gateway") ? [ResourceType.Gateway] : []),
     ...(routeKinds as ResourceKind[]),
   ]);
-  const gatewaysDenied = access[ResourceType.Gateway] === false;
+  // These pages resolve each kind's CRD first — a cluster-scoped get on
+  // `customresourcedefinitions` — so a token refused that cannot open them at
+  // all, whatever its rights on the routes themselves. The list reviews above
+  // cannot see this: a token may list a route kind (or even list CRDs) and
+  // still be refused the get. A mark, never a lock — the row stays a link.
+  const crdDenied = useCrdReadDenied();
+  const gatewaysDenied = crdDenied || access[ResourceType.Gateway] === false;
   const routesDenied =
-    routeKinds.length > 0 &&
-    routeKinds.every((kind) => access[kind as ResourceKind] === false);
+    crdDenied ||
+    (routeKinds.length > 0 &&
+      routeKinds.every((kind) => access[kind as ResourceKind] === false));
 
   const cacheKey = scopeCacheKey(scope);
 

--- a/src/generated/commands.ts
+++ b/src/generated/commands.ts
@@ -244,6 +244,10 @@ export async function checkListAccess(
   return invoke<ListAccess[]>("check_list_access", { queries, namespaces });
 }
 
+export async function checkCrdReadAccess(): Promise<boolean | null> {
+  return invoke<boolean | null>("check_crd_read_access");
+}
+
 export async function checkNamespaceAccess(
   namespaces: string[]
 ): Promise<NamespaceAccess[]> {

--- a/src/hooks/useListAccess.ts
+++ b/src/hooks/useListAccess.ts
@@ -70,3 +70,30 @@ export function useListAccess(kinds: ResourceKind[]): ListAccessMap {
   }
   return marks;
 }
+
+/**
+ * Whether the reader may not `get` customresourcedefinitions cluster-wide —
+ * the read every CRD-backed page (a route kind, a CRD-based integration)
+ * makes to resolve its kind before it reads a single object.
+ *
+ * `get`, not `list`, on purpose: a token granted `list` on
+ * `customresourcedefinitions` but not `get` — a real split — passes every
+ * list review the nav runs and then meets the wall on the page. This asks the
+ * question the page will actually ask, so the row can be marked before the
+ * click. A mark, never a lock: `null`/`undefined` ("could not ask") returns
+ * `false`, so a review that never answered leaves the rows open.
+ */
+export function useCrdReadDenied(): boolean {
+  const currentContext = useClusterStore((s) => s.currentContext);
+  const isConnected = useClusterStore((s) => s.isConnected);
+
+  const { data } = useQuery({
+    queryKey: ["crd-read-access", currentContext],
+    queryFn: () => commands.checkCrdReadAccess(),
+    enabled: isConnected && Boolean(currentContext),
+    staleTime: REVIEW_FRESH_MS,
+    retry: false,
+  });
+
+  return data === false;
+}

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -37,6 +37,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 
 import { commands } from "@/lib/commands";
+import { useCrdReadDenied } from "@/hooks/useListAccess";
 import { useClusterStore } from "@/stores/clusterStore";
 import {
   forwardsFor,
@@ -894,6 +895,14 @@ export function useIntegrationPages(): {
     (vendor): vendor is (typeof here)[number] & { page: VendorPage } =>
       vendor.page?.gate !== undefined
   );
+  // A gated vendor's page reads its CRs by first resolving the CRD — a
+  // cluster-scoped get on `customresourcedefinitions`. A token refused that
+  // cannot open any of them, whatever its rights on the CRs themselves, so the
+  // review of the CR alone (the gate below) missed exactly this reader. The
+  // vendor appears at all only because detection *listed* the CRDs, so this is
+  // a token that may list them and not get one — the get review is the honest
+  // question. A mark, never a lock.
+  const crdDenied = useCrdReadDenied();
   const gateIds = (vendor: (typeof gated)[number]): string[] => {
     const crd = vendor.page.gate!.crd;
     return typeof crd === "string" ? [crd] : [...crd];
@@ -933,6 +942,7 @@ export function useIntegrationPages(): {
   const forbidden = new Set(
     gated
       .filter((vendor) => {
+        if (crdDenied) return true;
         const answers = gateIds(vendor).map((id) =>
           allowedByResource.get(id.slice(0, id.indexOf(".")))
         );


### PR DESCRIPTION
## What #138's reporter hit

After the v4.10.0 RBAC work, a token that can *list* customresourcedefinitions but cannot *get* one — a real, common split — saw cert-manager / Traefik / Istio and the Routes/Gateways rows as normal, clickable entries, and only met the 403 on the page. Detection surfaces a vendor by *listing* the CRDs, and the nav's access review checked the leaf CR's *list* — neither is the `get customresourcedefinitions` the pages actually make to resolve their kind.

## Fix

Add `check_crd_read_access` (an SSAR for `get customresourcedefinitions`, cluster-wide — `get`, not `list`, is the verb the pages use) and fold its refusal into the integration and route/gateway denied state via `useCrdReadDenied`. A mark, never a block — the row stays a link, so a review that never answered leaves it open.

## Verified

Unit tests (sabotage-checked) on the Sidebar rows and a Rust attributes test. Live on a kind cluster with a role granting `list` CRDs + list of the CRs but not `get` CRD: cert-manager / Traefik / Istio show the lock; CRDs and Nodes stay unlocked (list is allowed).

Reported on #138.