### PR TITLE
chore: keep a local cargo target-dir override out of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Rust
 /target/
+# A local `target-dir` override, so several worktrees share one build
+# directory. It holds an absolute path from one machine.
+/.cargo/
 
 # Node
 node_modules/


### PR DESCRIPTION
## What is wrong today

Several worktrees of this repo each build their own `target/`, which grew to tens of gigabytes of byte-identical dependency artifacts. The fix people reach for is a `.cargo/config.toml` in the repo root pointing `target-dir` at one shared directory.

That file is not ignored. It sits untracked next to `/target/`, so any `git add -A` sweeps it into a commit, and the path inside it is absolute and belongs to one machine:

```toml
[build]
target-dir = "/home/belliel/.cache/cargo-target/k8s-gui"
```

Committed, it silently redirects every other developer's and CI's build output to a directory that does not exist for them.

## What changes

One line in `.gitignore`, beside `/target/` and with the same reason written next to it. Rooted (`/.cargo/`) so it only covers the repo's own override and not a `.cargo` directory somebody adds deeper in the tree on purpose.

## How to check it

```
git check-ignore -v .cargo/config.toml
.gitignore:5:/.cargo/   .cargo/config.toml
```

`git status` no longer offers the file, and `git add -A` cannot pick it up.

## Risk and rollback

None: nothing tracked changes, and no branch has ever carried the file (`git ls-tree -r --name-only <branch> | grep '^\.cargo/'` is empty on all of them). Reverting the line puts the file back in `git status`.