### PR TITLE
fix(generated): regenerate bindings for the perf commands (fixes red main)

### DIFF
--- a/src/generated/commands.ts
+++ b/src/generated/commands.ts
@@ -70,6 +70,7 @@ import type {
   NodeFilters,
   NodeInfo,
   NodeMetricsResponse,
+  PerfSnapshot,
   PersistentVolumeClaimInfo,
   PersistentVolumeInfo,
   PodFilters,
@@ -738,6 +739,14 @@ export async function logFrontendEventsBatch(
 
 export async function cancelAuthSession(sessionId: string): Promise<void> {
   return invoke<void>("cancel_auth_session", { sessionId });
+}
+
+export async function perfSetRecording(recording: boolean): Promise<void> {
+  return invoke<void>("perf_set_recording", { recording });
+}
+
+export async function perfCounters(): Promise<PerfSnapshot> {
+  return invoke<PerfSnapshot>("perf_counters");
 }
 
 export async function listServices(

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -1037,6 +1037,14 @@ export type ServiceFilters = {
   serviceType: string | null;
 } & ResourceFilters;
 
+export interface PerfSnapshot {
+  recording: boolean;
+  eventsEmitted: number;
+  eventBytes: number;
+  maxEventBytes: number;
+  watchChanges: number;
+}
+
 export interface BatchLogResult {
   processed: number;
   failed: number;


### PR DESCRIPTION
#124 registered `perf_set_recording`/`perf_counters` in Rust but its regenerated `src/generated/{commands,types}.ts` were staged and never committed, so main's committed bindings lack them while `src/lib/perf-session.ts` calls `commands.perfSetRecording`/`perfCounters` — `bunx tsc --noEmit` fails on a clean checkout of main. Regenerated with `make gen-entities-tauri` (225 commands). tsc + build clean.