### PR TITLE
feat(ux): what a week of use asked for: copyable names, a predictable row click, a search that stays, notes after an update

### DIFF
--- a/shared/file-limits.json
+++ b/shared/file-limits.json
@@ -1,5 +1,6 @@
 {
-  "downloadMaxBytes": 104857600,
+  "downloadMaxBytes": 2147483648,
+  "downloadConfirmBytes": 104857600,
   "previewMaxBytes": 524288,
   "maxEntries": 20000
 }

--- a/src-tauri/src/files/mod.rs
+++ b/src-tauri/src/files/mod.rs
@@ -29,8 +29,9 @@ pub use parse::{FileEntry, FileKind};
 pub const PREVIEW_MAX_BYTES: usize = 512 * 1024;
 /// The cap a download is cut off at — counted as the bytes arrive, into a
 /// scratch file beside the destination, so nothing over it is ever renamed
-/// onto the reader's own file.
-pub const DOWNLOAD_MAX_BYTES: u64 = 100 * 1024 * 1024;
+/// onto the reader's own file. Wide, because the exec channel is the only
+/// slow part and the frontend asks before starting anything that large.
+pub const DOWNLOAD_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 /// Rows per event on the way to the frontend.
 pub const BATCH_ROWS: usize = 500;
 /// The most rows one listing hands over. Nothing capped this: `list_dir`

