### PR TITLE
fix(integrations): a vendor page backed by custom resources states its lock

### DIFF
--- a/src/integrations/aws/index.ts
+++ b/src/integrations/aws/index.ts
@@ -47,6 +47,8 @@ export const awsLoadBalancerController = defineVendor({
       staleTime: ROUTING_STALE,
     }),
     load: () => import("./page"),
+    // The page draws Ingresses; its CR reads carry their own unread marks.
+    gate: null,
   },
   crd,
 });

--- a/src/integrations/azure/index.ts
+++ b/src/integrations/azure/index.ts
@@ -53,6 +53,8 @@ export const aksAddons = defineVendor({
       staleTime: ROUTING_STALE,
     }),
     load: () => import("./page"),
+    // The page draws Ingresses; its CR reads carry their own unread marks.
+    gate: null,
   },
   crd,
 });

--- a/src/integrations/cloudnativepg/index.ts
+++ b/src/integrations/cloudnativepg/index.ts
@@ -2,7 +2,7 @@ import { Database } from "lucide-react";
 
 import { defineVendor, pageCount } from "../registry";
 import { crd } from "./crd";
-import { CLUSTERS_KEY, CNPG_STALE, fetchClusters } from "./data";
+import { CLUSTERS_CRD, CLUSTERS_KEY, CNPG_STALE, fetchClusters } from "./data";
 import { facts } from "./facts";
 import { readCluster } from "./model";
 
@@ -29,6 +29,8 @@ export default defineVendor({
       staleTime: CNPG_STALE,
     }),
     load: () => import("./page"),
+    // The page is the Clusters list and what hangs off it.
+    gate: { crd: CLUSTERS_CRD, namespaced: true },
   },
   crd,
 });

--- a/src/integrations/google-cloud/index.ts
+++ b/src/integrations/google-cloud/index.ts
@@ -64,6 +64,8 @@ export const gkeIngress = defineVendor({
       staleTime: ROUTING_STALE,
     }),
     load: () => import("./page"),
+    // The page draws Ingresses; its CR reads carry their own unread marks.
+    gate: null,
   },
   crd,
 });

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -69,6 +69,7 @@ import type {
   Capabilities,
   ClusterProvider,
   Connect,
+  Gate,
   ConnectionDraft,
   CrdView,
   EdgeConfig,
@@ -905,9 +906,13 @@ export function useIntegrationPages(): {
   // cluster's own authorizer once and draw the row disabled where it is
   // refused — a screen that only errors is worse than one the reader was
   // told not to open. Only detected vendors that declare a `gate` are asked.
+  // `!= null`: `gate: null` is a page that works without its custom resources.
   const gated = here.filter(
-    (vendor): vendor is (typeof here)[number] & { page: VendorPage } =>
-      vendor.page?.gate !== undefined
+    (
+      vendor
+    ): vendor is (typeof here)[number] & {
+      page: VendorPage & { gate: Gate };
+    } => vendor.page?.gate != null
   );
   // A gated vendor's page reads its CRs by first resolving the CRD — a
   // cluster-scoped get on `customresourcedefinitions`. A token refused that
@@ -918,7 +923,7 @@ export function useIntegrationPages(): {
   // question. A mark, never a lock.
   const crdDenied = useCrdReadDenied();
   const gateIds = (vendor: (typeof gated)[number]): string[] => {
-    const crd = vendor.page.gate!.crd;
+    const crd = vendor.page.gate.crd;
     return typeof crd === "string" ? [crd] : [...crd];
   };
   const gateQueries = gated.flatMap((vendor) =>
@@ -927,7 +932,7 @@ export function useIntegrationPages(): {
       return {
         group: id.slice(dot + 1),
         resource: id.slice(0, dot),
-        namespaced: vendor.page.gate!.namespaced,
+        namespaced: vendor.page.gate.namespaced,
       };
     })
   );

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -937,13 +937,21 @@ export interface VendorPage {
   load: () => Promise<{ default: ComponentType }>;
   /**
    * The one list this page cannot do without — the custom resource whose 403
-   * makes the screen useless. When the authorizer refuses the reader this
-   * list, the sidebar row is drawn disabled with a reason rather than linking
-   * to a page that only errors. The id is the CRD's `<plural>.<group>`; an
-   * array is alternative spellings of one kind across a group rename, refused
-   * only when every spelling is.
+   * makes the screen useless. The sidebar row is then drawn disabled with a
+   * reason rather than linking to a page that only errors. The id is the
+   * CRD's `<plural>.<group>`; an array is alternative spellings of one kind
+   * across a group rename, refused only when every spelling is. `null` is a
+   * page that shows something without them, and {@link defineVendor} refuses
+   * silence — which is what a vendor added after the lock says by default,
+   * and how #138 kept coming back.
    */
-  gate?: { crd: string | readonly string[]; namespaced: boolean };
+  gate?: Gate | null;
+}
+
+/** What to ask the cluster's authorizer before offering a vendor's page. */
+export interface Gate {
+  crd: string | readonly string[];
+  namespaced: boolean;
 }
 
 /**
@@ -1065,6 +1073,13 @@ export interface Vendor {
  * Declare a vendor. Only a type-check today, and that is the point: the
  * registry is a list, not a framework.
  */
-export function defineVendor(vendor: Vendor): Vendor {
+/** A page backed by custom resources states its {@link VendorPage.gate}. */
+export function defineVendor<const V extends Vendor>(
+  vendor: V & GateStated<V>
+): Vendor {
   return vendor;
 }
+
+type GateStated<V> = V extends { crd: CrdView; page: VendorPage }
+  ? { page: { gate: Gate | null } }
+  : unknown;

--- a/src/integrations/scylla/index.ts
+++ b/src/integrations/scylla/index.ts
@@ -2,7 +2,12 @@ import { Layers } from "lucide-react";
 
 import { defineVendor, pageCount } from "../registry";
 import { crd } from "./crd";
-import { CLUSTERS_KEY, SCYLLA_STALE, fetchClusters } from "./data";
+import {
+  CLUSTERS_CRD,
+  CLUSTERS_KEY,
+  SCYLLA_STALE,
+  fetchClusters,
+} from "./data";
 import { facts } from "./facts";
 import { readScyllaCluster } from "./model";
 
@@ -29,6 +34,7 @@ export default defineVendor({
       staleTime: SCYLLA_STALE,
     }),
     load: () => import("./page"),
+    gate: { crd: CLUSTERS_CRD, namespaced: true },
   },
   crd,
 });

