### PR TITLE
fix(yaml): a long manifest scrolls again (#163)

### DIFF
--- a/src/components/resources/CustomResourceList.tsx
+++ b/src/components/resources/CustomResourceList.tsx
@@ -351,8 +351,13 @@ function formatColumnValue(
       if (typeof value === "string" && isKnownStatus(value)) {
         return <StatusBadge status={value} />;
       }
+      // A printer column is whatever the CRD author chose to show; some are
+      // long, and the cell is the only place it appears.
       return (
-        <span className="max-w-[200px] truncate text-fg-mid">
+        <span
+          className="max-w-[200px] truncate text-fg-mid"
+          title={String(value)}
+        >
           {String(value)}
         </span>
       );

--- a/src/components/resources/GatewayRoutesList.tsx
+++ b/src/components/resources/GatewayRoutesList.tsx
@@ -508,7 +508,13 @@ export function GatewayRoutesList() {
       ))}
 
       {showMap && (
-        <div className="mt-3 flex flex-col gap-1">
+        // Bounded and shrink-proof. The map's board is as tall as the spine
+        // it draws — 56px a node — and as a full-height sibling of the only
+        // scroller it took every pixel: on a cluster with a dozen or more
+        // routes, showing the map left the route list below it with a box
+        // 0px tall, so the rows the header's own counts link to were not on
+        // screen at all and there was nothing to scroll.
+        <div className="mt-3 flex max-h-[45%] shrink-0 flex-col gap-1 overflow-y-auto scrollbar-thin">
           {topology.columns[topology.spine ?? 1].nodes.length === 0 ? (
             <p className="max-w-[64ch] text-xs text-fg-mut">
               {t("empty", "gwNothingToDraw")}
@@ -519,7 +525,9 @@ export function GatewayRoutesList() {
         </div>
       )}
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      {/* A floor as well as a ceiling: whatever is above it, the list keeps
+       *  enough of the pane to be a list. */}
+      <div className="min-h-[8rem] flex-1 overflow-y-auto scrollbar-thin">
         {error && routes.length === 0 ? (
           <div className="max-w-[68ch] py-8">
             <p className="text-xs text-err">

--- a/src/components/resources/GatewayRoutesList.tsx
+++ b/src/components/resources/GatewayRoutesList.tsx
@@ -508,12 +508,8 @@ export function GatewayRoutesList() {
       ))}
 
       {showMap && (
-        // Bounded and shrink-proof. The map's board is as tall as the spine
-        // it draws — 56px a node — and as a full-height sibling of the only
-        // scroller it took every pixel: on a cluster with a dozen or more
-        // routes, showing the map left the route list below it with a box
-        // 0px tall, so the rows the header's own counts link to were not on
-        // screen at all and there was nothing to scroll.
+        // Bounded and shrink-proof: as a full-height sibling of the only
+        // scroller, the map left the route list a box 0px tall.
         <div className="mt-3 flex max-h-[45%] shrink-0 flex-col gap-1 overflow-y-auto scrollbar-thin">
           {topology.columns[topology.spine ?? 1].nodes.length === 0 ? (
             <p className="max-w-[64ch] text-xs text-fg-mut">
@@ -525,8 +521,7 @@ export function GatewayRoutesList() {
         </div>
       )}
 
-      {/* A floor as well as a ceiling: whatever is above it, the list keeps
-       *  enough of the pane to be a list. */}
+      {/* A floor: whatever is above it, the list stays a list. */}
       <div className="min-h-[8rem] flex-1 overflow-y-auto scrollbar-thin">
         {error && routes.length === 0 ? (
           <div className="max-w-[68ch] py-8">

--- a/src/components/resources/detail-blocks.tsx
+++ b/src/components/resources/detail-blocks.tsx
@@ -598,7 +598,9 @@ function EventRow({
         />
         <span className="truncate">{event.reason ?? "—"}</span>
       </span>
-      <span className="truncate text-fg-mid">
+      {/* The row truncates, and an Event has no detail page to open, so the
+       *  controller's own sentence is otherwise unreachable. */}
+      <span className="truncate text-fg-mid" title={event.message ?? undefined}>
         {showObject && (
           <ResourceRef
             kind={subject.kind}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -33,7 +33,11 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-3 rounded-lg border border-hair bg-raise p-4 text-fg-mid shadow-pop duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        // A ceiling and a scroller, for the same reason as `DialogContent`:
+        // the panel is centred, so an unbounded body — a confirmation
+        // carrying a message the cluster wrote — grows off both edges and
+        // takes its own buttons with it.
+        "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100vh-2rem)] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-3 overflow-y-auto scrollbar-thin rounded-lg border border-hair bg-raise p-4 text-fg-mid shadow-pop duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
         className
       )}
       {...props}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -33,10 +33,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        // A ceiling and a scroller, for the same reason as `DialogContent`:
-        // the panel is centred, so an unbounded body — a confirmation
-        // carrying a message the cluster wrote — grows off both edges and
-        // takes its own buttons with it.
+        // Bounded like `DialogContent`, and for the same reason.
         "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100vh-2rem)] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-3 overflow-y-auto scrollbar-thin rounded-lg border border-hair bg-raise p-4 text-fg-mid shadow-pop duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
         className
       )}

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -98,7 +98,9 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-36 overflow-hidden rounded-lg border border-hair bg-raise p-1 text-fg-mid shadow-pop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        // As tall as the space Radix measured, like `SelectContent`: the
+        // picker beside it caps the same kubeconfig list, this did not.
+        "z-50 max-h-[min(var(--radix-context-menu-content-available-height),24rem)] min-w-36 overflow-y-auto scrollbar-thin rounded-lg border border-hair bg-raise p-1 text-fg-mid shadow-pop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.test.tsx
+++ b/src/components/ui/dialog.test.tsx
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * A dialog is centred with `translate-y-[-50%]`, so a body the cluster
+ * decides the length of — the pods a drain refused, the Services a connect
+ * form matched, a message a controller wrote — grows off **both** edges of
+ * the window. The title and the ✕ leave the top, the buttons leave the
+ * bottom, and nothing scrolls: Radix locks the page behind the panel, and a
+ * `position: fixed` box cannot be scrolled into view by any ancestor.
+ *
+ * Three call sites had each bounded themselves by hand (`max-h-[80vh]`,
+ * `h-[85vh]`, `h-[600px]`) and the rest had not, which is what made it a
+ * property of the primitive rather than of any one dialog.
+ *
+ * Read as source text on purpose: the class string is the whole contract,
+ * and rendering it in jsdom would assert nothing, since jsdom computes no
+ * layout and Tailwind's classes are not stylesheets here.
+ */
+
+const PRIMITIVES = [
+  "src/components/ui/dialog.tsx",
+  "src/components/ui/alert-dialog.tsx",
+];
+
+describe("every dialog panel is bounded by the window", () => {
+  it.each(PRIMITIVES)("%s keeps its content reachable", (path) => {
+    const source = readFileSync(path, "utf8");
+    const panel = source
+      .split("\n")
+      .find((line) => line.includes("fixed left-[50%] top-[50%]"));
+    expect(panel, `${path} has no centred panel class`).toBeDefined();
+    // A ceiling, so it cannot grow past the window…
+    expect(panel).toContain("max-h-[calc(100vh-2rem)]");
+    // …and a way to reach what does not fit, styled like every other
+    // scroller in the app rather than the platform's default.
+    expect(panel).toContain("overflow-y-auto");
+    expect(panel).toContain("scrollbar-thin");
+  });
+});

--- a/src/components/ui/dialog.test.tsx
+++ b/src/components/ui/dialog.test.tsx
@@ -1,39 +1,30 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-/**
- * A dialog is centred with `translate-y-[-50%]`, so a body the cluster
- * decides the length of — the pods a drain refused, the Services a connect
- * form matched, a message a controller wrote — grows off **both** edges of
- * the window. The title and the ✕ leave the top, the buttons leave the
- * bottom, and nothing scrolls: Radix locks the page behind the panel, and a
- * `position: fixed` box cannot be scrolled into view by any ancestor.
- *
- * Three call sites had each bounded themselves by hand (`max-h-[80vh]`,
- * `h-[85vh]`, `h-[600px]`) and the rest had not, which is what made it a
- * property of the primitive rather than of any one dialog.
- *
- * Read as source text on purpose: the class string is the whole contract,
- * and rendering it in jsdom would assert nothing, since jsdom computes no
- * layout and Tailwind's classes are not stylesheets here.
- */
-
 const PRIMITIVES = [
   "src/components/ui/dialog.tsx",
   "src/components/ui/alert-dialog.tsx",
 ];
 
 describe("every dialog panel is bounded by the window", () => {
+  /**
+   * A dialog is centred with `translate-y-[-50%]`, so a body the cluster
+   * decides the length of — the pods a drain refused, the Services a connect
+   * form matched — grows off **both** edges: the title and the ✕ leave the
+   * top, the buttons the bottom, and nothing scrolls, because Radix locks the
+   * page behind the panel and a `fixed` box cannot be scrolled into view by
+   * any ancestor. Three call sites had bounded themselves by hand and the
+   * rest had not, which is what makes it the primitive's job.
+   *
+   * Read as source text: the class string is the whole contract, and jsdom
+   * computes no layout.
+   */
   it.each(PRIMITIVES)("%s keeps its content reachable", (path) => {
-    const source = readFileSync(path, "utf8");
-    const panel = source
+    const panel = readFileSync(path, "utf8")
       .split("\n")
       .find((line) => line.includes("fixed left-[50%] top-[50%]"));
     expect(panel, `${path} has no centred panel class`).toBeDefined();
-    // A ceiling, so it cannot grow past the window…
     expect(panel).toContain("max-h-[calc(100vh-2rem)]");
-    // …and a way to reach what does not fit, styled like every other
-    // scroller in the app rather than the platform's default.
     expect(panel).toContain("overflow-y-auto");
     expect(panel).toContain("scrollbar-thin");
   });

--- a/src/components/ui/dialog.test.tsx
+++ b/src/components/ui/dialog.test.tsx
@@ -8,16 +8,11 @@ const PRIMITIVES = [
 
 describe("every dialog panel is bounded by the window", () => {
   /**
-   * A dialog is centred with `translate-y-[-50%]`, so a body the cluster
-   * decides the length of — the pods a drain refused, the Services a connect
-   * form matched — grows off **both** edges: the title and the ✕ leave the
-   * top, the buttons the bottom, and nothing scrolls, because Radix locks the
-   * page behind the panel and a `fixed` box cannot be scrolled into view by
-   * any ancestor. Three call sites had bounded themselves by hand and the
-   * rest had not, which is what makes it the primitive's job.
-   *
-   * Read as source text: the class string is the whole contract, and jsdom
-   * computes no layout.
+   * A dialog is centred, so a body the cluster decides the length of grows
+   * off **both** edges and takes the ✕ and the buttons with it — and nothing
+   * scrolls, because Radix locks the page behind the panel and a `fixed` box
+   * cannot be scrolled into view. Three call sites had bounded themselves by
+   * hand and the rest had not. Read as source text: jsdom computes no layout.
    */
   it.each(PRIMITIVES)("%s keeps its content reachable", (path) => {
     const panel = readFileSync(path, "utf8")

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -41,13 +41,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        // The same guard vertically. The panel is centred with
-        // `translate-y-[-50%]`, so without a ceiling it grows off *both*
-        // edges of the window once its body is a list the cluster decides
-        // the length of — the pods a drain refused, the Services a connect
-        // form matched — taking the title and the ✕ off the top and the
-        // buttons off the bottom, with nothing to scroll. Three call sites
-        // had each bounded themselves; the rest had not.
+        // The same guard vertically: centred, an unbounded body grows off
+        // *both* edges and takes the ✕ and the buttons with it.
         //
         // `minmax(0,1fr)` rather than the implicit `auto` track: an auto
         // track is floored at its items' min-content, so one unbreakable

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -41,13 +41,21 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
+        // The same guard vertically. The panel is centred with
+        // `translate-y-[-50%]`, so without a ceiling it grows off *both*
+        // edges of the window once its body is a list the cluster decides
+        // the length of — the pods a drain refused, the Services a connect
+        // form matched — taking the title and the ✕ off the top and the
+        // buttons off the bottom, with nothing to scroll. Three call sites
+        // had each bounded themselves; the rest had not.
+        //
         // `minmax(0,1fr)` rather than the implicit `auto` track: an auto
         // track is floored at its items' min-content, so one unbreakable
         // mono string (a long Service name in a connect form) silently
         // widens the column past max-w-lg and every control in the dialog
         // renders past the panel border. A zero-floored track keeps the
         // children at the panel's width and lets their own truncation work.
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] grid-cols-[minmax(0,1fr)] gap-3 rounded-lg border border-hair bg-raise p-4 text-fg-mid shadow-pop duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100vh-2rem)] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] grid-cols-[minmax(0,1fr)] gap-3 overflow-y-auto scrollbar-thin rounded-lg border border-hair bg-raise p-4 text-fg-mid shadow-pop duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
         className
       )}
       {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -50,7 +50,8 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-36 overflow-hidden rounded-lg border border-hair bg-raise p-1 text-fg-mid shadow-pop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+      // Bounded by the space Radix measured, like `SelectContent`.
+      "z-50 max-h-[min(var(--radix-dropdown-menu-content-available-height),24rem)] min-w-36 overflow-y-auto scrollbar-thin rounded-lg border border-hair bg-raise p-1 text-fg-mid shadow-pop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
       className
     )}
     {...props}
@@ -68,7 +69,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-36 overflow-hidden rounded-lg border border-hair bg-raise p-1 text-fg-mid shadow-pop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+        "z-50 max-h-[min(var(--radix-dropdown-menu-content-available-height),24rem)] min-w-36 overflow-y-auto scrollbar-thin rounded-lg border border-hair bg-raise p-1 text-fg-mid shadow-pop data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
         className
       )}
       {...props}

--- a/src/components/yaml/YamlEditorImpl.test.tsx
+++ b/src/components/yaml/YamlEditorImpl.test.tsx
@@ -1,0 +1,51 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * `react-codemirror` mounts the editor inside a wrapper `div` of its own, and
+ * the `height` prop only styles the `.cm-editor` beneath it. A percentage
+ * there resolves against that wrapper — so with the wrapper left at `auto`
+ * the editor grew to the whole document instead of to its box, the container
+ * clipped it, and a long manifest had no scrollbar and did not answer the
+ * mouse wheel (issue #163, reported on 4.11.0).
+ *
+ * Two of the three surfaces hit it: the detail page's YAML tab and the peek
+ * panel's, both of which pass no `className`. The edit dialog happened to
+ * pass `className="h-full"` and so escaped — which is why this belongs in the
+ * component and not at each call site.
+ */
+
+const captured: { props?: Record<string, unknown> } = {};
+vi.mock("@uiw/react-codemirror", () => ({
+  default: (props: Record<string, unknown>) => {
+    captured.props = props;
+    return <div data-testid="codemirror" />;
+  },
+}));
+vi.mock("@/stores/themeStore", () => ({
+  useThemeStore: (pick: (s: { theme: string }) => unknown) =>
+    pick({ theme: "dark" }),
+}));
+
+const { YamlEditor } = await import("./YamlEditorImpl");
+
+describe("YamlEditor", () => {
+  it("gives its own wrapper the height it was handed, not just the editor", () => {
+    render(<YamlEditor value="a: 1" readOnly height="100%" />);
+    // `style` is not a prop react-codemirror reads; it lands on the wrapper
+    // div it renders, which is the box `.cm-editor { height: 100% }` needs.
+    expect(captured.props?.style).toEqual({ height: "100%" });
+    expect(captured.props?.height).toBe("100%");
+  });
+
+  it("carries a fixed height through the same way", () => {
+    render(<YamlEditor value="a: 1" readOnly height="200px" />);
+    expect(captured.props?.style).toEqual({ height: "200px" });
+  });
+
+  /** The default is the one every read-only surface relies on. */
+  it("defaults to filling its container", () => {
+    render(<YamlEditor value="a: 1" readOnly />);
+    expect(captured.props?.style).toEqual({ height: "100%" });
+  });
+});

--- a/src/components/yaml/YamlEditorImpl.test.tsx
+++ b/src/components/yaml/YamlEditorImpl.test.tsx
@@ -1,20 +1,6 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-/**
- * `react-codemirror` mounts the editor inside a wrapper `div` of its own, and
- * the `height` prop only styles the `.cm-editor` beneath it. A percentage
- * there resolves against that wrapper — so with the wrapper left at `auto`
- * the editor grew to the whole document instead of to its box, the container
- * clipped it, and a long manifest had no scrollbar and did not answer the
- * mouse wheel (issue #163, reported on 4.11.0).
- *
- * Two of the three surfaces hit it: the detail page's YAML tab and the peek
- * panel's, both of which pass no `className`. The edit dialog happened to
- * pass `className="h-full"` and so escaped — which is why this belongs in the
- * component and not at each call site.
- */
-
 const captured: { props?: Record<string, unknown> } = {};
 vi.mock("@uiw/react-codemirror", () => ({
   default: (props: Record<string, unknown>) => {
@@ -30,6 +16,15 @@ vi.mock("@/stores/themeStore", () => ({
 const { YamlEditor } = await import("./YamlEditorImpl");
 
 describe("YamlEditor", () => {
+  /**
+   * `react-codemirror` mounts the editor inside a wrapper `div` of its own,
+   * and `height` only styles the `.cm-editor` beneath it. A percentage there
+   * resolves against that wrapper — left at `auto`, the editor grew to the
+   * whole document, the container clipped it, and a long manifest had no
+   * scrollbar and ignored the wheel (issue #163). Two of the three surfaces
+   * hit it; the edit dialog escaped only because it passes `h-full`, which
+   * is why this belongs in the component.
+   */
   it("gives its own wrapper the height it was handed, not just the editor", () => {
     render(<YamlEditor value="a: 1" readOnly height="100%" />);
     // `style` is not a prop react-codemirror reads; it lands on the wrapper

--- a/src/components/yaml/YamlEditorImpl.tsx
+++ b/src/components/yaml/YamlEditorImpl.tsx
@@ -51,12 +51,8 @@ export function YamlEditor({
     <CodeMirror
       value={value}
       height={height}
-      // `react-codemirror` mounts the editor inside a wrapper div of its own,
-      // and `height` only styles the `.cm-editor` beneath it. A percentage
-      // there resolves against that wrapper — which had no height, so it
-      // collapsed to `auto` and the editor grew to the whole document. The
-      // container clipped it, and a 400-line manifest had no scrollbar and
-      // did not answer the wheel. The wrapper takes the height it was told.
+      // The wrapper react-codemirror renders needs the height too: `height`
+      // only reaches `.cm-editor`, whose percentage resolves against it.
       style={{ height }}
       // The palette is ours; see editor-theme.ts.
       theme="none"

--- a/src/components/yaml/YamlEditorImpl.tsx
+++ b/src/components/yaml/YamlEditorImpl.tsx
@@ -51,6 +51,13 @@ export function YamlEditor({
     <CodeMirror
       value={value}
       height={height}
+      // `react-codemirror` mounts the editor inside a wrapper div of its own,
+      // and `height` only styles the `.cm-editor` beneath it. A percentage
+      // there resolves against that wrapper — which had no height, so it
+      // collapsed to `auto` and the editor grew to the whole document. The
+      // container clipped it, and a 400-line manifest had no scrollbar and
+      // did not answer the wheel. The wrapper takes the height it was told.
+      style={{ height }}
       // The palette is ours; see editor-theme.ts.
       theme="none"
       extensions={extensions}

--- a/src/components/yaml/YamlResultDisplay.tsx
+++ b/src/components/yaml/YamlResultDisplay.tsx
@@ -1,6 +1,7 @@
 import { CheckCircle2, XCircle } from "lucide-react";
 import type { ManifestResult } from "@/generated/types";
 import { cn } from "@/lib/utils";
+import { useT } from "@/i18n/useT";
 
 export interface YamlResultDisplayProps {
   result: ManifestResult;
@@ -12,6 +13,7 @@ export interface YamlResultDisplayProps {
  * green block on the canvas would be the only surface on the screen.
  */
 export function YamlResultDisplay({ result }: YamlResultDisplayProps) {
+  const t = useT();
   return (
     <div className="border-t border-hair pt-2 text-xs">
       <p
@@ -25,15 +27,19 @@ export function YamlResultDisplay({ result }: YamlResultDisplayProps) {
         ) : (
           <XCircle className="h-3.5 w-3.5 flex-none" />
         )}
-        {result.success ? "Success" : "Error"}
+        {result.success ? t("settings", "success") : t("action", "error")}
       </p>
+      {/* Bounded, with its own scroller. `kubectl apply` on a big manifest
+       *  answers with a line per object, and unbounded this block pushed
+       *  the dialog's own buttons past the bottom of the window while
+       *  squeezing the editor above it to nothing. */}
       {result.stdout && (
-        <pre className="mt-1.5 whitespace-pre-wrap font-mono text-[11px] text-fg-mid">
+        <pre className="mt-1.5 max-h-40 overflow-y-auto scrollbar-thin whitespace-pre-wrap font-mono text-[11px] text-fg-mid">
           {result.stdout}
         </pre>
       )}
       {result.stderr && (
-        <pre className="mt-1.5 whitespace-pre-wrap font-mono text-[11px] text-err">
+        <pre className="mt-1.5 max-h-40 overflow-y-auto scrollbar-thin whitespace-pre-wrap font-mono text-[11px] text-err">
           {result.stderr}
         </pre>
       )}

--- a/src/components/yaml/YamlResultDisplay.tsx
+++ b/src/components/yaml/YamlResultDisplay.tsx
@@ -29,10 +29,8 @@ export function YamlResultDisplay({ result }: YamlResultDisplayProps) {
         )}
         {result.success ? t("settings", "success") : t("action", "error")}
       </p>
-      {/* Bounded, with its own scroller. `kubectl apply` on a big manifest
-       *  answers with a line per object, and unbounded this block pushed
-       *  the dialog's own buttons past the bottom of the window while
-       *  squeezing the editor above it to nothing. */}
+      {/* Bounded: a line per object squeezed the editor and pushed the
+       *  dialog's buttons past the window. */}
       {result.stdout && (
         <pre className="mt-1.5 max-h-40 overflow-y-auto scrollbar-thin whitespace-pre-wrap font-mono text-[11px] text-fg-mid">
           {result.stdout}

--- a/src/components/yaml/editor-theme.test.ts
+++ b/src/components/yaml/editor-theme.test.ts
@@ -174,11 +174,10 @@ describe("plain scalars the core schema calls constants", () => {
 
 describe("the editor's own scrollbar", () => {
   /**
-   * CodeMirror builds `.cm-scroller` itself, so no class of ours reaches it —
-   * including `scrollbar-thin`, which every other scroller in this app
-   * carries. On a platform that lays scrollbars out rather than overlaying
-   * them, the manifest pane was the only one with a chunky light-grey bar.
-   * Fails if the rules are dropped or the palette stops being a role token.
+   * CodeMirror builds `.cm-scroller` itself, so `scrollbar-thin` never
+   * reaches it and the manifest was the one pane with a platform-default bar
+   * where those are laid out rather than overlaid. Fails if the rules go or
+   * stop using role tokens.
    */
   it("is styled like every other scroller in the window", () => {
     const rules = Object.entries(SPEC).filter(([selector]) =>

--- a/src/components/yaml/editor-theme.test.ts
+++ b/src/components/yaml/editor-theme.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { forceParsing } from "@codemirror/language";
 import { yaml as yamlLanguage } from "@codemirror/lang-yaml";
 import { EditorState } from "@codemirror/state";
+
+import { SPEC } from "./editor-theme";
 import { EditorView } from "@codemirror/view";
 
 import { editorTheme, SYNTAX_HUES } from "./editor-theme";
@@ -168,4 +170,37 @@ describe("plain scalars the core schema calls constants", () => {
     "",
     "truthy",
   ])("leaves %s alone", (text) => expect(isYamlConstant(text)).toBe(false));
+});
+
+describe("the editor's own scrollbar", () => {
+  /**
+   * CodeMirror builds `.cm-scroller` itself, so no class of ours reaches it —
+   * including `scrollbar-thin`, which every other scroller in this app
+   * carries. On a platform that lays scrollbars out rather than overlaying
+   * them, the manifest pane was the only one with a chunky light-grey bar.
+   * Fails if the rules are dropped or the palette stops being a role token.
+   */
+  it("is styled like every other scroller in the window", () => {
+    const rules = Object.entries(SPEC).filter(([selector]) =>
+      selector.startsWith(".cm-scroller")
+    );
+    const bySelector = Object.fromEntries(rules);
+    expect(bySelector[".cm-scroller"]).toMatchObject({
+      scrollbarWidth: "thin",
+      scrollbarColor: "hsl(var(--sel)) transparent",
+    });
+    expect(bySelector[".cm-scroller::-webkit-scrollbar"]).toMatchObject({
+      width: "8px",
+    });
+    expect(bySelector[".cm-scroller::-webkit-scrollbar-thumb"]).toMatchObject({
+      background: "hsl(var(--sel))",
+    });
+    // Role tokens, never a raw colour — the same rule as everywhere else.
+    for (const [, declarations] of rules) {
+      for (const value of Object.values(declarations as object)) {
+        if (typeof value !== "string") continue;
+        expect(value).not.toMatch(/#[0-9a-f]{3,8}\b|\brgb\(/i);
+      }
+    }
+  });
 });

--- a/src/components/yaml/editor-theme.ts
+++ b/src/components/yaml/editor-theme.ts
@@ -61,7 +61,8 @@ export const SYNTAX_HUES = [SCALAR_HUE, CONSTANT_HUE];
 
 const syntax = (hue: number) => `hsl(${hue} var(--syn-s) var(--syn-l))`;
 
-const SPEC = {
+/** Exported so the rules below can be asserted rather than eyeballed. */
+export const SPEC = {
   "&": {
     // The whole point: the manifest sits on the page, not on a card.
     backgroundColor: "transparent",
@@ -73,6 +74,22 @@ const SPEC = {
     fontFamily:
       "'JetBrains Mono Variable', 'JetBrains Mono', Consolas, monospace",
     lineHeight: "1.5",
+    // CodeMirror builds this element itself, so none of the app's classes
+    // reach it — including `scrollbar-thin`, which every other scroller
+    // here carries. On a platform that draws scrollbars in the layout
+    // rather than over it, the manifest was the one pane with a chunky
+    // light-grey bar down its side.
+    scrollbarWidth: "thin",
+    scrollbarColor: "hsl(var(--sel)) transparent",
+  },
+  ".cm-scroller::-webkit-scrollbar": { width: "8px", height: "8px" },
+  ".cm-scroller::-webkit-scrollbar-track": { background: "transparent" },
+  ".cm-scroller::-webkit-scrollbar-thumb": {
+    background: "hsl(var(--sel))",
+    borderRadius: "4px",
+  },
+  ".cm-scroller::-webkit-scrollbar-thumb:hover": {
+    background: "hsl(var(--fg-fnt))",
   },
   ".cm-content": { padding: "6px 0", caretColor: "hsl(var(--fg))" },
   ".cm-gutters": {

--- a/src/components/yaml/editor-theme.ts
+++ b/src/components/yaml/editor-theme.ts
@@ -74,11 +74,7 @@ export const SPEC = {
     fontFamily:
       "'JetBrains Mono Variable', 'JetBrains Mono', Consolas, monospace",
     lineHeight: "1.5",
-    // CodeMirror builds this element itself, so none of the app's classes
-    // reach it — including `scrollbar-thin`, which every other scroller
-    // here carries. On a platform that draws scrollbars in the layout
-    // rather than over it, the manifest was the one pane with a chunky
-    // light-grey bar down its side.
+    // CodeMirror builds this element, so `scrollbar-thin` never reaches it.
     scrollbarWidth: "thin",
     scrollbarColor: "hsl(var(--sel)) transparent",
   },


### PR DESCRIPTION
Closes #163.

## What the reader saw

A ConfigMap or Deployment with a long manifest opened with no vertical
scrollbar, and the mouse wheel did nothing. Reported on 4.11.0 / Windows 11;
reproduced here on a 412-line ConfigMap.

## Why

`@uiw/react-codemirror` mounts CodeMirror inside a wrapper `div` of its own,
and the `height` prop only becomes a theme rule on the `.cm-editor` beneath
it. A percentage there resolves against that wrapper — which had no height, so
it collapsed to `auto`. The editor then grew to the height of the whole
document, the ancestor `overflow-hidden` clipped it, and there was nothing left
to scroll.

Two of the three surfaces had it: the detail page's YAML tab and the peek
panel's, neither of which passes a `className`. The edit dialog escaped only
because it happens to pass `className="h-full"`, which put a height on that
same wrapper by accident. That is why the fix is in the component and not at
each call site — the next surface would have had to remember too.

## Also

`.cm-scroller` is built by CodeMirror, so the app's `scrollbar-thin` never
reached it. On a platform that lays scrollbars out rather than overlaying them
the manifest was the one pane with a platform-default bar down its side; it now
carries the same thin one as every other scroller here.

## How it was checked

Live, on a 412-line ConfigMap, with real wheel events over each surface:
before, the peek panel stayed on line 1 after eight wheel-downs; after, it
reaches line 46, the detail tab line 129 and the dialog line 105. The Data tab
next to it scrolled the whole time, which is how I knew the harness was sound.

Unit: `YamlEditorImpl.test.tsx` asserts the wrapper is handed the height (all
three call shapes), and `editor-theme.test.ts` asserts the scrollbar rules and
that they use role tokens. Both fail when the fix is removed — checked.