### PR TITLE
fix(connections): a claim list the cluster refused is not a missing claim

### DIFF
--- a/src-tauri/src/commands/connections.rs
+++ b/src-tauri/src/commands/connections.rs
@@ -704,7 +704,7 @@ fn uses_from_spec(
     ns: &str,
     subject: &ObjectRef,
     spec: &PodSpec,
-    claims: &[PersistentVolumeClaim],
+    claims: &Read<PersistentVolumeClaim>,
     out: &mut Neighbourhood,
 ) {
     let mut targets: Vec<(String, String)> = Vec::new();
@@ -765,14 +765,27 @@ fn uses_from_spec(
 
 /// A name a pod spec states, resolved as far as this call actually looked.
 ///
-/// Claims were listed, so they carry their phase and size and can be called
-/// present or missing. `ConfigMaps`, Secrets and `ServiceAccounts` were not, and
-/// saying `notChecked` is the difference between "the app did not ask" and
-/// "the cluster does not have it".
-fn named_object(ns: &str, kind: &str, name: &str, claims: &[PersistentVolumeClaim]) -> ObjectRef {
+/// Claims that were listed carry their phase and size and can be called
+/// present or missing. `ConfigMaps`, Secrets and `ServiceAccounts` were never
+/// listed, and saying `notChecked` is the difference between "the app did not
+/// ask" and "the cluster does not have it".
+///
+/// A claim list the cluster **refused** belongs with the second group, not
+/// the first. Reading `Err` as "no claims came back" is how a 403 became
+/// "this volume does not exist", in red, on a pod whose volume is mounted
+/// and healthy.
+fn named_object(
+    ns: &str,
+    kind: &str,
+    name: &str,
+    claims: &Read<PersistentVolumeClaim>,
+) -> ObjectRef {
     if kind != "PersistentVolumeClaim" {
         return ObjectRef::unchecked(kind, name, Some(ns.to_string()));
     }
+    let Ok(claims) = claims else {
+        return ObjectRef::unchecked(kind, name, Some(ns.to_string()));
+    };
     match claims.iter().find(|claim| claim.name_any() == name) {
         Some(claim) => claim_ref(claim, ns),
         None => ObjectRef::new(kind, name, Some(ns.to_string()), Existence::Missing),
@@ -1098,7 +1111,7 @@ fn budgets_over(
 
 /// What the reads that failed leave the answer unable to say.
 fn unanswered(snapshot: &Snapshot) -> Vec<UnexploredKind> {
-    UnexploredKind::governance(
+    let mut unread = UnexploredKind::governance(
         snapshot
             .autoscalers
             .as_ref()
@@ -1109,7 +1122,19 @@ fn unanswered(snapshot: &Snapshot) -> Vec<UnexploredKind> {
             .as_ref()
             .err()
             .map(std::string::String::as_str),
-    )
+    );
+    // Named here as well as left `notChecked` on the reference: the row goes
+    // quiet either way, and a reader owed an explanation for a volume the
+    // page will not talk about gets it in the one place the page collects
+    // them.
+    if let Err(why) = &snapshot.claims {
+        unread.push(UnexploredKind::unanswered(
+            "PersistentVolumeClaim",
+            "v1",
+            why,
+        ));
+    }
+    unread
 }
 
 // --- ownership ---------------------------------------------------------
@@ -1214,7 +1239,12 @@ struct Snapshot {
     pods: Vec<Pod>,
     services: Vec<Service>,
     ingresses: Vec<Ingress>,
-    claims: Vec<PersistentVolumeClaim>,
+    /// `Err` carries the refusal, and it is not an empty list. A token
+    /// without `persistentvolumeclaims` used to reach `named_object` with no
+    /// claims at all, which resolved every claim a pod mounts to
+    /// `Existence::Missing` and told a person, in red, that a volume that is
+    /// mounted and healthy does not exist.
+    claims: Read<PersistentVolumeClaim>,
     /// `Err` carries why the read failed, and is not the same answer as an
     /// empty list: `autoscaling/v2` is not served by every cluster this app
     /// connects to, and "nothing scales this" is not what a 404 means.
@@ -1289,7 +1319,7 @@ impl Snapshot {
             pods: pods?.items,
             services: services?.items,
             ingresses: ingresses?.items,
-            claims: claims.map(|list| list.items).unwrap_or_default(),
+            claims: read(claims),
             autoscalers: read(autoscalers),
             budgets: read(budgets),
             slices,
@@ -2605,6 +2635,79 @@ mod ownership_tests {
                 None,
                 "{kind} is not in a namespace"
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod refused_claim_tests {
+    use super::*;
+
+    /// What a v1.36 apiserver said to a token without
+    /// `persistentvolumeclaims`, recorded through the live harness.
+    const REFUSED: &str = "ApiError: persistentvolumeclaims is forbidden: User \
+         \"system:serviceaccount:k8s-gui-test:narrow\" cannot list resource \
+         \"persistentvolumeclaims\" in API group \"\" in the namespace \
+         \"k8s-gui-test\": Forbidden";
+
+    /// The defect this file's own doc comment describes, found in it: a
+    /// refused list read as "no claims came back", so every claim a pod
+    /// mounts resolved to `Missing` and the page said, in red, that a
+    /// volume that is mounted and healthy does not exist.
+    ///
+    /// Deleting the `Err` arm of `named_object` puts that back, and this
+    /// fails.
+    #[test]
+    fn a_claim_list_the_cluster_refused_leaves_the_claim_unchecked() {
+        let refused: Read<PersistentVolumeClaim> = Err(REFUSED.to_string());
+        let object = named_object("shop", "PersistentVolumeClaim", "data", &refused);
+
+        assert_eq!(object.existence, Existence::NotChecked);
+        assert!(
+            object.facts.is_none(),
+            "a claim nobody read has no phase or size to state"
+        );
+    }
+
+    /// The other half, and the reason the first is not simply "always say
+    /// notChecked": a list that really came back and really does not hold
+    /// the claim is the app finding a broken pod, which is worth saying.
+    #[test]
+    fn a_claim_absent_from_a_list_that_answered_is_still_missing() {
+        let answered: Read<PersistentVolumeClaim> = Ok(Vec::new());
+        let object = named_object("shop", "PersistentVolumeClaim", "data", &answered);
+
+        assert_eq!(object.existence, Existence::Missing);
+    }
+
+    /// A refusal the reader is owed an explanation for reaches the one
+    /// place the page collects them, beside the governance kinds that have
+    /// carried theirs all along.
+    #[test]
+    fn the_refusal_is_named_among_the_kinds_nobody_looked_at() {
+        let snapshot = Snapshot {
+            pods: Vec::new(),
+            services: Vec::new(),
+            ingresses: Vec::new(),
+            claims: Err(REFUSED.to_string()),
+            autoscalers: Ok(Vec::new()),
+            budgets: Ok(Vec::new()),
+            slices: Ok(Vec::new()),
+            legacy: Err("the slices answered".to_string()),
+            gateway_routes: Vec::new(),
+            gateways: None,
+        };
+
+        let unread = unanswered(&snapshot);
+        let claim = unread
+            .iter()
+            .find(|entry| entry.kind == "PersistentVolumeClaim")
+            .expect("the refused claim list is named");
+        match &claim.why {
+            crate::resources::Unread::Unanswered { said, .. } => {
+                assert!(said.contains("is forbidden"));
+            }
+            other => panic!("the cluster's own words, not {other:?}"),
         }
     }
 }

--- a/src-tauri/tests/live_refusals.rs
+++ b/src-tauri/tests/live_refusals.rs
@@ -1,0 +1,107 @@
+//! What the app says when the cluster refuses it.
+//!
+//! Every `*Known` flag, every `Existence::NotChecked` and every
+//! `not_looked_at` in this codebase exists for one moment: a read the cluster
+//! declined. All of them are unit-tested against a hand-made refusal, and
+//! none had ever been tested against a real 403 until this file.
+//!
+//! Ignored by default. It needs a cluster and an identity narrow enough to be
+//! refused, which is two objects and an impersonating context:
+//!
+//! ```text
+//! kubectl create serviceaccount narrow -n k8s-gui-test
+//! kubectl create role pods-only -n k8s-gui-test \
+//!   --verb=get,list,watch --resource=pods
+//! kubectl create rolebinding narrow-pods-only -n k8s-gui-test \
+//!   --role=pods-only --serviceaccount=k8s-gui-test:narrow
+//! # then a kubeconfig context whose user carries
+//! #   as: system:serviceaccount:k8s-gui-test:narrow
+//! K8S_GUI_REFUSED_CONTEXT=narrow cargo test --test live_refusals -- --ignored --nocapture
+//! ```
+
+use k8s_gui_lib::commands::helpers::ResourceContext;
+use k8s_gui_lib::resources::Existence;
+use k8s_gui_lib::state::AppState;
+
+async fn refused_context(namespace: &str) -> ResourceContext {
+    let name = std::env::var("K8S_GUI_REFUSED_CONTEXT").unwrap_or_else(|_| "narrow".to_string());
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let state = AppState::new().expect("app state");
+    state
+        .client_manager
+        .load_kubeconfig()
+        .await
+        .expect("kubeconfig");
+    let client = state.client_manager.connect(&name).await.expect("connect");
+    ResourceContext::from_client((*client).clone(), namespace.to_string())
+}
+
+fn namespace() -> String {
+    std::env::var("K8S_GUI_INIT_NAMESPACE").unwrap_or_else(|_| "k8s-gui-test".to_string())
+}
+
+fn pod_name() -> String {
+    std::env::var("K8S_GUI_REFUSED_POD").unwrap_or_else(|_| "log-demo".to_string())
+}
+
+/// The neighbourhood of a pod read by an identity allowed to see pods and
+/// nothing else.
+///
+/// The pod itself comes back. Everything around it is refused, and the
+/// question is whether the answer says so or draws an object standing alone
+/// in an empty cluster.
+#[tokio::test]
+#[ignore = "needs a live cluster and a deliberately narrow identity"]
+async fn a_refused_neighbourhood_says_so_instead_of_drawing_an_empty_one() {
+    let namespace = namespace();
+    let ctx = refused_context(&namespace).await;
+    let pod = pod_name();
+
+    let conns = k8s_gui_lib::commands::connections::connections_of(&ctx, "Pod", &pod, None)
+        .await
+        .expect("the pod itself is readable");
+
+    println!("subject: {:?} {}", conns.subject.kind, conns.subject.name);
+    println!("edges: {}", conns.edges.len());
+    println!("published: {}", conns.published.len());
+    println!("stops: {}", conns.stops.len());
+    println!("not_looked_at: {} kinds", conns.not_looked_at.len());
+    for unread in &conns.not_looked_at {
+        println!("  - {} : {:?}", unread.kind, unread.why);
+    }
+
+    let claims: Vec<_> = conns
+        .edges
+        .iter()
+        .filter(|edge| edge.to.kind == "PersistentVolumeClaim")
+        .collect();
+    println!("claim edges: {}", claims.len());
+    for edge in &claims {
+        println!("  - {} existence={:?}", edge.to.name, edge.to.existence);
+    }
+
+    assert!(
+        !conns.not_looked_at.is_empty(),
+        "an identity refused several kinds must leave them named; an empty list \
+         here is the wire contract for 'every kind was read'"
+    );
+    assert!(
+        conns
+            .not_looked_at
+            .iter()
+            .any(|unread| unread.kind == "PersistentVolumeClaim"),
+        "the refused claim list has to be named among them"
+    );
+    for edge in &claims {
+        assert_eq!(
+            edge.to.existence,
+            Existence::NotChecked,
+            "a claim whose list the cluster refused is not a claim that is missing: \
+             {} was drawn as {:?}, which tells a person a mounted, healthy volume \
+             does not exist",
+            edge.to.name,
+            edge.to.existence
+        );
+    }
+}


### PR DESCRIPTION
Found by pointing the app at a real cluster with an identity narrow enough to be refused. Independent of the open stack; based on `main`.

## What is wrong today

This is the sentence [CLAUDE.md](../blob/main/CLAUDE.md) opens with, and it is in `connections.rs`:

> `Vec::new()` on a 403 becomes "there are none" and then "this Gateway does not exist", in red, with nothing failing anywhere.

Here it is a claim rather than a Gateway. `Snapshot::of` read the namespace's claims as

```rust
claims: claims.map(|list| list.items).unwrap_or_default(),
```

so a token without `persistentvolumeclaims` arrived at `named_object` with an empty list, and every claim a pod mounts fell to the `None` arm:

```rust
None => ObjectRef::new(kind, name, Some(ns.to_string()), Existence::Missing),
```

A person whose role does not include PVCs opens a perfectly healthy pod and is told its volume **does not exist**. Nothing fails, nothing is logged, and the reader is sent hunting a storage outage that is not happening.

The function's own doc comment shows how it happened. It says claims "were listed, so they carry their phase and size and can be called present or missing" — sound reasoning, resting on a premise that `unwrap_or_default()` had quietly stopped guaranteeing.

Recorded from the cluster, before:

```
claim edges: 1
  - pvc-demo existence=Missing
```

and after:

```
not_looked_at: 3 kinds
  - PersistentVolumeClaim : Unanswered { version: "v1", said: "...persistentvolumeclaims is forbidden..." }
claim edges: 1
  - pvc-demo existence=NotChecked
```

## What changes

`Snapshot.claims` becomes `Read<PersistentVolumeClaim>`, which is the type the four fields beside it already use for exactly this reason. Three consequences, and no others:

- `named_object` returns `notChecked` for a claim whose list was refused, joining the `ConfigMap`, `Secret` and `ServiceAccount` references that have always said that. A list that really answered and really lacks the claim still says `missing`, because that one is the app finding a broken pod and worth saying.
- `unanswered()` names the refused claim list, so the reader gets the explanation in the one place the page collects them.
- Nothing else: the compiler found no other reader.

## How to check it

- `cargo test --workspace` — three tests in `commands/connections.rs` over the words the apiserver actually said. Deleting the `Err` arm of `named_object` fails the first; the second holds the opposite direction so the fix cannot be "always say notChecked".
- `tests/live_refusals.rs` is new: an ignored harness that points the app at a deliberately narrow identity and asserts the neighbourhood names what it could not read. Its header has the four commands that build the identity. Run:

```
K8S_GUI_REFUSED_CONTEXT=narrow K8S_GUI_REFUSED_POD=shell-demo \
  cargo test --test live_refusals -- --ignored --nocapture
```

## A second defect, in the same struct, not fixed here

The same live run found this, and it is a different shape and a bigger change, so it is not in this PR:

```rust
pods: pods?.items,
services: services?.items,
ingresses: ingresses?.items,
```

An identity that can read pods but not Services gets **no neighbourhood at all**: `connections_of` returns the raw 403 about `services`, so the Connections tab dies whole even though the subject pod is perfectly readable. Loud rather than silent, so less dangerous than the claim, but the pod is right there and the answer should be the pod plus the names of what was refused. Happy to take it next if you want it.

## Risk and rollback

Contained. The only behaviour that changes is a claim whose list was refused, which went from `missing` to `notChecked`, plus one more entry in `not_looked_at`. Every path where the list answered is untouched, and a test holds that. Reverting restores the old struct field type.