--- a/src/integrations/vendor-gate.test.ts
+++ b/src/integrations/vendor-gate.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every vendor module, loaded the way the registry loads them — by glob, so a
+ * vendor nobody remembered to mention is still weighed. Same reason as
+ * `vendor-copy.test.ts`, which this sits beside.
+ */
+const MODULES = import.meta.glob<Record<string, unknown>>("./*/index.ts", {
+  eager: true,
+});
+
+interface Weighed {
+  id: string;
+  crd?: unknown;
+  page?: { gate?: { crd: string | readonly string[] } | null };
+}
+
+function vendorsIn(module: Record<string, unknown>): Weighed[] {
+  return Object.values(module).filter(
+    (value): value is Weighed =>
+      typeof value === "object" && value !== null && "extension" in value
+  );
+}
+
+const VENDORS = Object.entries(MODULES).flatMap(([path, module]) =>
+  vendorsIn(module).map((vendor) => ({ path, vendor }))
+);
+
+describe("the lock over a vendor's own page", () => {
+  /**
+   * Issue #138, twice. A page backed by custom resources is useless to a token
+   * refused them, so it declares the CRD to ask the authorizer about — and a
+   * vendor added after that lock existed declares nothing and is silently
+   * never locked, which is how CloudNativePG and Scylla shipped unlocked in
+   * 4.12. `defineVendor` types this now; the type is the guard and this is the
+   * check that the type has not been loosened back.
+   */
+  it("is stated by every vendor whose page is backed by custom resources", () => {
+    const unstated = VENDORS.filter(
+      ({ vendor }) =>
+        vendor.crd !== undefined &&
+        vendor.page !== undefined &&
+        vendor.page.gate === undefined
+    ).map(({ path, vendor }) => `${vendor.id} (${path})`);
+    expect(unstated).toEqual([]);
+  });
+
+  /**
+   * A gate is a string the cluster is asked about, so a typo is a question
+   * about a CRD that does not exist — answered "no" by an authorizer that has
+   * never heard of it, and the row locks for everybody.
+   */
+  it("names a CRD the way the API server spells one", () => {
+    const wrong = VENDORS.flatMap(({ path, vendor }) => {
+      const gate = vendor.page?.gate;
+      if (!gate) return [];
+      const ids = typeof gate.crd === "string" ? [gate.crd] : [...gate.crd];
+      return ids
+        .filter(
+          (id) => !/^[a-z][a-z0-9-]*\.[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/.test(id)
+        )
+        .map((id) => `${vendor.id} (${path}): ${id}`);
+    });
+    expect(wrong).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follows #138, reported again by techmick: the two integrations added in 4.12
have no lock for a token that cannot read CRDs.

### What was wrong

The lock added in #152 is opt-in — `useIntegrations` only asks the authorizer
about vendors whose page declares a `gate`. A vendor added afterwards declares
nothing, is never asked, and is never locked. CloudNativePG and Scylla are
that; so, quietly, were the AWS Load Balancer Controller, GKE Ingress and the
AKS add-ons.

Nothing failed. The vendor appears, its count is right, and only a reader whose
token may `list` customresourcedefinitions but not `get` one sees the
difference — they click through to the API server's own `Forbidden`.

### What changed

`defineVendor` no longer accepts silence: a vendor that declares custom
resources and a page must state its gate. The compiler named all five.

- CloudNativePG and Scylla state theirs — their pages *are* the Clusters list.
- The three cloud controllers state `gate: null`, because their pages draw the
  Ingresses the controller serves and only enrich from the CRs; a lock there
  would cover a screen that works. That is now a decision in the file rather
  than an omission.

`vendor-gate.test.ts` beside it checks the type has not been loosened back, and
that every gate names a CRD the way the API server spells one — a typo'd gate
would be a question about a CRD nobody has, answered "no", locking the row for
everybody.

### Verifying

Unit: sabotage-checked — removing CloudNativePG's gate fails the test and the
compiler.

Live, on the kind cluster, with the token shape that made the first fix wrong:
`list customresourcedefinitions` yes, `get` no, CRs readable.

- CloudNativePG and Scylla now show the padlock, as do cert-manager, Traefik
  and Istio.
- GKE Ingress stays unlocked — the `gate: null` decision rendering as intended.
- The lock is still a mark, never a block: the row opens and the page shows
  `cannot get resource "customresourcedefinitions" ... Forbidden` verbatim.