--- a/src/components/files/FilesTab.test.tsx
+++ b/src/components/files/FilesTab.test.tsx
@@ -318,6 +318,60 @@ describe("FilesTab", () => {
   });
 
   /**
+   * Issue #178: a file over the old 100 MiB cap was refused outright. It is
+   * asked about now, and the file dialog opens only after the answer. Would
+   * break if the confirmation went away, or if the cap fell back under it.
+   */
+  it("asks before a download that will take minutes, and not before a small one", async () => {
+    listing.mockReturnValue(
+      done([
+        {
+          name: "core.1842",
+          kind: "file",
+          mode: "600",
+          size: 300 * 1024 * 1024,
+          modified: null,
+          owner: "app",
+          group: "app",
+          target: null,
+        },
+      ])
+    );
+    readContainerFile.mockResolvedValue({
+      state: "preview",
+      preview: {
+        bytesRead: 1024,
+        truncated: true,
+        binary: true,
+        nonTextShare: 0.5,
+        lossy: false,
+        text: null,
+      },
+    });
+    const { save } = await import("@tauri-apps/plugin-dialog");
+    wrap(
+      <FilesTab
+        pod={pod()}
+        via={null}
+        onDebug={() => {}}
+        onStopVia={() => {}}
+      />
+    );
+    await userEvent.click(screen.getByText("core.1842"));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Download" })
+    );
+    expect(
+      await screen.findByText(/Download core.1842 \(300.0 MB\)\?/)
+    ).toBeInTheDocument();
+    expect(save).not.toHaveBeenCalled();
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Download" }).at(-1)!
+    );
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+  });
+
+  /**
    * "Reading, and nothing has arrived yet" and "the tool finished and found
    * nothing" are two different answers. Only the second one is emptiness, and
    * a listing that streams its rows in spends every read in the first.

--- a/src/components/files/FilesTab.tsx
+++ b/src/components/files/FilesTab.tsx
@@ -30,6 +30,7 @@ import {
   matches,
   modeText,
   mountFor,
+  startPath,
   parentOf,
   sortEntries,
   type FileEntry,
@@ -88,14 +89,9 @@ export function FilesTab({ pod, via, onDebug, onStopVia }: FilesTabProps) {
       ""
   );
   const container = containers.find((c) => c.name === containerName) ?? null;
-  const firstMount = useMemo(
-    () =>
-      pod.volumes
-        .flatMap((v) => v.mounts)
-        .find((m) => m.container === containerName)?.path ?? null,
-    [pod.volumes, containerName]
+  const [path, setPath] = useState<string>(() =>
+    startPath(pod.volumes, containerName)
   );
-  const [path, setPath] = useState<string>(() => firstMount ?? "/");
   const [sort, setSort] = useState<{ key: SortKey; descending: boolean }>({
     key: "name",
     descending: false,

--- a/src/components/files/FilesTab.tsx
+++ b/src/components/files/FilesTab.tsx
@@ -18,11 +18,13 @@ import {
   Square,
 } from "lucide-react";
 
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { useNow, useNowTenths } from "@/hooks/useNow";
 import { commands } from "@/lib/commands";
 import {
+  DOWNLOAD_CONFIRM_BYTES,
   DOWNLOAD_MAX_BYTES,
   PREVIEW_MAX_BYTES,
   crumbs,
@@ -183,58 +185,66 @@ export function FilesTab({ pod, via, onDebug, onStopVia }: FilesTabProps) {
 
   const { toast } = useToast();
   const selectedEntry = rows.find((r) => r.name === selected) ?? null;
-  const download = useCallback(async () => {
-    if (!selectedEntry || !container) return;
-    // The button is disabled past the cap; ⌘S reached the same command with
-    // nothing in its way, and the reader got a refusal from the backend
-    // instead of the sentence the button's tooltip had been showing.
-    if (selectedEntry.size > DOWNLOAD_MAX_BYTES) {
-      toast({
-        title: t("files", "downloadFailed", { name: selectedEntry.name }),
-        description: t("files", "tooBigToDownload", {
-          cap: formatBytes(DOWNLOAD_MAX_BYTES, 0),
-        }),
-        variant: "destructive",
-      });
-      return;
-    }
-    const destination = await save({ defaultPath: selectedEntry.name });
-    if (!destination) return;
-    try {
-      const result = await commands.downloadContainerFile(
-        pod.name,
-        pod.namespace,
-        container.name,
-        joinPath(path, selectedEntry.name),
-        via,
-        destination
-      );
-      if (result.state === "noTools" || result.state === "failed") {
+  const [bigDownload, setBigDownload] = useState(false);
+  const download = useCallback(
+    async (confirmed = false) => {
+      if (!selectedEntry || !container) return;
+      // The button is disabled past the cap; ⌘S reached the same command with
+      // nothing in its way, and the reader got a refusal from the backend
+      // instead of the sentence the button's tooltip had been showing.
+      if (selectedEntry.size > DOWNLOAD_MAX_BYTES) {
         toast({
           title: t("files", "downloadFailed", { name: selectedEntry.name }),
-          description:
-            result.state === "noTools"
-              ? t("files", "noCatInImage")
-              : result.message,
+          description: t("files", "tooBigToDownload", {
+            cap: formatBytes(DOWNLOAD_MAX_BYTES, 0),
+          }),
           variant: "destructive",
         });
-      } else {
+        return;
+      }
+      if (selectedEntry.size > DOWNLOAD_CONFIRM_BYTES && !confirmed) {
+        setBigDownload(true);
+        return;
+      }
+      const destination = await save({ defaultPath: selectedEntry.name });
+      if (!destination) return;
+      try {
+        const result = await commands.downloadContainerFile(
+          pod.name,
+          pod.namespace,
+          container.name,
+          joinPath(path, selectedEntry.name),
+          via,
+          destination
+        );
+        if (result.state === "noTools" || result.state === "failed") {
+          toast({
+            title: t("files", "downloadFailed", { name: selectedEntry.name }),
+            description:
+              result.state === "noTools"
+                ? t("files", "noCatInImage")
+                : result.message,
+            variant: "destructive",
+          });
+        } else {
+          toast({
+            title: t("files", "downloaded", { name: selectedEntry.name }),
+            description:
+              result.state === "written"
+                ? `${destination} · ${formatBytes(result.bytes, 1)}`
+                : destination,
+          });
+        }
+      } catch (error) {
         toast({
-          title: t("files", "downloaded", { name: selectedEntry.name }),
-          description:
-            result.state === "written"
-              ? `${destination} · ${formatBytes(result.bytes, 1)}`
-              : destination,
+          title: t("files", "downloadFailed", { name: selectedEntry.name }),
+          description: normalizeTauriError(error),
+          variant: "destructive",
         });
       }
-    } catch (error) {
-      toast({
-        title: t("files", "downloadFailed", { name: selectedEntry.name }),
-        description: normalizeTauriError(error),
-        variant: "destructive",
-      });
-    }
-  }, [selectedEntry, container, pod.name, pod.namespace, path, via, toast, t]);
+    },
+    [selectedEntry, container, pod.name, pod.namespace, path, via, toast, t]
+  );
 
   const onKey = (event: KeyboardEvent<HTMLDivElement>) => {
     const index = rows.findIndex((r) => r.name === selected);
@@ -267,6 +277,17 @@ export function FilesTab({ pod, via, onDebug, onStopVia }: FilesTabProps) {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
+      <ConfirmDialog
+        open={bigDownload}
+        onOpenChange={setBigDownload}
+        title={t("files", "bigDownloadTitle", {
+          name: selectedEntry?.name ?? "",
+          size: formatBytes(selectedEntry?.size ?? 0, 1),
+        })}
+        description={t("files", "bigDownloadBody")}
+        confirmLabel={t("action", "download")}
+        onConfirm={() => void download(true)}
+      />
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-hair px-3 py-2 text-[11px]">
         <span
           className="flex items-center gap-0.5"
@@ -468,7 +489,7 @@ export function FilesTab({ pod, via, onDebug, onStopVia }: FilesTabProps) {
               entry={previewEntry}
               life={readingLife}
               via={via}
-              onDownload={download}
+              onDownload={() => void download()}
             />
           )}
         </div>

--- a/src/components/layout/CommandPalette.test.tsx
+++ b/src/components/layout/CommandPalette.test.tsx
@@ -116,6 +116,25 @@ describe("the command palette's hits", () => {
     expect(useClusterStore.getState().currentNamespace).toBe("");
   });
 
+  /**
+   * Issue #178: opening a hit in a background tab closed the palette, so a
+   * reader wanting three pods open typed the search three times. Would
+   * break if the background arm went back to closing.
+   */
+  it("stays open after opening a hit in a background tab", async () => {
+    search.hits = [
+      hit({ kind: "Pod", name: "api-web", namespace: "shop" }),
+      hit({ kind: "Pod", name: "api-worker", namespace: "shop" }),
+    ];
+    await open("api");
+    fireEvent.click(await screen.findByText(/api-web/), { ctrlKey: true });
+    expect(useScopeTabStore.getState().tabs).toHaveLength(2);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/api-worker/), { ctrlKey: true });
+    expect(useScopeTabStore.getState().tabs).toHaveLength(3);
+    expect(useScopeTabStore.getState().activeId).toBe("palette");
+  });
+
   it("does not offer a kind the router has no page for at all", async () => {
     search.hits = [
       hit({ kind: "Event", name: "burst-demo.17f", namespace: "k8s-gui-test" }),

--- a/src/components/layout/CommandPalette.tsx
+++ b/src/components/layout/CommandPalette.tsx
@@ -730,7 +730,10 @@ export function CommandPalette() {
             } else {
               void switchNamespace(hit.name);
             }
-            close();
+            // A tab opened behind the palette leaves it standing: the next
+            // one is a keystroke away, and closing was the reason a reader
+            // could not open three pods in a row.
+            if (!newTab) close();
             return;
           }
           // Crossing a cluster boundary costs a tab: switching this one
@@ -742,7 +745,7 @@ export function CommandPalette() {
               namespace: hit.namespace ?? "",
               background: newTab,
             });
-            close();
+            if (!newTab) close();
             return;
           }
           go(entry.path, {
@@ -755,7 +758,6 @@ export function CommandPalette() {
         case "recent":
           if (newTab) {
             openTab({ href: entry.path, background: true });
-            close();
             return;
           }
           go(entry.path, {
@@ -767,7 +769,6 @@ export function CommandPalette() {
         case "link":
           if (newTab) {
             openTab({ href: entry.path, background: true });
-            close();
             return;
           }
           go(entry.path);
@@ -1168,7 +1169,10 @@ function EntryRow({
               namespace={entry.hit.namespace}
               showKind={false}
               onClick={(event) => {
+                // The row underneath picks too; without stopping here a
+                // ctrl-click on the name opened the object in two tabs.
                 event.preventDefault();
+                event.stopPropagation();
                 onPick(event);
               }}
             />
@@ -1198,7 +1202,10 @@ function EntryRow({
               namespace={entry.namespace}
               showKind={false}
               onClick={(event) => {
+                // The row underneath picks too; without stopping here a
+                // ctrl-click on the name opened the object in two tabs.
                 event.preventDefault();
+                event.stopPropagation();
                 onPick(event);
               }}
             />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -16,6 +16,7 @@ import { useDeepLinks } from "@/hooks/useDeepLinks";
 import { useCopyLink } from "@/hooks/useCopyLink";
 import { DeepLinkBanner } from "./DeepLinkBanner";
 import { ObjectMenu } from "@/components/resources/ObjectMenu";
+import { WhatsNew } from "./WhatsNew";
 import { useClusterForwards } from "@/hooks/useClusterForwards";
 import { usePrefetchCoreLists } from "@/hooks/usePrefetchCoreLists";
 import { useCritical } from "@/hooks/useCritical";
@@ -108,6 +109,7 @@ export function Layout() {
       </div>
       <CommandPalette />
       <YamlEditorDialog />
+      <WhatsNew />
       {/* Outside the outlet: one instance, and it survives the route change
           that `Open full page` performs. */}
       <PeekPanel />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -15,6 +15,7 @@ import { useScopeTabs } from "@/hooks/useScopeTabs";
 import { useDeepLinks } from "@/hooks/useDeepLinks";
 import { useCopyLink } from "@/hooks/useCopyLink";
 import { DeepLinkBanner } from "./DeepLinkBanner";
+import { ObjectMenu } from "@/components/resources/ObjectMenu";
 import { useClusterForwards } from "@/hooks/useClusterForwards";
 import { usePrefetchCoreLists } from "@/hooks/usePrefetchCoreLists";
 import { useCritical } from "@/hooks/useCritical";
@@ -95,6 +96,7 @@ export function Layout() {
                 ) : (
                   <>
                     <DeepLinkBanner />
+                    <ObjectMenu />
                     <Outlet />
                   </>
                 )}

--- a/src/components/layout/WhatsNew.test.tsx
+++ b/src/components/layout/WhatsNew.test.tsx
@@ -17,7 +17,7 @@ vi.mock("../../../CHANGELOG.md?raw", () => ({
 
 ### Added
 
-- **Credentials renew themselves.** Quietly.
+- **Credentials renew themselves.** Quietly, and _later_ rather than more often.
 
 ## [4.12.0] - 2026-09-11
 
@@ -57,6 +57,7 @@ describe("WhatsNew", () => {
     expect(
       screen.getByText(/Credentials renew themselves/)
     ).toBeInTheDocument();
+    expect(screen.getByText("later").tagName).toBe("EM");
     expect(screen.queryByText(/Files tab on a pod/)).toBeNull();
     await userEvent.click(
       screen.getAllByRole("button", { name: "Close" }).at(-1)!

--- a/src/components/layout/WhatsNew.test.tsx
+++ b/src/components/layout/WhatsNew.test.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { useWhatsNewStore } from "@/stores/whatsNewStore";
+import { WhatsNew } from "./WhatsNew";
+
+const getAppInfo = vi.fn();
+vi.mock("@/lib/commands", () => ({
+  commands: { getAppInfo: () => getAppInfo() },
+}));
+
+vi.mock("../../../CHANGELOG.md?raw", () => ({
+  default: `## [4.13.0] - 2026-09-12
+
+### Added
+
+- **Credentials renew themselves.** Quietly.
+
+## [4.12.0] - 2026-09-11
+
+### Added
+
+- **Files tab on a pod.**
+`,
+}));
+
+const wrap = (ui: ReactNode) =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      {ui}
+    </QueryClientProvider>
+  );
+
+describe("WhatsNew", () => {
+  beforeEach(() => {
+    getAppInfo.mockResolvedValue({
+      version: "4.13.0",
+      name: "Rubick",
+      tauriVersion: "2",
+      os: "linux",
+    });
+    useWhatsNewStore.setState({ seenVersion: null, showing: [] });
+  });
+
+  /** Issue #178: nobody who skips GitHub ever saw the notes. Would break if the update stopped opening them, or if a first launch started to. */
+  it("opens the notes once after an update, and not on a first launch", async () => {
+    useWhatsNewStore.setState({ seenVersion: "4.12.0" });
+    wrap(<WhatsNew />);
+    expect(await screen.findByText("What's new in 4.13.0")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Credentials renew themselves/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Files tab on a pod/)).toBeNull();
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Close" }).at(-1)!
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("What's new in 4.13.0")).toBeNull()
+    );
+    expect(useWhatsNewStore.getState().seenVersion).toBe("4.13.0");
+  });
+
+  it("records the first launch without opening anything", async () => {
+    wrap(<WhatsNew />);
+    await waitFor(() =>
+      expect(useWhatsNewStore.getState().seenVersion).toBe("4.13.0")
+    );
+    expect(screen.queryByText(/What's new/)).toBeNull();
+  });
+
+  it("shows every release skipped by a reader two versions behind", async () => {
+    useWhatsNewStore.setState({ seenVersion: "4.11.0" });
+    wrap(<WhatsNew />);
+    expect(await screen.findByText("What's new in 4.13.0")).toBeInTheDocument();
+    expect(screen.getByText("Everything since 4.12.0")).toBeInTheDocument();
+    expect(screen.getByText(/Files tab on a pod/)).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/WhatsNew.tsx
+++ b/src/components/layout/WhatsNew.tsx
@@ -1,0 +1,151 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, type ReactNode } from "react";
+
+import changelog from "../../../CHANGELOG.md?raw";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useT } from "@/i18n/useT";
+import {
+  parseChangelog,
+  releasesSince,
+  type ChangeItem,
+  type Release,
+} from "@/lib/changelog";
+import { commands } from "@/lib/commands";
+import { useWhatsNewStore } from "@/stores/whatsNewStore";
+
+const RELEASES = parseChangelog(changelog);
+
+/**
+ * The release notes, shown once after an update. The notes live in
+ * `CHANGELOG.md` and nowhere else, and a reader who does not follow the
+ * repository never saw them; the first launch of a new version now opens
+ * them, and About keeps a way back to the current ones.
+ */
+export function WhatsNew() {
+  const t = useT();
+  const { data: appInfo } = useQuery({
+    queryKey: ["appInfo"],
+    queryFn: commands.getAppInfo,
+    staleTime: Infinity,
+  });
+  const version = appInfo?.version ?? null;
+  const seen = useWhatsNewStore((state) => state.seenVersion);
+  const showing = useWhatsNewStore((state) => state.showing);
+  const markSeen = useWhatsNewStore((state) => state.markSeen);
+  const show = useWhatsNewStore((state) => state.show);
+  const close = useWhatsNewStore((state) => state.close);
+
+  useEffect(() => {
+    if (version === null || seen === version) return;
+    // A first launch has nothing that is new to this reader; it only
+    // records where they start from.
+    const arrived = releasesSince(RELEASES, seen, version);
+    if (arrived.length > 0) show(arrived.map((release) => release.version));
+    markSeen(version);
+  }, [version, seen, show, markSeen]);
+
+  const releases = showing
+    .map((v) => RELEASES.find((release) => release.version === v))
+    .filter((release): release is Release => release !== undefined);
+  if (releases.length === 0) return null;
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && close()}>
+      <DialogContent className="flex max-h-[80vh] flex-col sm:max-w-[640px]">
+        <DialogHeader>
+          <DialogTitle>
+            {t("settings", "whatsNewIn", { version: releases[0].version })}
+          </DialogTitle>
+          <DialogDescription>
+            {releases.length > 1
+              ? t("settings", "whatsNewSince", {
+                  version: releases[releases.length - 1].version,
+                })
+              : (releases[0].date ?? "")}
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="min-h-0 flex-1 pr-3">
+          <div className="flex flex-col gap-5">
+            {releases.map((release) => (
+              <section key={release.version} className="flex flex-col gap-3">
+                {releases.length > 1 && (
+                  <h3 className="font-mono text-xs text-fg-fnt">
+                    {release.version}
+                    {release.date ? ` · ${release.date}` : ""}
+                  </h3>
+                )}
+                {release.sections.map((section) => (
+                  <div key={section.title}>
+                    <h4 className="mb-1.5 text-[11px] font-semibold uppercase tracking-[.07em] text-fg-fnt">
+                      {section.title}
+                    </h4>
+                    <Items items={section.items} />
+                  </div>
+                ))}
+              </section>
+            ))}
+          </div>
+        </ScrollArea>
+        <DialogFooter>
+          <Button size="sm" onClick={close}>
+            {t("action", "close")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Items({ items }: { items: ChangeItem[] }) {
+  return (
+    <ul className="flex flex-col gap-1.5 pl-4 text-xs leading-relaxed text-fg-mut [&>li]:list-disc">
+      {items.map((item, index) => (
+        <li key={index}>
+          {inline(item.text)}
+          {item.children.length > 0 && (
+            <ul className="mt-1 flex flex-col gap-1 pl-4 [&>li]:list-[circle]">
+              {item.children.map((child, childIndex) => (
+                <li key={childIndex}>{inline(child.text)}</li>
+              ))}
+            </ul>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** `**bold**` and `` `code` ``, which is all the notes use. */
+function inline(text: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  const pattern = /\*\*([^*]+)\*\*|`([^`]+)`/g;
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > last) out.push(text.slice(last, match.index));
+    if (match[1] !== undefined)
+      out.push(
+        <strong key={match.index} className="font-semibold text-fg">
+          {match[1]}
+        </strong>
+      );
+    else
+      out.push(
+        <code key={match.index} className="font-mono text-[11px] text-fg">
+          {match[2]}
+        </code>
+      );
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return out;
+}

--- a/src/components/layout/WhatsNew.tsx
+++ b/src/components/layout/WhatsNew.tsx
@@ -124,10 +124,10 @@ function Items({ items }: { items: ChangeItem[] }) {
   );
 }
 
-/** `**bold**` and `` `code` ``, which is all the notes use. */
+/** `**bold**`, `` `code` `` and `_emphasis_`, which is all the notes use. */
 function inline(text: string): ReactNode[] {
   const out: ReactNode[] = [];
-  const pattern = /\*\*([^*]+)\*\*|`([^`]+)`/g;
+  const pattern = /\*\*([^*]+)\*\*|`([^`]+)`|(?<![\w])_([^_]+)_(?![\w])/g;
   let last = 0;
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(text)) !== null) {
@@ -138,12 +138,13 @@ function inline(text: string): ReactNode[] {
           {match[1]}
         </strong>
       );
-    else
+    else if (match[2] !== undefined)
       out.push(
         <code key={match.index} className="font-mono text-[11px] text-fg">
           {match[2]}
         </code>
       );
+    else out.push(<em key={match.index}>{match[3]}</em>);
     last = match.index + match[0].length;
   }
   if (last < text.length) out.push(text.slice(last));

--- a/src/components/resources/CopyName.tsx
+++ b/src/components/resources/CopyName.tsx
@@ -1,0 +1,10 @@
+import { CopyButton } from "@/components/ui/copyable-value";
+import { useT } from "@/i18n/useT";
+
+/** The hover mark beside a name, wherever the name is a link and not a button. */
+export function CopyName({ name }: { name: string }) {
+  const t = useT();
+  return (
+    <CopyButton value={name} label={`${t("action", "copyName")}: ${name}`} />
+  );
+}

--- a/src/components/resources/EditGoverning.tsx
+++ b/src/components/resources/EditGoverning.tsx
@@ -1,0 +1,28 @@
+import { YamlEditorAction } from "@/components/yaml";
+import { fetchResourceYaml } from "@/hooks/useResourceYaml";
+import { useT } from "@/i18n/useT";
+
+/**
+ * The way into an autoscaler or a budget. Neither kind has a page (it is a
+ * property of the workload, not a thing to browse), so the workload's
+ * block is where a reader who wants to change one has to find the editor.
+ */
+export function EditGoverning({
+  object,
+}: {
+  object: { kind: string; name: string; namespace?: string | null };
+}) {
+  const t = useT();
+  const namespace = object.namespace ?? undefined;
+  return (
+    <YamlEditorAction
+      title={t("action", "editResourceTitle", {
+        kind: object.kind,
+        name: object.name,
+      })}
+      resourceKey={{ kind: object.kind, name: object.name, namespace }}
+      fetchYaml={() => fetchResourceYaml(object.kind, object.name, namespace)}
+      className="ml-1.5 h-5 px-1.5 text-[11px]"
+    />
+  );
+}

--- a/src/components/resources/ObjectMenu.tsx
+++ b/src/components/resources/ObjectMenu.tsx
@@ -1,0 +1,69 @@
+import { Copy, ExternalLink, Link2 } from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { useT } from "@/i18n/useT";
+import { buildDeepLink } from "@/lib/deep-link";
+import { useClusterStore } from "@/stores/clusterStore";
+import { useObjectMenuStore } from "@/stores/objectMenuStore";
+import { useScopeTabStore } from "@/stores/scopeTabStore";
+
+/**
+ * The right-click menu of an object link. The webview's own menu offered
+ * "Copy link address" and copied `http://tauri.localhost/...`, an address
+ * that opens nothing anywhere; this one copies the name, the link that
+ * does open, or the object in a tab behind this one.
+ */
+export function ObjectMenu() {
+  const t = useT();
+  const copy = useCopyToClipboard();
+  const target = useObjectMenuStore((state) => state.target);
+  const close = useObjectMenuStore((state) => state.close);
+  const context = useClusterStore((state) => state.currentContext);
+  const openTab = useScopeTabStore((state) => state.openTab);
+  if (target === null) return null;
+  const link = context ? buildDeepLink(context, target.to) : null;
+  return (
+    <DropdownMenu open onOpenChange={(open) => !open && close()}>
+      <DropdownMenuTrigger asChild>
+        <span
+          aria-hidden
+          style={{ position: "fixed", left: target.x, top: target.y }}
+          className="size-0"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[200px]">
+        <DropdownMenuItem
+          onSelect={() =>
+            void copy(
+              target.name,
+              t("action", "nameCopied", { name: target.name })
+            )
+          }
+        >
+          <Copy className="mr-2 size-3.5" aria-hidden />
+          {t("action", "copyName")}
+        </DropdownMenuItem>
+        {link !== null && (
+          <DropdownMenuItem
+            onSelect={() => void copy(link, t("cluster", "linkCopied"))}
+          >
+            <Link2 className="mr-2 size-3.5" aria-hidden />
+            {t("action", "copyLink")}
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem
+          onSelect={() => void openTab({ href: target.to, background: true })}
+        >
+          <ExternalLink className="mr-2 size-3.5" aria-hidden />
+          {t("action", "openInNewTab")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/resources/PeekPanel.test.tsx
+++ b/src/components/resources/PeekPanel.test.tsx
@@ -470,6 +470,18 @@ describe("PeekPanel", () => {
     expect(location()).toBe("/pods/k8s-gui-test/crash-demo-56588f6b8c-8bj9v");
   });
 
+  /** Issue #178: leaving Logs for the page landed on Overview. Would break if the tab stopped travelling. */
+  it("takes the open tab along to the full page", async () => {
+    wrap(POD_PEEK);
+    await openTab("Logs");
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Open full page/ })
+    );
+    expect(location()).toBe(
+      "/pods/k8s-gui-test/crash-demo-56588f6b8c-8bj9v?tab=logs"
+    );
+  });
+
   // Radix owns Escape; a second listener here would close it twice.
   it("closes on Escape by dropping the parameter", async () => {
     wrap(POD_PEEK);

--- a/src/components/resources/PeekPanel.tsx
+++ b/src/components/resources/PeekPanel.tsx
@@ -171,12 +171,14 @@ function PeekContent({
   // A custom resource has a page of its own too — the CRD's instance route —
   // so it gets the same Open full page and the same Enter shortcut.
   const routable = !!target.crd || isRoutableKind(target.kind, namespace);
-  const openFullPage = () =>
-    navigate(
-      target.crd
-        ? getCustomResourceUrl(target.crd, target.name, namespace)
-        : getResourceDetailUrl(target.kind, target.name, namespace)
-    );
+  // The tab the reader is on comes along: leaving Logs for the page and
+  // landing on Overview is a second click nobody asked for.
+  const openFullPage = () => {
+    const path = target.crd
+      ? getCustomResourceUrl(target.crd, target.name, namespace)
+      : getResourceDetailUrl(target.kind, target.name, namespace);
+    navigate(activeTab === "overview" ? path : `${path}?tab=${activeTab}`);
+  };
 
   // Enter is the panel's shortcut, not the focused control's — once the
   // reader has tabbed onto a button, that button owns the key.

--- a/src/components/resources/ResourceDetailHeader.tsx
+++ b/src/components/resources/ResourceDetailHeader.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from "react-router-dom";
 
 import { DataFreshness, RealtimeAge } from "@/components/ui/realtime";
 import { ResourceName } from "@/components/resources/ResourceName";
+import { CopyName } from "@/components/resources/CopyName";
 import { useLinkGesture } from "@/hooks/useLinkGesture";
 import {
   getResourceListUrl,
@@ -209,7 +210,7 @@ export function ResourceDetailHeader({
   // you are on is a promise the app cannot keep. The breadcrumb above already
   // names the kind, so only the glyph carries it.
   const title = (
-    <h1 className="flex min-w-0 items-baseline gap-1.5 font-semibold tracking-tight text-fg">
+    <h1 className="group/name flex min-w-0 items-center gap-1.5 font-semibold tracking-tight text-fg">
       <ResourceName
         kind={kind}
         name={name}
@@ -217,6 +218,7 @@ export function ResourceDetailHeader({
         size="title"
         iconClassName="h-3 w-3"
       />
+      <CopyName name={name} />
     </h1>
   );
 

--- a/src/components/resources/ResourceList.tsx
+++ b/src/components/resources/ResourceList.tsx
@@ -372,6 +372,7 @@ export function ResourceList<
           fill={!embedded}
           isLoading={showSkeleton}
           searchKey={searchKey}
+          searchParam={embedded ? undefined : "q"}
           searchPlaceholder={searchPlaceholder}
           getRowHref={getRowHref}
           quickActions={resolvedQuickActions}

--- a/src/components/resources/ResourceRef.test.tsx
+++ b/src/components/resources/ResourceRef.test.tsx
@@ -11,6 +11,7 @@ import {
   type ResourceColouring,
 } from "@/stores/displaySettingsStore";
 import { useScopeTabStore } from "@/stores/scopeTabStore";
+import { useObjectMenuStore } from "@/stores/objectMenuStore";
 
 /** Where the click landed: the peek is a query parameter, not component state. */
 function LocationProbe() {
@@ -49,6 +50,29 @@ describe("ResourceRef", () => {
       ],
       activeId: "ref-tab",
       pendingHref: null,
+    });
+  });
+
+  /**
+   * Issue #178: a right-click reached the webview's own menu, whose "Copy
+   * link address" copied `http://tauri.localhost/...`. The link now opens
+   * the app's menu instead. Would break if the handler stopped claiming
+   * the event.
+   */
+  it("opens the object menu on a right-click, at the pointer", () => {
+    wrap(<ResourceRef kind="Pod" name="web" namespace="shop" />);
+    fireEvent.contextMenu(screen.getByRole("link", { name: "Pod web" }), {
+      clientX: 40,
+      clientY: 60,
+    });
+    expect(useObjectMenuStore.getState().target).toEqual({
+      kind: "Pod",
+      name: "web",
+      namespace: "shop",
+      crd: undefined,
+      to: "/pods/shop/web",
+      x: 40,
+      y: 60,
     });
   });
 

--- a/src/components/resources/ResourceRef.tsx
+++ b/src/components/resources/ResourceRef.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/resource-registry";
 import { readLinkIntent, useLinkGesture } from "@/hooks/useLinkGesture";
 import { usePeek } from "@/hooks/usePeek";
+import { useObjectMenuStore } from "@/stores/objectMenuStore";
 import {
   ResourceName,
   RESOURCE_NAME_SHELL,
@@ -180,6 +181,18 @@ export function ObjectLink({
       to={to}
       onClick={handle}
       onAuxClick={handle}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        useObjectMenuStore.getState().open({
+          kind,
+          name,
+          namespace,
+          crd,
+          to,
+          x: event.clientX,
+          y: event.clientY,
+        });
+      }}
       // The name is split across spans so the tail can carry its own hue, and
       // the accessible-name algorithm joins those spans with a space — which
       // announces "k3d-agent -0" for a pod that is called neither. Naming the

--- a/src/components/resources/columns.tsx
+++ b/src/components/resources/columns.tsx
@@ -17,6 +17,7 @@ import { parseCPU, parseMemory } from "@/lib/k8s-quantity";
 import { cn } from "@/lib/utils";
 import type { ResourceKind } from "@/lib/resource-registry";
 import { ResourceRef } from "./ResourceRef";
+import { CopyName } from "./CopyName";
 
 interface WithCreatedAt {
   createdAt?: string | null;
@@ -54,12 +55,15 @@ export function createNameColumn<
     accessorKey: "name",
     header: () => <T section="columns" k="name" />,
     cell: ({ row }) => (
-      <ResourceRef
-        kind={kind}
-        name={row.original.name}
-        namespace={row.original.namespace}
-        showKind={false}
-      />
+      <span className="group/name inline-flex min-w-0 max-w-full items-center gap-1">
+        <ResourceRef
+          kind={kind}
+          name={row.original.name}
+          namespace={row.original.namespace}
+          showKind={false}
+        />
+        <CopyName name={row.original.name} />
+      </span>
     ),
   };
 }

--- a/src/components/resources/governance.tsx
+++ b/src/components/resources/governance.tsx
@@ -21,6 +21,7 @@
 
 import type { T } from "@/i18n/useT";
 import { ResourceRef } from "./ResourceRef";
+import { EditGoverning } from "./EditGoverning";
 import {
   autoscalerFinding,
   autoscalerRange,
@@ -166,6 +167,7 @@ export function governanceRows(
             {" "}
             · {autoscalerRange(auto.facts, t)}
           </span>
+          <EditGoverning object={auto.object} />
         </>
       ),
     });
@@ -192,6 +194,7 @@ export function governanceRows(
             {" "}
             keeps {budgetRule(budget.facts, t)} — {budgetRoom(budget.facts, t)}
           </span>
+          <EditGoverning object={budget.object} />
         </>
       ),
     });

--- a/src/components/resources/workload-overview.test.tsx
+++ b/src/components/resources/workload-overview.test.tsx
@@ -124,6 +124,14 @@ describe("CountBlock", () => {
     expect(screen.getByText(/against 80%/)).toBeInTheDocument();
   });
 
+  /** Issue #178: the block described the autoscaler and gave no way to change it. */
+  it("offers the editor beside the autoscaler it names", () => {
+    renderBlock(query(conns(autoscaler({ lastScaleTime: null }))));
+    expect(
+      screen.getByRole("button", { name: /Edit YAML/ })
+    ).toBeInTheDocument();
+  });
+
   it("reduces a budget that is doing its job to one clause", () => {
     renderBlock(query(conns(budget())));
 

--- a/src/components/settings/AboutSettings.tsx
+++ b/src/components/settings/AboutSettings.tsx
@@ -7,6 +7,7 @@ import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/components/ui/use-toast";
 import { commands } from "@/lib/commands";
 import { useUpdaterStore } from "@/stores/updaterStore";
+import { useWhatsNewStore } from "@/stores/whatsNewStore";
 import { SettingRow, SettingsGroup } from "./settings-row";
 import { useT } from "@/i18n/useT";
 
@@ -51,6 +52,23 @@ export function AboutSettings() {
             <span className="font-mono text-xs text-fg">
               {appInfo?.version ?? "…"}
             </span>
+          }
+        />
+        <SettingRow
+          label={t("settings", "whatsNew")}
+          hint={t("settings", "whatsNewHint")}
+          keywords={t("settings", "searchWhatsNewWords")}
+          control={
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!appInfo}
+              onClick={() =>
+                appInfo && useWhatsNewStore.getState().show([appInfo.version])
+              }
+            >
+              {t("settings", "showWhatsNew")}
+            </Button>
           }
         />
         <SettingRow

--- a/src/components/ui/copyable-value.test.tsx
+++ b/src/components/ui/copyable-value.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { CopyableValue } from "./copyable-value";
+import { CopyButton, CopyableValue } from "./copyable-value";
 
 /**
  * `userEvent.setup()` installs its own clipboard stub, so ours has to go in
@@ -79,5 +79,27 @@ describe("CopyableValue", () => {
   it("shows the value itself, not a placeholder", () => {
     render(<CopyableValue value="10.43.107.238" />);
     expect(screen.getByText("10.43.107.238")).toBeInTheDocument();
+  });
+});
+
+describe("CopyButton", () => {
+  /** The mark beside a name that is itself a link: it copies, and neither the row nor a double click sees it. */
+  it("copies the name and keeps the row and a double click out of it", async () => {
+    const rowClick = vi.fn();
+    const rowDouble = vi.fn();
+    const user = userEvent.setup();
+    const writeText = vi.fn(async () => {});
+    stubClipboard(writeText);
+    render(
+      <div onClick={rowClick} onDoubleClick={rowDouble}>
+        <CopyButton value="web-7f4" label="Copy name: web-7f4" />
+      </div>
+    );
+    await user.dblClick(
+      screen.getByRole("button", { name: "Copy name: web-7f4" })
+    );
+    expect(writeText).toHaveBeenCalledWith("web-7f4");
+    expect(rowClick).not.toHaveBeenCalled();
+    expect(rowDouble).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ui/copyable-value.tsx
+++ b/src/components/ui/copyable-value.tsx
@@ -206,3 +206,58 @@ export function AddressCell({
   const t = useT();
   return <CopyableAddress value={value} label={t("columns", labelKey)} />;
 }
+
+/**
+ * The mark alone, for a value that is already drawn by something else in
+ * the row: the name beside it is a link, and a link inside a button is
+ * neither. Shown on hover of the enclosing `group/name`.
+ */
+export function CopyButton({
+  value,
+  label,
+  className,
+}: {
+  value: string;
+  label: string;
+  className?: string;
+}) {
+  const t = useT();
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => () => clearTimeout(timer.current), []);
+  const copy = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      clearTimeout(timer.current);
+      timer.current = setTimeout(() => setCopied(false), CONFIRM_MS);
+    } catch {
+      setCopied(false);
+    }
+  };
+  const Mark = copied ? Check : Copy;
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      onDoubleClick={(event) => event.stopPropagation()}
+      title={copied ? t("action", "copied") : label}
+      aria-label={label}
+      className={cn(
+        "inline-flex size-4 flex-none items-center justify-center rounded-sm transition-opacity",
+        "focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-info",
+        copied
+          ? "text-ok opacity-100"
+          : "text-fg-fnt opacity-0 hover:text-fg-mut group-hover/name:opacity-100",
+        className
+      )}
+    >
+      <Mark className="size-2.5" aria-hidden="true" />
+      <span className="sr-only" role="status">
+        {copied ? t("action", "copied") : ""}
+      </span>
+    </button>
+  );
+}

--- a/src/components/ui/data-table.test.tsx
+++ b/src/components/ui/data-table.test.tsx
@@ -18,6 +18,7 @@ import type { RowGrouping } from "./row-grouping";
 import { RouteLink } from "./route-link";
 import { TooltipProvider } from "./tooltip";
 import { useScopeTabStore } from "@/stores/scopeTabStore";
+import { useClusterStore } from "@/stores/clusterStore";
 import { useDisplaySettingsStore } from "@/stores/displaySettingsStore";
 
 vi.mock("./data-table-rows", async (importOriginal) => {
@@ -982,5 +983,25 @@ describe("a table given the page's height", () => {
     const scrolled = port();
     expect(scrolled.contains(screen.getByLabelText("Search..."))).toBe(false);
     expect(scrolled.contains(screen.getByText("500 pods"))).toBe(false);
+  });
+});
+
+describe("the namespace column", () => {
+  const withNamespace: ColumnDef<Item>[] = [
+    ...columns,
+    { accessorKey: "namespace", header: "Namespace" },
+  ];
+
+  /** Issue #178: with one namespace chosen the column repeated the scope bar on every row. */
+  it("is hidden while one namespace is chosen, and back for all or several", () => {
+    useClusterStore.setState({ namespaceScope: ["ns"] });
+    const { unmount } = wrap(
+      <DataTable<Item> columns={withNamespace} data={DATA} />
+    );
+    expect(screen.queryByText("Namespace")).toBeNull();
+    unmount();
+    useClusterStore.setState({ namespaceScope: [] });
+    wrap(<DataTable<Item> columns={withNamespace} data={DATA} />);
+    expect(screen.getByText("Namespace")).toBeInTheDocument();
   });
 });

--- a/src/components/ui/data-table.test.tsx
+++ b/src/components/ui/data-table.test.tsx
@@ -55,8 +55,8 @@ const columns: ColumnDef<Item>[] = [
 ];
 
 function LocationProbe() {
-  const { pathname } = useLocation();
-  return <span data-testid="location">{pathname}</span>;
+  const { pathname, search } = useLocation();
+  return <span data-testid="location">{`${pathname}${search}`}</span>;
 }
 
 const wrap = (ui: ReactNode) =>
@@ -191,14 +191,32 @@ describe("DataTable rows", () => {
       />
     );
 
-  // A list is the page you are already browsing, so opening a row from it is
-  // a drill-down, not a look-without-leaving. If this starts peeking, Back
-  // stops being the way home from a list.
-  it("navigates on a plain click anywhere in the row", () => {
+  /**
+   * Issue #178: the name in a row peeked and the whitespace beside it went
+   * to the page, and nobody could tell which they would get. Now both peek,
+   * and the page is a double click. Would break if the row went back to
+   * navigating on a plain click, or if the double click stopped opening it.
+   */
+  it("peeks on a plain click anywhere in the row, and opens the page on a double click", () => {
     renderTable();
     fireEvent.click(whitespace());
-    expect(location()).toBe("/pods/ns/a-1");
+    expect(location()).toBe("/pods?peek=pods%2Fns%2Fa-1");
     expect(tabs()).toHaveLength(1);
+    fireEvent.doubleClick(whitespace());
+    expect(location()).toBe("/pods/ns/a-1");
+  });
+
+  // A row whose route has no peek behind it is a plain link, as it always was.
+  it("navigates on a plain click where the route is not an object", () => {
+    wrap(
+      <DataTable<Item>
+        columns={columns}
+        data={DATA}
+        getRowHref={(row) => `/helm/${row.namespace}/${row.name}`}
+      />
+    );
+    fireEvent.click(whitespace());
+    expect(location()).toBe("/helm/ns/a-1");
   });
 
   // This is the regression the whole change exists for: the row used to call

--- a/src/components/ui/data-table.test.tsx
+++ b/src/components/ui/data-table.test.tsx
@@ -1005,3 +1005,28 @@ describe("the namespace column", () => {
     expect(screen.getByText("Namespace")).toBeInTheDocument();
   });
 });
+
+describe("the search box", () => {
+  /**
+   * Issue #178: the search was component state, so leaving the tab and
+   * coming back remounted the table with an empty box. It lives in the
+   * query string now, which is what a tab records. Would break if the box
+   * stopped reading the parameter, or stopped writing it.
+   */
+  it("reads its value from the query string and writes it back", async () => {
+    render(
+      <MemoryRouter initialEntries={["/pods?q=b-2"]}>
+        <TooltipProvider>
+          <DataTable<Item> columns={columns} data={DATA} searchParam="q" />
+        </TooltipProvider>
+        <LocationProbe />
+      </MemoryRouter>
+    );
+    expect(search()).toHaveValue("b-2");
+    await waitFor(() => expect(screen.queryByText("a-1")).toBeNull());
+    fireEvent.change(search(), { target: { value: "a-1" } });
+    expect(location()).toBe("/pods?q=a-1");
+    fireEvent.change(search(), { target: { value: "" } });
+    expect(location()).toBe("/pods");
+  });
+});

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -30,6 +30,7 @@ import { QuickActions, type QuickAction } from "@/components/ui/quick-actions";
 import { useTableKeyboardNav } from "@/hooks/useTableKeyboardNav";
 import { readLinkIntent, useLinkGesture } from "@/hooks/useLinkGesture";
 import { peekTargetOfHref, usePeek } from "@/hooks/usePeek";
+import { useClusterStore } from "@/stores/clusterStore";
 import {
   Search,
   SearchX,
@@ -298,13 +299,19 @@ function DataTableInner<TData extends RowData>({
     return seen.size >= (grouping.minGroups ?? 1);
   }, [data, grouping]);
 
+  // One namespace chosen is the same word on every row, and the scope bar
+  // above already says it; several are grouped, and the caption says it.
+  const oneNamespace = useClusterStore(
+    (state) => state.namespaceScope.length === 1
+  );
   const columnVisibility = React.useMemo<ColumnVisibilityState>(() => {
     const state: ColumnVisibilityState = {};
     if (groupingActive) {
       for (const id of grouping?.hides ?? []) state[id] = false;
     }
+    if (oneNamespace) state.namespace = false;
     return state;
-  }, [groupingActive, grouping]);
+  }, [groupingActive, grouping, oneNamespace]);
 
   // Latched rather than derived: between the two marks the answer is
   // "whatever it already was", which is a fact about the last render and not

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { PerfProfiler } from "@/lib/perf-profiler";
 import { toSingularNoun } from "@/lib/resource-registry";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   flexRender,
   useTable,
@@ -57,6 +57,12 @@ interface DataTableProps<TData extends RowData> {
   data: TData[];
   isLoading?: boolean;
   searchKey?: string;
+  /**
+   * The query-string key the search lives under. A tab records its route
+   * with the query string, so a search kept here survives leaving the tab
+   * and coming back; one kept in state did not.
+   */
+  searchParam?: string;
   searchPlaceholder?: string;
   /** Force the windowed layout on or off; unset, the table reads its own length. */
   enableVirtualScroll?: boolean;
@@ -244,6 +250,7 @@ function DataTableInner<TData extends RowData>({
   data,
   isLoading = false,
   searchKey,
+  searchParam,
   searchPlaceholder,
   enableVirtualScroll,
   fill = false,
@@ -267,7 +274,23 @@ function DataTableInner<TData extends RowData>({
   );
   const [globalFilter, setGlobalFilter] = React.useState("");
   const t = useT();
-  const [searchValue, setSearchValue] = React.useState("");
+  const [params, setParams] = useSearchParams();
+  const [searchValue, setSearchValue] = React.useState(() =>
+    searchParam ? (params.get(searchParam) ?? "") : ""
+  );
+  const changeSearch = (value: string) => {
+    setSearchValue(value);
+    if (!searchParam) return;
+    setParams(
+      (current) => {
+        const next = new URLSearchParams(current);
+        if (value) next.set(searchParam, value);
+        else next.delete(searchParam);
+        return next;
+      },
+      { replace: true }
+    );
+  };
   const deferredSearch = React.useDeferredValue(searchValue);
 
   // Compact rows stay strictly single-line — a pod name like
@@ -673,7 +696,7 @@ function DataTableInner<TData extends RowData>({
               aria-label={searchPlaceholder ?? t("action", "searchEllipsis")}
               placeholder={searchPlaceholder ?? t("action", "searchEllipsis")}
               value={searchValue}
-              onChange={(event) => setSearchValue(event.target.value)}
+              onChange={(event) => changeSearch(event.target.value)}
               className="w-40 bg-transparent text-xs text-fg outline-hidden placeholder:text-fg-fnt"
             />
           </div>
@@ -819,7 +842,7 @@ function DataTableInner<TData extends RowData>({
                           variant="ghost"
                           size="sm"
                           className="h-7 text-xs"
-                          onClick={() => setSearchValue("")}
+                          onClick={() => changeSearch("")}
                         >
                           {t("action", "clearSearch")}
                         </Button>

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -29,6 +29,7 @@ import { TableSkeleton } from "@/components/ui/skeleton";
 import { QuickActions, type QuickAction } from "@/components/ui/quick-actions";
 import { useTableKeyboardNav } from "@/hooks/useTableKeyboardNav";
 import { readLinkIntent, useLinkGesture } from "@/hooks/useLinkGesture";
+import { peekTargetOfHref, usePeek } from "@/hooks/usePeek";
 import {
   Search,
   SearchX,
@@ -257,6 +258,7 @@ function DataTableInner<TData extends RowData>({
 }: DataTableProps<TData>) {
   const navigate = useNavigate();
   const linkGesture = useLinkGesture();
+  const { open: openPeek } = usePeek();
   const { tableDensity, setTableDensity } = useDisplaySettingsStore();
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
@@ -501,9 +503,16 @@ function DataTableInner<TData extends RowData>({
 
     const href = getRowHref?.(row);
     if (href) {
-      // A list is where you are already browsing, so plain click goes there
-      // rather than peeking: the peek exists to check a name mentioned
-      // elsewhere without losing the page, and here the page is the list.
+      // A plain click on a row whose object has a peek opens the peek, the
+      // same as the click on the name inside it: one gesture, one answer,
+      // wherever on the row it lands. The page itself is a double click, or
+      // Enter, away. Modified clicks open tabs exactly as before.
+      const peek = "key" in event ? null : peekTargetOfHref(href);
+      if (peek && readLinkIntent(event) === "activate") {
+        event.preventDefault();
+        openPeek(peek);
+        return;
+      }
       linkGesture(event, href, () => navigate(href));
     } else if (onRowClick && readLinkIntent(event) === "activate") {
       // No destination, so nothing to open a tab on; only a plain click acts.
@@ -518,6 +527,15 @@ function DataTableInner<TData extends RowData>({
       ? (event: React.MouseEvent | React.KeyboardEvent) =>
           handleRowGesture(row.original, event)
       : undefined;
+    const href = getRowHref?.(row.original);
+    const openPage =
+      href && peekTargetOfHref(href)
+        ? (event: React.MouseEvent) => {
+            const target = event.target as HTMLElement;
+            if (target.closest("button") || target.closest("a")) return;
+            navigate(href);
+          }
+        : undefined;
 
     return (
       <TableRow
@@ -541,6 +559,7 @@ function DataTableInner<TData extends RowData>({
           "relative group"
         )}
         onClick={act}
+        onDoubleClick={openPage}
         onAuxClick={act}
         onKeyDown={
           rowProps &&

--- a/src/components/yaml/YamlEditorDialog.tsx
+++ b/src/components/yaml/YamlEditorDialog.tsx
@@ -59,6 +59,7 @@ interface YamlEditorActionProps {
   fetchYaml: () => Promise<string>;
   menuLabel?: string;
   readOnly?: boolean;
+  className?: string;
 }
 
 /** Open it, and say why if it will not open. Shared by both affordances. */
@@ -99,6 +100,7 @@ export function YamlEditorAction(props: YamlEditorActionProps) {
       label={editorLabel(t, props)}
       icon={FileJson}
       onClick={open}
+      className={props.className}
     />
   );
 }

--- a/src/hooks/usePeek.test.ts
+++ b/src/hooks/usePeek.test.ts
@@ -2,7 +2,7 @@ import { createElement, type ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
-import { usePeek } from "./usePeek";
+import { peekTargetOfHref, usePeek } from "./usePeek";
 
 const at =
   (entry: string) =>
@@ -149,5 +149,27 @@ describe("usePeek", () => {
     const { result } = renderPeek("/events?type=Warning&peek=pods/ns/a-1");
     act(() => result.current.peek.close());
     expect(result.current.search).toBe("?type=Warning");
+  });
+});
+
+describe("peekTargetOfHref", () => {
+  /** A row's route is the peek's value with a slash in front; anything else has no peek. */
+  it("reads a core route and refuses every other shape", () => {
+    expect(peekTargetOfHref("/pods/default/nginx")).toEqual({
+      kind: "Pod",
+      name: "nginx",
+      namespace: "default",
+    });
+    expect(peekTargetOfHref("/nodes/k3d-agent-0?tab=pods")).toEqual({
+      kind: "Node",
+      name: "k3d-agent-0",
+      namespace: null,
+    });
+    expect(peekTargetOfHref("/helm/default/release")).toBeNull();
+    expect(
+      peekTargetOfHref(
+        "/customresourcedefinitions/applications.argoproj.io/instances/argocd/shop"
+      )
+    ).toBeNull();
   });
 });

--- a/src/hooks/usePeek.ts
+++ b/src/hooks/usePeek.ts
@@ -29,6 +29,46 @@ const PARAM = "peek";
  */
 const isCrdName = (segment: string) => segment.includes(".");
 
+/** The parameter's value as a target, or `null` for a value in neither shape. */
+export function parsePeekValue(raw: string): PeekTarget | null {
+  if (!raw) return null;
+  const parts = raw.split("/");
+
+  if (isCrdName(parts[0])) {
+    const [crd, kind, ...rest] = parts;
+    // A kind is UpperCamelCase — required of every CRD by the API server.
+    // Without this check a link truncated to `<crd>/<ns>/<name>` would open
+    // a panel headed with the namespace, which reads as a real object.
+    if (!kind || !/^[A-Z]/.test(kind)) return null;
+    if (rest.length < 1 || rest.length > 2) return null;
+    const [namespace, name] = rest.length === 2 ? rest : [null, rest[0]];
+    if (!name) return null;
+    return { kind, name, namespace, crd };
+  }
+
+  if (parts.length < 2 || parts.length > 3) return null;
+  const kind = toKind(parts[0]);
+  if (!kind) return null;
+  const [, first, second] = parts;
+  const [namespace, name] =
+    parts.length === 3 ? [first, second] : [null, first];
+  if (!name) return null;
+  return { kind, name, namespace };
+}
+
+/**
+ * The object behind a core route, `/pods/default/nginx`, in the shape the
+ * parameter takes: the same segments without the slash. A route in any
+ * other shape has no peek and is opened the way it always was.
+ */
+export function peekTargetOfHref(href: string): PeekTarget | null {
+  const path = href.split("?")[0];
+  if (!path.startsWith("/")) return null;
+  const parts = path.slice(1).split("/");
+  if (parts.length < 2 || parts.length > 3 || isCrdName(parts[0])) return null;
+  return parsePeekValue(parts.join("/"));
+}
+
 /**
  * The peek lives in the query string so browser back closes it and a peek is
  * linkable — the alternative, component state, makes back navigate away from
@@ -49,31 +89,10 @@ export function usePeek() {
   const [params, setParams] = useSearchParams();
   const raw = params.get(PARAM);
 
-  const target = useMemo<PeekTarget | null>(() => {
-    if (!raw) return null;
-    const parts = raw.split("/");
-
-    if (isCrdName(parts[0])) {
-      const [crd, kind, ...rest] = parts;
-      // A kind is UpperCamelCase — required of every CRD by the API server.
-      // Without this check a link truncated to `<crd>/<ns>/<name>` would open
-      // a panel headed with the namespace, which reads as a real object.
-      if (!kind || !/^[A-Z]/.test(kind)) return null;
-      if (rest.length < 1 || rest.length > 2) return null;
-      const [namespace, name] = rest.length === 2 ? rest : [null, rest[0]];
-      if (!name) return null;
-      return { kind, name, namespace, crd };
-    }
-
-    if (parts.length < 2 || parts.length > 3) return null;
-    const kind = toKind(parts[0]);
-    if (!kind) return null;
-    const [, first, second] = parts;
-    const [namespace, name] =
-      parts.length === 3 ? [first, second] : [null, first];
-    if (!name) return null;
-    return { kind, name, namespace };
-  }, [raw]);
+  const target = useMemo<PeekTarget | null>(
+    () => (raw ? parsePeekValue(raw) : null),
+    [raw]
+  );
 
   const open = useCallback(
     (next: PeekTarget) => {
@@ -89,6 +108,7 @@ export function usePeek() {
         if (!kind) return;
         value = [toPlural(kind), ...where].join("/");
       }
+      if (value === raw) return;
       setParams(
         (current) => {
           const updated = new URLSearchParams(current);
@@ -98,7 +118,7 @@ export function usePeek() {
         { replace: false }
       );
     },
-    [setParams]
+    [setParams, raw]
   );
 
   const close = useCallback(() => {

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -1504,6 +1504,9 @@ export const en = {
     pathCopied: "Path copied",
     copyPath: "Copy path",
     tooBigToDownload: "Downloads over {cap} are refused in this version",
+    bigDownloadTitle: "Download {name} ({size})?",
+    bigDownloadBody:
+      "It comes through the exec channel, which is slow: a file this size takes minutes, and the download gives up after 30 seconds of silence. Nothing is written to your file until the whole of it has arrived.",
     noHeadInImage: "No head in this image to read the file with.",
     readFailed: "Could not read the file (exit {code}):",
     noPreviewBinary:

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -2795,6 +2795,13 @@ export const en = {
   settings: {
     installationFailed: "Installation failed",
     updateAvailableTitle: "Update available",
+    whatsNew: "What's new",
+    whatsNewHint:
+      "The release notes for this version, the ones that open once after an update.",
+    searchWhatsNewWords: "release notes changelog",
+    showWhatsNew: "Show",
+    whatsNewIn: "What's new in {version}",
+    whatsNewSince: "Everything since {version}",
     updateAvailableToast:
       "Version {version} is available. Go to Settings to download it.",
     notOnPathPlain: "{label} is not on PATH. Set the path below.",

--- a/src/i18n/catalogue.ts
+++ b/src/i18n/catalogue.ts
@@ -840,6 +840,7 @@ export const en = {
     nameCopied: "{name} copied",
     copyContextName: "Copy context name",
     openInNewTab: "Open in a new tab",
+    copyLink: "Copy link",
     recentChanges: "Recent Changes",
     nativeHelmRelease: "Native Helm release",
     searchKindPlaceholder: "Search {kind}...",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -817,6 +817,7 @@ export const ru: Catalogue = {
     nameCopied: "Скопировано: {name}",
     copyContextName: "Копировать имя контекста",
     openInNewTab: "Открыть в новой вкладке",
+    copyLink: "Копировать ссылку",
     recentChanges: "Недавние изменения",
     nativeHelmRelease: "Собственный релиз Helm",
     searchKindPlaceholder: "Поиск {kind}…",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -3003,6 +3003,13 @@ export const ru: Catalogue = {
   settings: {
     installationFailed: "Установка не удалась",
     updateAvailableTitle: "Доступно обновление",
+    whatsNew: "Что нового",
+    whatsNewHint:
+      "Заметки к этой версии, те, что открываются один раз после обновления.",
+    searchWhatsNewWords: "release notes changelog что нового заметки к выпуску",
+    showWhatsNew: "Показать",
+    whatsNewIn: "Что нового в {version}",
+    whatsNewSince: "Всё с версии {version}",
     updateAvailableToast:
       "Доступна версия {version}. Загрузить её можно в настройках.",
     notOnPathPlain: "{label} нет в PATH. Укажите путь ниже.",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -1534,6 +1534,9 @@ export const ru: Catalogue = {
     pathCopied: "Путь скопирован",
     copyPath: "Копировать путь",
     tooBigToDownload: "Скачивание больше {cap} в этой версии отклоняется",
+    bigDownloadTitle: "Скачать {name} ({size})?",
+    bigDownloadBody:
+      "Файл идёт через exec-канал, а он медленный: такой размер это минуты, и после 30 секунд тишины скачивание прекращается. В ваш файл ничего не пишется, пока не придёт всё целиком.",
     noHeadInImage: "В образе нет head, чтобы прочитать файл.",
     readFailed: "Не удалось прочитать файл (exit {code}):",
     noPreviewBinary:

--- a/src/lib/changelog.test.ts
+++ b/src/lib/changelog.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  newerVersion,
+  parseChangelog,
+  releaseOf,
+  releasesSince,
+} from "./changelog";
+
+const SAMPLE = `# Changelog
+
+## [4.13.0] - 2026-09-12
+
+### Added
+
+- **Credentials renew themselves.** A plugin names the moment,
+  and Rubick acts on it.
+  - A plugin that needs a person is left alone.
+- **Second item.**
+
+### Fixed
+
+- **A flash is gone.**
+
+## [4.12.0] - 2026-09-11
+
+### Added
+
+- **Files tab on a pod.**
+`;
+
+describe("parseChangelog", () => {
+  /** The release workflow reads the same headings; a section it cannot find is a release note nobody sees. */
+  it("reads versions, sections, bullets and their sub-bullets", () => {
+    const releases = parseChangelog(SAMPLE);
+    expect(releases.map((r) => [r.version, r.date])).toEqual([
+      ["4.13.0", "2026-09-12"],
+      ["4.12.0", "2026-09-11"],
+    ]);
+    const [added, fixed] = releases[0].sections;
+    expect(added.title).toBe("Added");
+    expect(added.items.map((i) => i.text)).toEqual([
+      "**Credentials renew themselves.** A plugin names the moment, and Rubick acts on it.",
+      "**Second item.**",
+    ]);
+    expect(added.items[0].children.map((i) => i.text)).toEqual([
+      "A plugin that needs a person is left alone.",
+    ]);
+    expect(fixed.items).toHaveLength(1);
+  });
+});
+
+describe("releasesSince", () => {
+  const releases = parseChangelog(SAMPLE);
+
+  /** A first launch has nothing to announce; an update announces everything between. */
+  it("is empty on a first launch and lists what arrived since otherwise", () => {
+    expect(releasesSince(releases, null, "4.13.0")).toEqual([]);
+    expect(
+      releasesSince(releases, "4.12.0", "4.13.0").map((r) => r.version)
+    ).toEqual(["4.13.0"]);
+    expect(
+      releasesSince(releases, "4.11.0", "4.13.0").map((r) => r.version)
+    ).toEqual(["4.13.0", "4.12.0"]);
+    expect(releasesSince(releases, "4.13.0", "4.13.0")).toEqual([]);
+  });
+
+  it("compares versions by number, not by string", () => {
+    expect(newerVersion("4.10.0", "4.9.2")).toBe(true);
+    expect(newerVersion("4.9.2", "4.10.0")).toBe(false);
+    expect(newerVersion("dev", "4.10.0")).toBe(false);
+    expect(releaseOf(releases, "4.12.0")?.date).toBe("2026-09-11");
+    expect(releaseOf(releases, "9.9.9")).toBeNull();
+  });
+});

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,0 +1,103 @@
+/**
+ * `CHANGELOG.md`, read the way the release workflow reads it: one `## [x.y.z]`
+ * heading per version, `###` sections under it, bullets with two spaces of
+ * indent for a sub-bullet. Nothing more is understood, because nothing more
+ * is written there.
+ */
+
+export interface ChangeItem {
+  text: string;
+  children: ChangeItem[];
+}
+
+export interface ChangeSection {
+  title: string;
+  items: ChangeItem[];
+}
+
+export interface Release {
+  version: string;
+  date: string | null;
+  sections: ChangeSection[];
+}
+
+const HEADING = /^## \[([^\]]+)\](?:\s*-\s*(\S+))?/;
+
+export function parseChangelog(markdown: string): Release[] {
+  const releases: Release[] = [];
+  let release: Release | null = null;
+  let section: ChangeSection | null = null;
+  let last: ChangeItem | null = null;
+  let lastChild: ChangeItem | null = null;
+
+  for (const line of markdown.split("\n")) {
+    const heading = HEADING.exec(line);
+    if (heading) {
+      release = { version: heading[1], date: heading[2] ?? null, sections: [] };
+      releases.push(release);
+      section = null;
+      last = null;
+      lastChild = null;
+      continue;
+    }
+    if (!release) continue;
+    if (line.startsWith("### ")) {
+      section = { title: line.slice(4).trim(), items: [] };
+      release.sections.push(section);
+      last = null;
+      lastChild = null;
+      continue;
+    }
+    if (!section) continue;
+    if (line.startsWith("- ")) {
+      last = { text: line.slice(2).trim(), children: [] };
+      section.items.push(last);
+      lastChild = null;
+    } else if (line.startsWith("  - ") && last) {
+      lastChild = { text: line.slice(4).trim(), children: [] };
+      last.children.push(lastChild);
+    } else if (line.startsWith("    ") && lastChild) {
+      lastChild.text += ` ${line.trim()}`;
+    } else if (line.startsWith("  ") && last) {
+      last.text += ` ${line.trim()}`;
+    }
+  }
+  return releases;
+}
+
+/** `a` newer than `b`, by the three numbers; anything unreadable is not newer. */
+export function newerVersion(a: string, b: string): boolean {
+  const parse = (v: string) => v.split(/[.-]/).slice(0, 3).map(Number);
+  const [x, y] = [parse(a), parse(b)];
+  if (x.some(Number.isNaN) || y.some(Number.isNaN)) return false;
+  for (let i = 0; i < 3; i++) {
+    if ((x[i] ?? 0) !== (y[i] ?? 0)) return (x[i] ?? 0) > (y[i] ?? 0);
+  }
+  return false;
+}
+
+/**
+ * What arrived between the version last seen and the one running: every
+ * release newer than `seen` up to and including `current`, newest first. A
+ * `seen` of `null` is a first launch, and a first launch has nothing new.
+ */
+export function releasesSince(
+  releases: Release[],
+  seen: string | null,
+  current: string
+): Release[] {
+  if (seen === null) return [];
+  return releases.filter(
+    (release) =>
+      newerVersion(release.version, seen) &&
+      !newerVersion(release.version, current)
+  );
+}
+
+/** The one release the running version has, or `null` if the file has no entry for it. */
+export function releaseOf(
+  releases: Release[],
+  version: string
+): Release | null {
+  return releases.find((release) => release.version === version) ?? null;
+}

--- a/src/lib/container-files.test.ts
+++ b/src/lib/container-files.test.ts
@@ -14,6 +14,7 @@ import {
   mountFor,
   parentOf,
   sortEntries,
+  startPath,
 } from "./container-files";
 
 const volumes: PodVolumeInfo[] = [
@@ -122,6 +123,35 @@ describe("mountFor", () => {
 
   it("does not match a sibling that merely shares a prefix", () => {
     expect(mountFor("/etc/application", "app", volumes)).toBeNull();
+  });
+});
+
+describe("startPath", () => {
+  const volumes = (subPath: string | null): PodVolumeInfo[] => [
+    {
+      name: "config",
+      source: "configMap",
+      refs: [{ kind: "ConfigMap", name: "app-config" }],
+      mounts: [
+        {
+          container: "app",
+          path: "/etc/app/app.conf",
+          readOnly: true,
+          subPath,
+        },
+      ],
+    },
+  ];
+
+  /**
+   * Issue #178: a ConfigMap key mounted over one file made the tab open on
+   * the file and say it could not be opened. Would break if the tab went
+   * back to opening on the mount path whatever the mount is.
+   */
+  it("opens a single-file mount at its parent, a directory mount at itself", () => {
+    expect(startPath(volumes("app.conf"), "app")).toBe("/etc/app");
+    expect(startPath(volumes(null), "app")).toBe("/etc/app/app.conf");
+    expect(startPath(volumes("app.conf"), "sidecar")).toBe("/");
   });
 });
 

--- a/src/lib/container-files.test.ts
+++ b/src/lib/container-files.test.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 
 import type { PodVolumeInfo } from "@/generated/types";
 import {
+  DOWNLOAD_CONFIRM_BYTES,
   DOWNLOAD_MAX_BYTES,
   MAX_ENTRIES,
   PREVIEW_MAX_BYTES,
@@ -207,10 +208,12 @@ describe("the caps both halves apply", () => {
       readFileSync(resolve(process.cwd(), "shared/file-limits.json"), "utf8")
     ) as {
       downloadMaxBytes: number;
+      downloadConfirmBytes: number;
       previewMaxBytes: number;
       maxEntries: number;
     };
     expect(DOWNLOAD_MAX_BYTES).toBe(shared.downloadMaxBytes);
+    expect(DOWNLOAD_CONFIRM_BYTES).toBe(shared.downloadConfirmBytes);
     expect(PREVIEW_MAX_BYTES).toBe(shared.previewMaxBytes);
     expect(MAX_ENTRIES).toBe(shared.maxEntries);
   });

--- a/src/lib/container-files.ts
+++ b/src/lib/container-files.ts
@@ -173,6 +173,8 @@ export function matches(entry: FileEntry, filter: string): boolean {
  * into the catalogue copy — which is exactly the drift the shared-constant
  * rule exists to stop.
  */
-export const DOWNLOAD_MAX_BYTES = 104_857_600;
+export const DOWNLOAD_MAX_BYTES = 2_147_483_648;
+/** Past this a download is asked about first: minutes over exec, not a click. */
+export const DOWNLOAD_CONFIRM_BYTES = 104_857_600;
 export const PREVIEW_MAX_BYTES = 524_288;
 export const MAX_ENTRIES = 20_000;

--- a/src/lib/container-files.ts
+++ b/src/lib/container-files.ts
@@ -80,6 +80,23 @@ export function mountFor(
   return best?.tag ?? null;
 }
 
+/**
+ * Where the browser opens for a container: its first mount, because that
+ * is what the reader came to look at. A mount with a `subPath` is often a
+ * single file (a ConfigMap key over `/etc/app/app.conf`), and a file cannot
+ * be listed; the mount's parent can, and shows the file as a row.
+ */
+export function startPath(
+  volumes: readonly PodVolumeInfo[],
+  container: string
+): string {
+  const mount = volumes
+    .flatMap((volume) => volume.mounts)
+    .find((m) => m.container === container);
+  if (!mount) return "/";
+  return mount.subPath ? parentOf(mount.path) : mount.path;
+}
+
 export function joinPath(dir: string, name: string): string {
   return dir === "/" ? `/${name}` : `${dir}/${name}`;
 }

--- a/src/stores/objectMenuStore.ts
+++ b/src/stores/objectMenuStore.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+import type { PeekTarget } from "@/hooks/usePeek";
+
+/** What the reader right-clicked, and where the pointer was. */
+export interface ObjectMenuTarget extends PeekTarget {
+  to: string;
+  x: number;
+  y: number;
+}
+
+interface ObjectMenuState {
+  target: ObjectMenuTarget | null;
+  open: (target: ObjectMenuTarget) => void;
+  close: () => void;
+}
+
+/**
+ * One menu for every object link in the window, rather than a menu root
+ * per row: a list of ten thousand pods must not mount ten thousand of them.
+ */
+export const useObjectMenuStore = create<ObjectMenuState>((set) => ({
+  target: null,
+  open: (target) => set({ target }),
+  close: () => set({ target: null }),
+}));

--- a/src/stores/whatsNewStore.ts
+++ b/src/stores/whatsNewStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface WhatsNewState {
+  /** The version whose notes were last shown, or never shown on purpose. */
+  seenVersion: string | null;
+  /** The versions the open dialog is about; empty when it is closed. */
+  showing: string[];
+  markSeen: (version: string) => void;
+  show: (versions: string[]) => void;
+  close: () => void;
+}
+
+export const useWhatsNewStore = create<WhatsNewState>()(
+  persist(
+    (set) => ({
+      seenVersion: null,
+      showing: [],
+      markSeen: (version) => set({ seenVersion: version }),
+      show: (versions) => set({ showing: versions }),
+      close: () => set({ showing: [] }),
+    }),
+    {
+      name: "whats-new",
+      partialize: (state) => ({ seenVersion: state.seenVersion }),
+    }
+  )
+);


### PR DESCRIPTION
Closes #178.

## What is wrong today

A reader who used the app for a week wrote down what got in the way. Each item is small; together they are the difference between a tool that is used and one that is put up with.

- A pod's name could not be copied where it is read: the hover mark exists for addresses only, and "copy link address" in the right-click menu copied `http://tauri.localhost/...`, which opens nothing anywhere.
- Clicking a pod in a list sometimes opened the peek and sometimes the page, with no rule the reader could find. There was one (the name link peeks, the whitespace navigates), and it was invisible. Leaving a peek's Logs tab for the page landed on Overview.
- The Deployment page described its autoscaler and its budget and gave no way to change either; neither kind has a page.
- The Files tab opened on a ConfigMap key mounted over a single file and said the path could not be opened. Downloads over 100 MiB were refused with "refused in this version" and nothing else.
- The search box emptied whenever the reader left the tab and came back, and the palette closed after opening a hit in a background tab, so opening three pods meant typing the search three times.
- With one namespace chosen the pods list still carried a namespace column that said the same word on every row.
- Nothing in the app said what a new version brought.

## What changes

- **Names.** The same hover mark addresses have, on the page title and in every list row. A right-click on any object name opens the app's own menu: copy name, copy link (a `rubick://` link that opens the same place), open in a new tab.
- **Rows.** A plain click anywhere on a row peeks, the same as the name; a double click or Enter opens the page; modified clicks open tabs as before. Only rows whose route is an object behave this way, so a table of Helm releases is a plain link still. Leaving a peek for the page carries the open tab with it.
- **Autoscalers and budgets.** Each one named on a workload page carries the YAML editor every detail page has, through the manifest command that already serves any registered kind.
- **Files.** A mount with a `subPath` opens the tab on its folder, where the file is a row with its mount tag. The download cap moves to 2 GiB, and anything over 100 MiB is asked about first, naming the size and the wait; the idle timeout still ends a stream that goes quiet.
- **Search and the palette.** The list search lives in the query string, which is what a tab records, so it survives leaving and returning. The palette stays open after a background tab. A ctrl-click on the name inside a palette hit also opened the object twice, once for the link and once for the row; it opens once now.
- **The namespace column** is hidden while exactly one namespace is chosen. Several are grouped under captions already; all namespaces keep the column.
- **Release notes.** The first launch of a new version opens what arrived since the version last seen, parsed from `CHANGELOG.md` at build time; a first install records where it starts and opens nothing. Settings › About has a "What's new" row that opens the current version's notes.

## How to check it

- `bun run test`: the new cases name the issue item they cover. Files: the start path for a single-file mount, the confirmation before a big download and its absence for a small one, both halves of `shared/file-limits.json`. Rows: peek on click, page on double click, plain link where the route is not an object, the peek's tab travelling. Names: the right-click reaches the app's menu at the pointer, the copy mark keeps the row and a double click out of it. Search: read from and written to the query string; the palette stays open after a background tab; the namespace column hidden for one namespace and back for none. Governance: the editor beside the autoscaler. Release notes: opened after an update with every skipped release, not on a first launch, closed and recorded.
- `cargo test --workspace files::`: the Rust side of the shared limits.
- In the app: right-click a pod name; click a row, then double-click one; open a peek's Logs tab and press Enter; search a list, switch tabs and come back; pick one namespace; open a Deployment with an HPA; open Settings › About › What's new.

## Risk and rollback

The row click is the one behaviour change a reader will feel on day one: the list peeks where it used to navigate. Back closes the peek, and the page is a double click away. Everything else is additive. Rollback is a revert.
